### PR TITLE
Optimize SQLite write contention

### DIFF
--- a/src/relay_teams/agent_runtimes/clients/cli.py
+++ b/src/relay_teams/agent_runtimes/clients/cli.py
@@ -5,8 +5,11 @@ import asyncio
 import json
 import logging
 import os
+import subprocess
+import sys
 from collections.abc import Mapping
 from pathlib import Path
+from typing import IO
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -204,7 +207,14 @@ def _cli_command_exists(
     runtime_cwd: Path | None = None,
     env: dict[str, str] | None = None,
 ) -> bool:
-    return _resolve_cli_command(command, runtime_cwd=runtime_cwd, env=env) is not None
+    return (
+        _resolve_cli_command_path(
+            command,
+            runtime_cwd=runtime_cwd,
+            env=env,
+        )
+        is not None
+    )
 
 
 def _resolve_cli_command(
@@ -213,31 +223,94 @@ def _resolve_cli_command(
     runtime_cwd: Path | None = None,
     env: dict[str, str] | None = None,
 ) -> str | None:
-    lookup_env = env or os.environ
+    resolved = _resolve_cli_command_path(
+        command,
+        runtime_cwd=runtime_cwd,
+        env=env,
+    )
+    return str(resolved) if resolved is not None else None
+
+
+def _resolve_cli_command_path(
+    command: str,
+    *,
+    runtime_cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> Path | None:
     if "/" in command or "\\" in command:
         candidate = Path(command)
         if not candidate.is_absolute() and runtime_cwd is not None:
             candidate = runtime_cwd / candidate
-        return _resolve_executable_path(candidate, env=lookup_env)
+        if os.name == "nt" and not candidate.suffix:
+            pathext_candidate = _resolve_windows_pathext_candidate(
+                candidate.parent,
+                candidate.name,
+                env or os.environ,
+            )
+            if pathext_candidate is not None:
+                return pathext_candidate
+        return candidate if _executable_path_exists(candidate) else None
+    lookup_env = env or os.environ
     for directory in os.get_exec_path(lookup_env):
         candidate = Path(directory) / command
-        resolved = _resolve_executable_path(candidate, env=lookup_env)
-        if resolved is not None:
-            return resolved
+        if os.name == "nt":
+            pathext_candidate = _resolve_windows_pathext_candidate(
+                Path(directory),
+                command,
+                lookup_env,
+            )
+            if pathext_candidate is not None:
+                return pathext_candidate
+        if _executable_path_exists(candidate):
+            return candidate
     return None
 
 
-def _resolve_executable_path(path: Path, *, env: Mapping[str, str]) -> str | None:
-    if _executable_path_exists(path):
-        return str(path)
-    if os.name != "nt" or path.suffix:
+def _resolve_windows_pathext_candidate(
+    directory: Path,
+    command: str,
+    env: Mapping[str, str],
+) -> Path | None:
+    if Path(command).suffix:
         return None
-    for suffix in env.get("PATHEXT", "").split(";"):
-        if suffix:
-            candidate = path.with_name(f"{path.name}{suffix}")
-            if _executable_path_exists(candidate):
-                return str(candidate)
+    pathext = _windows_pathext(env)
+    for suffix in pathext.split(";"):
+        if not suffix:
+            continue
+        candidate = directory / f"{command}{suffix}"
+        if _executable_path_exists(candidate):
+            return candidate
     return None
+
+
+def _windows_pathext(env: Mapping[str, str]) -> str:
+    for key, value in env.items():
+        if key.upper() == "PATHEXT":
+            return value
+    return ".COM;.EXE;.BAT;.CMD"
+
+
+def _resolve_cli_process_command(
+    command: str,
+    *,
+    runtime_cwd: Path | None,
+    env: dict[str, str],
+) -> tuple[str, tuple[str, ...]]:
+    command_path = _resolve_cli_command_path(
+        command,
+        runtime_cwd=runtime_cwd,
+        env=env,
+    )
+    if command_path is None:
+        return command, ()
+    if os.name == "nt" and command_path.suffix.lower() not in {
+        ".bat",
+        ".cmd",
+        ".com",
+        ".exe",
+    }:
+        return sys.executable, (str(command_path),)
+    return str(command_path), ()
 
 
 def _executable_path_exists(path: Path) -> bool:
@@ -565,6 +638,7 @@ class _StdioCliJsonRpcClient:
         self._runtime_cwd = runtime_cwd
         self._transport = transport
         self._process: asyncio.subprocess.Process | None = None
+        self._blocking_process: subprocess.Popen[bytes] | None = None
         self._read_task: asyncio.Task[None] | None = None
         self._stderr_task: asyncio.Task[None] | None = None
         self._write_lock = asyncio.Lock()
@@ -576,24 +650,57 @@ class _StdioCliJsonRpcClient:
     async def start(self) -> None:
         if self._process is not None and self._process.returncode is None:
             return
+        if self._blocking_process is not None and self._blocking_process.poll() is None:
+            return
         env = _runtime_env(self._transport)
-        command = _resolve_cli_command(
+        command, command_args = _resolve_cli_process_command(
             self._command,
             runtime_cwd=self._runtime_cwd,
             env=env,
         )
-        self._process = await asyncio.create_subprocess_exec(
-            command or self._command,
-            *self._args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                command,
+                *command_args,
+                *self._args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._runtime_cwd,
+                env=env,
+            )
+        except NotImplementedError:
+            if os.name != "nt":
+                raise
+            await self._start_blocking_process(
+                command=command,
+                args=(*command_args, *self._args),
+                env=env,
+            )
+            return
+        self._runtime_closed_notified = False
+        self._read_task = asyncio.create_task(self._read_stdout_loop())
+        self._stderr_task = asyncio.create_task(self._drain_stderr_loop())
+
+    async def _start_blocking_process(
+        self,
+        *,
+        command: str,
+        args: tuple[str, ...],
+        env: dict[str, str],
+    ) -> None:
+        self._blocking_process = await asyncio.to_thread(
+            subprocess.Popen,
+            (command, *args),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=self._runtime_cwd,
             env=env,
         )
         self._runtime_closed_notified = False
-        self._read_task = asyncio.create_task(self._read_stdout_loop())
-        self._stderr_task = asyncio.create_task(self._drain_stderr_loop())
+        self._read_task = asyncio.create_task(self._read_blocking_stdout_loop())
+        self._stderr_task = asyncio.create_task(self._drain_blocking_stderr_loop())
 
     async def send_request(
         self,
@@ -662,17 +769,64 @@ class _StdioCliJsonRpcClient:
                         ),
                         payload={"error": str(exc) or exc.__class__.__name__},
                     )
+        blocking_process = self._blocking_process
+        if blocking_process is not None and blocking_process.poll() is None:
+            blocking_process.terminate()
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(blocking_process.wait),
+                    timeout=2.0,
+                )
+            except (asyncio.TimeoutError, ProcessLookupError):
+                blocking_process.kill()
+                try:
+                    await asyncio.wait_for(
+                        asyncio.to_thread(blocking_process.wait),
+                        timeout=2.0,
+                    )
+                except (asyncio.TimeoutError, ProcessLookupError) as exc:
+                    log_event(
+                        LOGGER,
+                        logging.DEBUG,
+                        event="external_agent.cli_jsonrpc.kill_wait_failed",
+                        message=(
+                            "Timed out waiting for killed CLI JSON-RPC runtime to exit"
+                        ),
+                        payload={"error": str(exc) or exc.__class__.__name__},
+                    )
         self._process = None
+        self._blocking_process = None
         self._read_task = None
         self._stderr_task = None
 
     async def _send_raw(self, message: dict[str, JsonValue]) -> None:
-        if self._process is None or self._process.stdin is None:
+        if (
+            self._process is None
+            and self._blocking_process is None
+            or self._process is not None
+            and self._process.stdin is None
+            or self._blocking_process is not None
+            and self._blocking_process.stdin is None
+        ):
             raise CliAgentError("CLI JSON-RPC runtime is not started")
         payload = json.dumps(message, ensure_ascii=False, separators=(",", ":"))
         async with self._write_lock:
-            self._process.stdin.write(payload.encode("utf-8") + b"\n")
-            await self._process.stdin.drain()
+            raw_payload = payload.encode("utf-8") + b"\n"
+            if self._process is not None and self._process.stdin is not None:
+                self._process.stdin.write(raw_payload)
+                await self._process.stdin.drain()
+                return
+            if (
+                self._blocking_process is not None
+                and self._blocking_process.stdin is not None
+            ):
+                await asyncio.to_thread(
+                    _write_blocking_stdio_message,
+                    self._blocking_process.stdin,
+                    raw_payload,
+                )
+                return
+            raise CliAgentError("CLI JSON-RPC runtime is not started")
 
     async def _read_stdout_loop(self) -> None:
         if self._process is None or self._process.stdout is None:
@@ -700,11 +854,60 @@ class _StdioCliJsonRpcClient:
             CliAgentError("CLI JSON-RPC runtime closed stdout before responding"),
         )
 
+    async def _read_blocking_stdout_loop(self) -> None:
+        if self._blocking_process is None or self._blocking_process.stdout is None:
+            return
+        stream = self._blocking_process.stdout
+        try:
+            while True:
+                raw_message = await asyncio.to_thread(
+                    _read_next_blocking_stdio_message,
+                    stream,
+                )
+                if raw_message is None:
+                    break
+                if not raw_message:
+                    continue
+                try:
+                    payload = json.loads(raw_message.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                await self._handle_payload(
+                    {str(key): value for key, value in payload.items()}
+                )
+        except Exception as exc:
+            self._fail_runtime(exc)
+            return
+        self._fail_runtime(
+            CliAgentError("CLI JSON-RPC runtime closed stdout before responding"),
+        )
+
     async def _drain_stderr_loop(self) -> None:
         if self._process is None or self._process.stderr is None:
             return
         while True:
             raw_line = await self._process.stderr.readline()
+            if not raw_line:
+                break
+            text = raw_line.decode("utf-8", errors="replace").strip()
+            if not text:
+                continue
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="external_agent.cli_jsonrpc.stderr",
+                message="External CLI JSON-RPC runtime wrote to stderr",
+                payload={"line": text[:500]},
+            )
+
+    async def _drain_blocking_stderr_loop(self) -> None:
+        if self._blocking_process is None or self._blocking_process.stderr is None:
+            return
+        stream = self._blocking_process.stderr
+        while True:
+            raw_line = await asyncio.to_thread(stream.readline)
             if not raw_line:
                 break
             text = raw_line.decode("utf-8", errors="replace").strip()
@@ -797,6 +1000,33 @@ async def _read_next_stdio_message(stream: asyncio.StreamReader) -> bytes | None
                 break
         return await stream.readexactly(content_length)
     return first_line.rstrip(b"\r\n")
+
+
+def _read_next_blocking_stdio_message(stream: IO[bytes]) -> bytes | None:
+    first_line = stream.readline()
+    if not first_line:
+        return None
+    if first_line.startswith(b"Content-Length:"):
+        try:
+            content_length = int(first_line.partition(b":")[2].strip())
+        except ValueError as exc:
+            raise CliAgentError(
+                "Invalid Content-Length header from CLI runtime"
+            ) from exc
+        while True:
+            header_line = stream.readline()
+            if not header_line or header_line in (b"\n", b"\r\n"):
+                break
+        payload = stream.read(content_length)
+        if len(payload) != content_length:
+            raise CliAgentError("CLI runtime closed stdout during framed message")
+        return payload
+    return first_line.rstrip(b"\r\n")
+
+
+def _write_blocking_stdio_message(stream: IO[bytes], payload: bytes) -> None:
+    stream.write(payload)
+    stream.flush()
 
 
 def _optional_id(payload: dict[str, JsonValue]) -> JsonRpcId | None:

--- a/src/relay_teams/agents/execution/spec_checkpoint.py
+++ b/src/relay_teams/agents/execution/spec_checkpoint.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai.messages import (
@@ -221,12 +222,13 @@ def render_spec_checkpoint(
         lines.extend(
             _format_nested_items(
                 "Proof Artifacts",
-                tuple(path.as_posix() for path in formal.proof_artifacts),
+                tuple(_format_spec_path(path) for path in formal.proof_artifacts),
             )
         )
         if formal.counterexample_path is not None:
             lines.append(
-                f"  - Counterexample Path: {formal.counterexample_path.as_posix()}"
+                "  - Counterexample Path: "
+                f"{_format_spec_path(formal.counterexample_path)}"
             )
         if formal.replay_command is not None:
             lines.append(
@@ -322,6 +324,10 @@ def _format_nested_items(label: str, items: tuple[str, ...]) -> list[str]:
     if not items:
         return []
     return [f"  - {label}:"] + [f"    - {_clip_item(item)}" for item in items]
+
+
+def _format_spec_path(path: Path) -> str:
+    return path.as_posix()
 
 
 def _clip_item(item: str) -> str:

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -408,26 +408,29 @@ class TaskExecutionService(BaseModel):
         )
 
         # OP-3: Create artifact container (spec phase).
+        artifact_writes_enabled = False
         if self.artifact_repo is not None:
             try:
-                await self.artifact_repo.ensure_artifact_async(
+                artifact_writes_enabled = self.artifact_repo.enqueue_ensure_artifact(
                     task_id=task.task_id,
                     spec_artifact_id=task.spec_artifact_id or "",
                 )
-                await self.artifact_repo.append_entry_async(
-                    task_id=task.task_id,
-                    entry=TaskArtifactEntry(
-                        entry_id=f"start-{task.task_id}",
-                        phase=TaskArtifactPhase.SPEC,
-                        timestamp=datetime.now(tz=timezone.utc).isoformat(),
-                        role_id=role_id,
-                        instance_id=instance_id,
-                        event_type="task_started",
-                        description="Task execution started",
-                        payload_json=task.model_dump_json(),
-                    ),
-                )
+                if artifact_writes_enabled:
+                    _ = self.artifact_repo.enqueue_append_entry(
+                        task_id=task.task_id,
+                        entry=TaskArtifactEntry(
+                            entry_id=f"start-{task.task_id}",
+                            phase=TaskArtifactPhase.SPEC,
+                            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                            role_id=role_id,
+                            instance_id=instance_id,
+                            event_type="task_started",
+                            description="Task execution started",
+                            payload_json=task.model_dump_json(),
+                        ),
+                    )
             except Exception as exc:
+                artifact_writes_enabled = False
                 log_event(
                     LOGGER,
                     logging.WARNING,
@@ -449,9 +452,9 @@ class TaskExecutionService(BaseModel):
 
         try:
             # OP-3: Append implementation phase entry.
-            if self.artifact_repo is not None:
+            if artifact_writes_enabled and self.artifact_repo is not None:
                 try:
-                    await self.artifact_repo.append_entry_async(
+                    _ = self.artifact_repo.enqueue_append_entry(
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"impl-{task.task_id}",
@@ -553,9 +556,9 @@ class TaskExecutionService(BaseModel):
             )
 
             # OP-3: Append verification phase entry.
-            if self.artifact_repo is not None:
+            if artifact_writes_enabled and self.artifact_repo is not None:
                 try:
-                    await self.artifact_repo.append_entry_async(
+                    _ = self.artifact_repo.enqueue_append_entry(
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"verify-{task.task_id}",
@@ -578,9 +581,9 @@ class TaskExecutionService(BaseModel):
                     )
 
             # OP-3: Append delivery phase entry and update summary.
-            if self.artifact_repo is not None:
+            if artifact_writes_enabled and self.artifact_repo is not None:
                 try:
-                    await self.artifact_repo.append_entry_async(
+                    _ = self.artifact_repo.enqueue_append_entry(
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"delivery-{task.task_id}",
@@ -593,7 +596,7 @@ class TaskExecutionService(BaseModel):
                             payload_json="{}",
                         ),
                     )
-                    await self.artifact_repo.update_summary_async(
+                    _ = self.artifact_repo.enqueue_update_summary(
                         task_id=task.task_id,
                         summary=result,
                     )

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -2218,10 +2218,32 @@ def _resolve_verification_path(
 ) -> Path | None:
     if workspace_root is None:
         return path if path.is_absolute() else None
-    root = workspace_root.resolve()
-    candidate = (path if path.is_absolute() else root / path).resolve()
+    root = _normalize_path_without_drive_injection(workspace_root).resolve(strict=False)
+    candidate = _normalize_path_without_drive_injection(
+        path if path.is_absolute() else root / path
+    ).resolve(strict=False)
     try:
-        candidate.relative_to(root)
+        _ = candidate.relative_to(root)
     except ValueError:
         return None
     return candidate
+
+
+def _normalize_path_without_drive_injection(path: Path) -> Path:
+    anchor = path.anchor
+    normalized_parts: list[str] = []
+    for part in path.parts[1 if anchor else 0 :]:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if normalized_parts and normalized_parts[-1] != "..":
+                _ = normalized_parts.pop()
+                continue
+            if anchor:
+                continue
+        normalized_parts.append(part)
+    if anchor:
+        return Path(anchor, *normalized_parts)
+    if not normalized_parts:
+        return Path(".")
+    return Path(*normalized_parts)

--- a/src/relay_teams/agents/tasks/artifact_repository.py
+++ b/src/relay_teams/agents/tasks/artifact_repository.py
@@ -2,17 +2,21 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
+import time
+import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
-from typing import TypeVar, cast
+from queue import Empty, Full, Queue
+from threading import Event, Lock, RLock, Thread
+from typing import Literal, TypeVar, cast
 
 import aiosqlite
+from pydantic import BaseModel, ConfigDict
 
 from relay_teams.agents.tasks.enums import TaskArtifactPhase
-from relay_teams.logger import get_logger
 from relay_teams.agents.tasks.models import (
     TaskArtifact,
     TaskArtifactEntry,
@@ -23,12 +27,16 @@ from relay_teams.persistence.db import (
     BlockingSqliteConnection,
     SQLITE_BUSY_TIMEOUT_MS,
     SQLITE_TIMEOUT_SECONDS,
+    is_retryable_sqlite_error,
     open_async_sqlite,
     run_async_sqlite_write_with_retry,
     run_sqlite_write_with_retry,
 )
+from relay_teams.logger import get_logger, log_event
 from relay_teams.persistence.sqlite_repository import async_fetchall, async_fetchone
 
+TASK_ARTIFACT_WRITE_QUEUE_MAXSIZE = 2000
+LOGGER = get_logger(__name__)
 ResultT = TypeVar("ResultT")
 
 _CREATE_TABLES_SQL = """\
@@ -64,13 +72,306 @@ CREATE INDEX IF NOT EXISTS idx_artifact_entries_event_type
 """
 
 
+class TaskArtifactWriteMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    enqueued: int = 0
+    completed: int = 0
+    dropped: int = 0
+    failed: int = 0
+    sqlite_lock_timeout_count: int = 0
+    total_wait_ms: int = 0
+    total_duration_ms: int = 0
+    queue_length: int = 0
+
+
+class _TaskArtifactWriteJob(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    operation: Literal["ensure", "append", "update_summary", "update_evidence_bundle"]
+    task_id: str
+    enqueued_monotonic: float
+    spec_artifact_id: str = ""
+    entry: TaskArtifactEntry | None = None
+    summary: str = ""
+    evidence_bundle: VerificationEvidenceBundle | None = None
+
+
 class TaskArtifactRepository:
     """Persist and query task artifacts and entries."""
 
     def __init__(self, db_path: Path | str) -> None:
         self._db_path = Path(db_path)
         self._lock = RLock()
+        self._queue: Queue[_TaskArtifactWriteJob] = Queue(
+            maxsize=TASK_ARTIFACT_WRITE_QUEUE_MAXSIZE
+        )
+        self._worker_stop = Event()
+        self._worker: Thread | None = None
+        self._worker_lock = RLock()
+        self._closed = False
+        self._metrics_lock = Lock()
+        self._metrics = TaskArtifactWriteMetrics()
         self._init_tables()
+
+    def enqueue_ensure_artifact(self, *, task_id: str, spec_artifact_id: str) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="ensure",
+                task_id=task_id,
+                spec_artifact_id=spec_artifact_id,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
+
+    def enqueue_append_entry(self, *, task_id: str, entry: TaskArtifactEntry) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="append",
+                task_id=task_id,
+                entry=entry,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
+
+    def enqueue_update_summary(self, *, task_id: str, summary: str) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="update_summary",
+                task_id=task_id,
+                summary=summary,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
+
+    def enqueue_update_evidence_bundle(
+        self,
+        *,
+        task_id: str,
+        bundle: VerificationEvidenceBundle,
+    ) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="update_evidence_bundle",
+                task_id=task_id,
+                evidence_bundle=bundle,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
+
+    def write_metrics(self) -> TaskArtifactWriteMetrics:
+        with self._metrics_lock:
+            return self._metrics.model_copy(
+                update={"queue_length": self._queue.qsize()}
+            )
+
+    def drain_write_queue(self, *, timeout_seconds: float = 2.0) -> bool:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            metrics = self.write_metrics()
+            if (
+                metrics.completed + metrics.failed >= metrics.enqueued
+                and self._queue.empty()
+            ):
+                return True
+            time.sleep(0.01)
+        metrics = self.write_metrics()
+        return (
+            metrics.completed + metrics.failed >= metrics.enqueued
+            and self._queue.empty()
+        )
+
+    def close(self, *, drain_timeout_seconds: float = 1.0) -> None:
+        with self._worker_lock:
+            self._closed = True
+            worker = self._worker
+
+        if worker is not None and worker.is_alive():
+            if not self.drain_write_queue(timeout_seconds=drain_timeout_seconds):
+                self._log_close_waiting_for_queued_writes(self.write_metrics())
+                self._queue.join()
+
+        self._worker_stop.set()
+        worker = self._worker
+        if worker is not None and worker.is_alive():
+            worker.join(timeout=1.0)
+
+    async def close_async(self) -> None:
+        await asyncio.to_thread(self.close)
+
+    def _enqueue(self, job: _TaskArtifactWriteJob) -> bool:
+        with self._worker_lock:
+            if self._closed:
+                self._record_metrics(dropped=1)
+                self._log_queued_write_rejected_after_close(job)
+                return False
+            self._ensure_write_worker_started()
+            try:
+                self._queue.put_nowait(job)
+            except Full:
+                self._record_metrics(dropped=1)
+                self._log_queued_write_dropped(job)
+                return False
+        self._record_metrics(enqueued=1)
+        return True
+
+    def _ensure_write_worker_started(self) -> None:
+        with self._worker_lock:
+            self._ensure_write_worker_started_locked()
+
+    def _ensure_write_worker_started_locked(self) -> None:
+        if self._worker is not None and self._worker.is_alive():
+            return
+        self._worker_stop.clear()
+        self._worker = Thread(
+            target=self._run_write_worker,
+            name="relay-teams-task-artifact-writer",
+            daemon=True,
+        )
+        self._worker.start()
+
+    def _run_write_worker(self) -> None:
+        while not self._worker_stop.is_set():
+            try:
+                job = self._queue.get(timeout=0.25)
+            except Empty:
+                continue
+            started = time.perf_counter()
+            wait_ms = int((started - job.enqueued_monotonic) * 1000)
+            try:
+                self._execute_queued_job(job)
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                self._record_metrics(
+                    completed=1,
+                    total_wait_ms=wait_ms,
+                    total_duration_ms=duration_ms,
+                )
+            except sqlite3.OperationalError as exc:
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                self._record_metrics(
+                    failed=1,
+                    sqlite_lock_timeout_count=(
+                        1 if is_retryable_sqlite_error(exc) else 0
+                    ),
+                    total_wait_ms=wait_ms,
+                    total_duration_ms=duration_ms,
+                )
+                self._log_queued_write_failure(job, exc)
+            except Exception as exc:
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                self._record_metrics(
+                    failed=1,
+                    total_wait_ms=wait_ms,
+                    total_duration_ms=duration_ms,
+                )
+                self._log_queued_write_failure(job, exc)
+            finally:
+                self._queue.task_done()
+
+    def _execute_queued_job(self, job: _TaskArtifactWriteJob) -> None:
+        if job.operation == "ensure":
+            self.ensure_artifact(
+                task_id=job.task_id,
+                spec_artifact_id=job.spec_artifact_id,
+            )
+            return
+        if job.operation == "append":
+            if job.entry is None:
+                raise ValueError("Queued artifact append missing entry")
+            self.append_entry(task_id=job.task_id, entry=job.entry)
+            return
+        if job.operation == "update_summary":
+            self.update_summary(task_id=job.task_id, summary=job.summary)
+            return
+        if job.evidence_bundle is None:
+            raise ValueError("Queued artifact evidence update missing bundle")
+        self.update_evidence_bundle(task_id=job.task_id, bundle=job.evidence_bundle)
+
+    def _record_metrics(
+        self,
+        *,
+        enqueued: int = 0,
+        completed: int = 0,
+        dropped: int = 0,
+        failed: int = 0,
+        sqlite_lock_timeout_count: int = 0,
+        total_wait_ms: int = 0,
+        total_duration_ms: int = 0,
+    ) -> None:
+        with self._metrics_lock:
+            self._metrics = TaskArtifactWriteMetrics(
+                enqueued=self._metrics.enqueued + enqueued,
+                completed=self._metrics.completed + completed,
+                dropped=self._metrics.dropped + dropped,
+                failed=self._metrics.failed + failed,
+                sqlite_lock_timeout_count=(
+                    self._metrics.sqlite_lock_timeout_count + sqlite_lock_timeout_count
+                ),
+                total_wait_ms=self._metrics.total_wait_ms + total_wait_ms,
+                total_duration_ms=self._metrics.total_duration_ms + total_duration_ms,
+                queue_length=self._queue.qsize(),
+            )
+
+    @staticmethod
+    def _log_queued_write_failure(
+        job: _TaskArtifactWriteJob,
+        exc: Exception,
+    ) -> None:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="artifact.write_queue.failed",
+            message="Queued artifact write failed",
+            payload={
+                "task_id": job.task_id,
+                "operation": job.operation,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+    @staticmethod
+    def _log_queued_write_dropped(job: _TaskArtifactWriteJob) -> None:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="artifact.write_queue.dropped",
+            message="Queued artifact write was dropped because the queue is full",
+            payload={
+                "task_id": job.task_id,
+                "operation": job.operation,
+            },
+        )
+
+    @staticmethod
+    def _log_queued_write_rejected_after_close(job: _TaskArtifactWriteJob) -> None:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="artifact.write_queue.rejected_after_close",
+            message="Queued artifact write was rejected because the repository is closed",
+            payload={
+                "task_id": job.task_id,
+                "operation": job.operation,
+            },
+        )
+
+    @staticmethod
+    def _log_close_waiting_for_queued_writes(
+        metrics: TaskArtifactWriteMetrics,
+    ) -> None:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="artifact.write_queue.close_waiting",
+            message="Waiting for queued artifact writes to finish before close",
+            payload={
+                "queue_length": metrics.queue_length,
+                "enqueued": metrics.enqueued,
+                "completed": metrics.completed,
+                "failed": metrics.failed,
+            },
+        )
 
     def _init_tables(self) -> None:
         def operation(conn: sqlite3.Connection) -> None:

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -1141,6 +1141,7 @@ class ServerContainer:
         )
         self._async_closeables: tuple[AsyncCloseableRepository, ...] = (
             self.task_repo,
+            self.artifact_repo,
             self.audit_repository,
             self.shared_store,
             self.workspace_repo,
@@ -1451,6 +1452,7 @@ class ServerContainer:
                 message="Requested active runs to stop during server shutdown",
                 payload={"stopped_run_count": stopped_runs},
             )
+        await self.run_service.drain_detached_notifications_async()
         await self.external_acp_session_manager.close()
         await self.background_task_manager.close()
         await self.mcp_config_file_watcher.stop()

--- a/src/relay_teams/metrics/definitions.py
+++ b/src/relay_teams/metrics/definitions.py
@@ -111,6 +111,48 @@ GATEWAY_OPERATION_FAILURES = MetricDefinition(
     description="Count of failed gateway ACP and MCP operations.",
     unit="calls",
 )
+SQLITE_WRITE_QUEUE_LENGTH = MetricDefinition(
+    name="relay_teams.sqlite.write_queue_length",
+    kind=MetricKind.GAUGE,
+    description="Current queued low-priority SQLite writes.",
+    unit="writes",
+)
+SQLITE_WRITE_DURATION_MS = MetricDefinition(
+    name="relay_teams.sqlite.write_duration_ms",
+    kind=MetricKind.HISTOGRAM,
+    description="Observed SQLite write duration in milliseconds.",
+    unit="ms",
+)
+SQLITE_WRITE_WAIT_MS = MetricDefinition(
+    name="relay_teams.sqlite.write_wait_ms",
+    kind=MetricKind.HISTOGRAM,
+    description="Observed time spent waiting for SQLite write coordination.",
+    unit="ms",
+)
+SQLITE_WRITE_RETRIES = MetricDefinition(
+    name="relay_teams.sqlite.write_retries",
+    kind=MetricKind.COUNTER,
+    description="Count of SQLite writes retried after lock contention.",
+    unit="retries",
+)
+SQLITE_LOCK_TIMEOUTS = MetricDefinition(
+    name="relay_teams.sqlite.lock_timeouts",
+    kind=MetricKind.COUNTER,
+    description="Count of SQLite lock timeout or lock contention observations.",
+    unit="timeouts",
+)
+SQLITE_WRITE_FAILURES = MetricDefinition(
+    name="relay_teams.sqlite.write_failures",
+    kind=MetricKind.COUNTER,
+    description="Count of SQLite writes that failed.",
+    unit="writes",
+)
+ARTIFACT_WRITE_QUEUE_DROPS = MetricDefinition(
+    name="relay_teams.artifact.write_queue_drops",
+    kind=MetricKind.COUNTER,
+    description="Count of low-priority artifact writes dropped before persistence.",
+    unit="writes",
+)
 
 DEFAULT_DEFINITIONS = (
     SESSION_STEPS,
@@ -131,4 +173,11 @@ DEFAULT_DEFINITIONS = (
     GATEWAY_OPERATIONS,
     GATEWAY_OPERATION_DURATION_MS,
     GATEWAY_OPERATION_FAILURES,
+    SQLITE_WRITE_QUEUE_LENGTH,
+    SQLITE_WRITE_DURATION_MS,
+    SQLITE_WRITE_WAIT_MS,
+    SQLITE_WRITE_RETRIES,
+    SQLITE_LOCK_TIMEOUTS,
+    SQLITE_WRITE_FAILURES,
+    ARTIFACT_WRITE_QUEUE_DROPS,
 )

--- a/src/relay_teams/persistence/__init__.py
+++ b/src/relay_teams/persistence/__init__.py
@@ -6,6 +6,7 @@ from relay_teams.persistence.db import (
     SQLITE_BUSY_TIMEOUT_MS,
     SQLITE_TIMEOUT_SECONDS,
     SQLITE_WRITE_RETRY_ATTEMPTS,
+    SqliteWriteMetrics,
     async_sqlite_compile_options,
     async_sqlite_supports_fts5,
     is_retryable_sqlite_error,
@@ -13,8 +14,10 @@ from relay_teams.persistence.db import (
     run_async_blocking,
     run_async_sqlite_write_with_retry,
     run_sqlite_write_with_retry,
+    reset_sqlite_write_metrics,
     sqlite_compile_options,
     sqlite_supports_fts5,
+    sqlite_write_metrics,
 )
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.sqlite_repository import (
@@ -41,6 +44,7 @@ __all__ = [
     "ScopeType",
     "SharedSqliteRepository",
     "SharedStateRepository",
+    "SqliteWriteMetrics",
     "StateMutation",
     "async_fetchall",
     "async_fetchone",
@@ -53,6 +57,8 @@ __all__ = [
     "run_async_blocking",
     "run_async_sqlite_write_with_retry",
     "run_sqlite_write_with_retry",
+    "reset_sqlite_write_metrics",
     "sqlite_compile_options",
     "sqlite_supports_fts5",
+    "sqlite_write_metrics",
 ]

--- a/src/relay_teams/persistence/db.py
+++ b/src/relay_teams/persistence/db.py
@@ -6,11 +6,12 @@ import logging
 import sqlite3
 import time
 from pathlib import Path
-from threading import Condition, Event, RLock, Thread, get_ident
+from threading import Condition, Event, Lock, RLock, Thread, get_ident
 from typing import Awaitable, Callable, Protocol, TypeVar
 from weakref import WeakKeyDictionary
 
 import aiosqlite
+from pydantic import BaseModel, ConfigDict
 
 from relay_teams.logger import get_logger, log_event
 
@@ -32,7 +33,65 @@ _ASYNC_WRITE_COORDINATORS: dict[
 ] = {}
 _RESOLVED_DB_PATH_KEYS: dict[str, str] = {}
 _ASYNC_BLOCKING_RUNNER: _AsyncBlockingRunner | None = None
+_SQLITE_WRITE_METRICS: SqliteWriteMetrics | None = None
+_SQLITE_WRITE_METRICS_LOCK = Lock()
 ResultT = TypeVar("ResultT")
+
+
+class SqliteWriteMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    queued: int = 0
+    completed: int = 0
+    failed: int = 0
+    retry_count: int = 0
+    sqlite_lock_timeout_count: int = 0
+    total_wait_ms: int = 0
+    total_duration_ms: int = 0
+
+
+def sqlite_write_metrics() -> SqliteWriteMetrics:
+    with _SQLITE_WRITE_METRICS_LOCK:
+        return _current_sqlite_write_metrics()
+
+
+def reset_sqlite_write_metrics() -> None:
+    global _SQLITE_WRITE_METRICS
+    with _SQLITE_WRITE_METRICS_LOCK:
+        _SQLITE_WRITE_METRICS = SqliteWriteMetrics()
+
+
+def _current_sqlite_write_metrics() -> SqliteWriteMetrics:
+    global _SQLITE_WRITE_METRICS
+    if _SQLITE_WRITE_METRICS is None:
+        _SQLITE_WRITE_METRICS = SqliteWriteMetrics()
+    return _SQLITE_WRITE_METRICS
+
+
+def _record_sqlite_write_metrics(
+    *,
+    queued: int = 0,
+    completed: int = 0,
+    failed: int = 0,
+    retry_count: int = 0,
+    sqlite_lock_timeout_count: int = 0,
+    total_wait_ms: int = 0,
+    total_duration_ms: int = 0,
+) -> None:
+    global _SQLITE_WRITE_METRICS
+    with _SQLITE_WRITE_METRICS_LOCK:
+        current = _current_sqlite_write_metrics()
+        _SQLITE_WRITE_METRICS = SqliteWriteMetrics(
+            queued=current.queued + queued,
+            completed=current.completed + completed,
+            failed=current.failed + failed,
+            retry_count=current.retry_count + retry_count,
+            sqlite_lock_timeout_count=(
+                current.sqlite_lock_timeout_count + sqlite_lock_timeout_count
+            ),
+            total_wait_ms=current.total_wait_ms + total_wait_ms,
+            total_duration_ms=current.total_duration_ms + total_duration_ms,
+        )
 
 
 class BlockingSqliteCursor(Protocol):
@@ -257,10 +316,15 @@ async def run_async_sqlite_write_with_retry(
     delay = SQLITE_WRITE_RETRY_INITIAL_DELAY_SECONDS
     cross_write_lock = _cross_write_coordinator_for(db_path)
     write_lock = _async_write_coordinator_for(db_path)
+    write_started = time.perf_counter()
+    accumulated_wait_ms = 0
+    _record_sqlite_write_metrics(queued=1)
     for attempt in range(max_retries + 1):
         operation_started = False
         try:
+            wait_started = time.perf_counter()
             cross_write_token = await cross_write_lock.acquire_async()
+            accumulated_wait_ms += int((time.perf_counter() - wait_started) * 1000)
             try:
                 async with write_lock:
                     if lock is not None:
@@ -268,17 +332,43 @@ async def run_async_sqlite_write_with_retry(
                             operation_started = True
                             result = await operation()
                             await conn.commit()
+                            _record_sqlite_write_metrics(
+                                completed=1,
+                                total_wait_ms=accumulated_wait_ms,
+                                total_duration_ms=int(
+                                    (time.perf_counter() - write_started) * 1000
+                                ),
+                            )
                             return result
                     operation_started = True
                     result = await operation()
                     await conn.commit()
+                    _record_sqlite_write_metrics(
+                        completed=1,
+                        total_wait_ms=accumulated_wait_ms,
+                        total_duration_ms=int(
+                            (time.perf_counter() - write_started) * 1000
+                        ),
+                    )
                     return result
             finally:
                 cross_write_lock.release(cross_write_token)
         except sqlite3.OperationalError as exc:
             await _async_rollback_quietly(conn)
             if not is_retryable_sqlite_error(exc) or attempt >= max_retries:
+                _record_sqlite_write_metrics(
+                    failed=1,
+                    sqlite_lock_timeout_count=(
+                        1 if is_retryable_sqlite_error(exc) else 0
+                    ),
+                    total_wait_ms=accumulated_wait_ms,
+                    total_duration_ms=int((time.perf_counter() - write_started) * 1000),
+                )
                 raise
+            _record_sqlite_write_metrics(
+                retry_count=1,
+                sqlite_lock_timeout_count=1,
+            )
             log_event(
                 LOGGER,
                 logging.WARNING,
@@ -297,6 +387,11 @@ async def run_async_sqlite_write_with_retry(
         except BaseException:
             if operation_started:
                 await _async_rollback_quietly(conn)
+                _record_sqlite_write_metrics(
+                    failed=1,
+                    total_wait_ms=accumulated_wait_ms,
+                    total_duration_ms=int((time.perf_counter() - write_started) * 1000),
+                )
             raise
     raise RuntimeError(
         f"SQLite write helper exhausted retries for {repository_name}.{operation_name}"
@@ -317,10 +412,15 @@ def run_sqlite_write_with_retry(
     delay = SQLITE_WRITE_RETRY_INITIAL_DELAY_SECONDS
     cross_write_lock = _cross_write_coordinator_for(db_path)
     write_lock = _write_coordinator_for(db_path)
+    write_started = time.perf_counter()
+    accumulated_wait_ms = 0
+    _record_sqlite_write_metrics(queued=1)
     for attempt in range(max_retries + 1):
         operation_started = False
         try:
+            wait_started = time.perf_counter()
             cross_write_token = cross_write_lock.acquire_sync()
+            accumulated_wait_ms += int((time.perf_counter() - wait_started) * 1000)
             try:
                 with write_lock:
                     if lock is not None:
@@ -328,17 +428,43 @@ def run_sqlite_write_with_retry(
                             operation_started = True
                             result = operation()
                             conn.commit()
+                            _record_sqlite_write_metrics(
+                                completed=1,
+                                total_wait_ms=accumulated_wait_ms,
+                                total_duration_ms=int(
+                                    (time.perf_counter() - write_started) * 1000
+                                ),
+                            )
                             return result
                     operation_started = True
                     result = operation()
                     conn.commit()
+                    _record_sqlite_write_metrics(
+                        completed=1,
+                        total_wait_ms=accumulated_wait_ms,
+                        total_duration_ms=int(
+                            (time.perf_counter() - write_started) * 1000
+                        ),
+                    )
                     return result
             finally:
                 cross_write_lock.release(cross_write_token)
         except sqlite3.OperationalError as exc:
             _rollback_quietly(conn)
             if not is_retryable_sqlite_error(exc) or attempt >= max_retries:
+                _record_sqlite_write_metrics(
+                    failed=1,
+                    sqlite_lock_timeout_count=(
+                        1 if is_retryable_sqlite_error(exc) else 0
+                    ),
+                    total_wait_ms=accumulated_wait_ms,
+                    total_duration_ms=int((time.perf_counter() - write_started) * 1000),
+                )
                 raise
+            _record_sqlite_write_metrics(
+                retry_count=1,
+                sqlite_lock_timeout_count=1,
+            )
             log_event(
                 LOGGER,
                 logging.WARNING,
@@ -357,6 +483,11 @@ def run_sqlite_write_with_retry(
         except BaseException:
             if operation_started:
                 _rollback_quietly(conn)
+                _record_sqlite_write_metrics(
+                    failed=1,
+                    total_wait_ms=accumulated_wait_ms,
+                    total_duration_ms=int((time.perf_counter() - write_started) * 1000),
+                )
             raise
     raise RuntimeError(
         f"SQLite write helper exhausted retries for {repository_name}.{operation_name}"

--- a/src/relay_teams/persistence/shared_state_repo.py
+++ b/src/relay_teams/persistence/shared_state_repo.py
@@ -54,15 +54,11 @@ class SharedStateRepository(SharedSqliteRepository):
     async def manage_state_async(
         self, mutation: StateMutation, ttl_seconds: int | None = None
     ) -> None:
-        expires_at: str | None = None
-        if ttl_seconds is not None:
-            expires_at = (
-                datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
-            ).isoformat()
+        expires_at = _expires_at(ttl_seconds)
 
         async def operation() -> None:
             conn = await self._get_async_conn()
-            await conn.execute(
+            cursor = await conn.execute(
                 """
                 INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
                 VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
@@ -78,9 +74,39 @@ class SharedStateRepository(SharedSqliteRepository):
                     expires_at,
                 ),
             )
+            await cursor.close()
 
         await self._run_async_write(
             operation_name="manage_state",
+            operation=lambda _conn: operation(),
+        )
+
+    async def manage_states_async(
+        self,
+        mutations: tuple[StateMutation, ...],
+        ttl_seconds: int | None = None,
+    ) -> None:
+        if not mutations:
+            return
+        expires_at = _expires_at(ttl_seconds)
+        parameters = _state_mutation_parameters(mutations, expires_at)
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.executemany(
+                """
+                INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
+                VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+                ON CONFLICT(scope_type, scope_id, state_key)
+                DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
+                              expires_at=COALESCE(excluded.expires_at, expires_at)
+                """,
+                parameters,
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="manage_states",
             operation=lambda _conn: operation(),
         )
 
@@ -92,11 +118,7 @@ class SharedStateRepository(SharedSqliteRepository):
         update: Callable[[str | None], str],
         ttl_seconds: int | None = None,
     ) -> str:
-        expires_at: str | None = None
-        if ttl_seconds is not None:
-            expires_at = (
-                datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
-            ).isoformat()
+        expires_at = _expires_at(ttl_seconds)
 
         async def operation() -> str:
             conn = await self._get_async_conn()
@@ -152,6 +174,44 @@ class SharedStateRepository(SharedSqliteRepository):
         if row is None:
             return None
         return str(row["value_json"])
+
+    async def get_states_async(
+        self,
+        scope: ScopeRef,
+        keys: tuple[str, ...],
+    ) -> tuple[tuple[str, str], ...]:
+        normalized_keys = tuple(
+            dict.fromkeys(key.strip() for key in keys if key.strip())
+        )
+        if not normalized_keys:
+            return ()
+        rows_by_key: dict[str, str] = {}
+        chunk_size = 250
+        for index in range(0, len(normalized_keys), chunk_size):
+            key_chunk = normalized_keys[index : index + chunk_size]
+            placeholders = ", ".join("?" for _key in key_chunk)
+            rows = await self._run_async_read(
+                lambda conn, chunk=key_chunk, chunk_placeholders=placeholders: (
+                    async_fetchall(
+                        conn,
+                        f"""
+                        SELECT state_key, value_json FROM shared_state
+                        WHERE scope_type=? AND scope_id=? AND state_key IN ({chunk_placeholders})
+                          AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                        """,
+                        (
+                            scope.scope_type.value,
+                            scope.scope_id,
+                            *chunk,
+                        ),
+                    )
+                )
+            )
+            for row in rows:
+                rows_by_key[str(row["state_key"])] = str(row["value_json"])
+        return tuple(
+            (key, rows_by_key[key]) for key in normalized_keys if key in rows_by_key
+        )
 
     def snapshot(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
         return run_async_blocking(self.snapshot_async(scope))
@@ -393,3 +453,26 @@ class SharedStateRepository(SharedSqliteRepository):
 
 def build_global_scope_ref() -> ScopeRef:
     return ScopeRef(scope_type=ScopeType.GLOBAL, scope_id="global")
+
+
+def _expires_at(ttl_seconds: int | None) -> str | None:
+    if ttl_seconds is None:
+        return None
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
+    return expires_at.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _state_mutation_parameters(
+    mutations: tuple[StateMutation, ...],
+    expires_at: str | None,
+) -> tuple[tuple[str, str, str, str, str | None], ...]:
+    return tuple(
+        (
+            mutation.scope.scope_type.value,
+            mutation.scope.scope_id,
+            mutation.key,
+            mutation.value_json,
+            expires_at,
+        )
+        for mutation in mutations
+    )

--- a/src/relay_teams/sessions/runs/event_log.py
+++ b/src/relay_teams/sessions/runs/event_log.py
@@ -213,6 +213,53 @@ class EventLog(SharedSqliteRepository):
             raise RuntimeError("Failed to persist run event id")
         return int(lastrowid)
 
+    async def emit_run_events_async(
+        self,
+        events: tuple[RunEvent, ...],
+    ) -> tuple[int, ...]:
+        if not events:
+            return ()
+
+        async def operation() -> tuple[int, ...]:
+            conn = await self._get_async_conn()
+            event_ids: list[int] = []
+            chunk_size = max(1, _SQLITE_SAFE_VARIABLE_LIMIT // 7)
+            for index in range(0, len(events), chunk_size):
+                chunk = events[index : index + chunk_size]
+                placeholders = ", ".join("(?, ?, ?, ?, ?, ?, ?)" for _event in chunk)
+                parameters: list[str | None] = []
+                for event in chunk:
+                    parameters.extend(
+                        (
+                            event.event_type.value,
+                            event.trace_id,
+                            event.session_id,
+                            event.task_id,
+                            event.instance_id,
+                            event.payload_json,
+                            event.occurred_at.isoformat(),
+                        )
+                    )
+                cursor = await conn.execute(
+                    f"""
+                    INSERT INTO events(event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at)
+                    VALUES {placeholders}
+                    """,
+                    tuple(parameters),
+                )
+                lastrowid = cursor.lastrowid
+                await cursor.close()
+                if lastrowid is None:
+                    raise RuntimeError("Failed to persist run event ids")
+                firstrowid = int(lastrowid) - len(chunk) + 1
+                event_ids.extend(range(firstrowid, int(lastrowid) + 1))
+            return tuple(event_ids)
+
+        return await self._run_async_write(
+            operation_name="emit_run_events_async",
+            operation=lambda _conn: operation(),
+        )
+
     def list_by_trace(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
         with self._lock:
             rows = self._conn.execute(

--- a/src/relay_teams/sessions/runs/event_stream.py
+++ b/src/relay_teams/sessions/runs/event_stream.py
@@ -145,6 +145,17 @@ class RunEventHub:
             _ = await task
             raise
 
+    async def publish_many_async(self, events: tuple[RunEvent, ...]) -> tuple[int, ...]:
+        if not events:
+            return ()
+        await self._acquire_publish_lock_async()
+        task = asyncio.create_task(self._publish_many_async_with_lock(events))
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            _ = await task
+            raise
+
     async def _publish_async_with_lock(self, event: RunEvent) -> int:
         try:
             event_id = 0
@@ -166,6 +177,38 @@ class RunEventHub:
             for queue in session_listeners:
                 queue.put_nowait(event)
             return event_id
+        finally:
+            self._publish_lock.release()
+
+    async def _publish_many_async_with_lock(
+        self, events: tuple[RunEvent, ...]
+    ) -> tuple[int, ...]:
+        try:
+            event_ids: tuple[int, ...] = tuple(0 for _event in events)
+            if self._event_log:
+                event_ids = await self._event_log.emit_run_events_async(events)
+            if self._run_state_repo is not None and any(
+                event_id > 0 for event_id in event_ids
+            ):
+                await self._run_state_repo.apply_events_async(
+                    event_ids=event_ids,
+                    events=events,
+                )
+
+            published_events = tuple(
+                event.model_copy(update={"event_id": event_id})
+                if event_id > 0
+                else event
+                for event, event_id in zip(events, event_ids, strict=True)
+            )
+            for event in published_events:
+                listeners = self._subscribers.get(event.run_id, [])
+                for queue in listeners:
+                    queue.put_nowait(event)
+                session_listeners = self._session_subscribers.get(event.session_id, [])
+                for queue in session_listeners:
+                    queue.put_nowait(event)
+            return event_ids
         finally:
             self._publish_lock.release()
 

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -316,6 +316,7 @@ class SessionRunService:
         self._pending_runs: dict[str, IntentInput] = {}
         self._running_run_ids: set[str] = set()
         self._resume_requested_runs: set[str] = set()
+        self._detached_notification_tasks: set[asyncio.Task[None]] = set()
         self._run_creation_lock = asyncio.Lock()
         self._event_loop: asyncio.AbstractEventLoop | None = None
         self._scheduler = RunScheduler(
@@ -1299,16 +1300,6 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error=((result.error_message or output_text) if failed else None),
             )
-            await self._emit_notification_async(
-                notification_type=notification_type,
-                session_id=session_id,
-                run_id=run_id,
-                trace_id=result.trace_id,
-                title=notification_title,
-                body=notification_body,
-                session_mode=notification_session_mode,
-                run_kind=notification_run_kind,
-            )
             await self._safe_publish_run_event_async(
                 RunEvent(
                     session_id=session_id,
@@ -1319,6 +1310,16 @@ class SessionRunService:
                     payload_json=dumps(result.model_dump()),
                 ),
                 failure_event="run.event.publish_failed",
+            )
+            await self._emit_terminal_notification_detached_async(
+                notification_type=notification_type,
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=result.trace_id,
+                title=notification_title,
+                body=notification_body,
+                session_mode=notification_session_mode,
+                run_kind=notification_run_kind,
             )
             with bind_trace_context(
                 trace_id=run_id, run_id=run_id, session_id=session_id
@@ -1456,7 +1457,22 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error=((result.error_message or output_text) if failed else None),
             )
-            await self._emit_notification_async(
+            await self._safe_publish_run_event_async(
+                RunEvent(
+                    session_id=session_id,
+                    run_id=run_id,
+                    trace_id=result.trace_id,
+                    task_id=result.root_task_id,
+                    event_type=(
+                        RunEventType.RUN_FAILED
+                        if failed
+                        else RunEventType.RUN_COMPLETED
+                    ),
+                    payload_json=dumps(result.model_dump()),
+                ),
+                failure_event="run.event.publish_failed",
+            )
+            await self._emit_terminal_notification_detached_async(
                 notification_type=(
                     NotificationType.RUN_FAILED
                     if failed
@@ -1481,21 +1497,6 @@ class SessionRunService:
                     if runtime_intent is not None
                     else "conversation"
                 ),
-            )
-            await self._safe_publish_run_event_async(
-                RunEvent(
-                    session_id=session_id,
-                    run_id=run_id,
-                    trace_id=result.trace_id,
-                    task_id=result.root_task_id,
-                    event_type=(
-                        RunEventType.RUN_FAILED
-                        if failed
-                        else RunEventType.RUN_COMPLETED
-                    ),
-                    payload_json=dumps(result.model_dump()),
-                ),
-                failure_event="run.event.publish_failed",
             )
             with bind_trace_context(
                 trace_id=run_id, run_id=run_id, session_id=session_id
@@ -1981,6 +1982,13 @@ class SessionRunService:
                 continue
             stopped_count += 1
         return stopped_count
+
+    async def drain_detached_notifications_async(self) -> None:
+        while self._detached_notification_tasks:
+            await asyncio.gather(
+                *tuple(self._detached_notification_tasks),
+                return_exceptions=True,
+            )
 
     def _stop_run_local(self, run_id: str) -> None:
         self._scheduler.stop_run_local(run_id)
@@ -2721,6 +2729,71 @@ class SessionRunService:
             session_mode=session_mode,
             run_kind=run_kind,
         )
+
+    async def _emit_terminal_notification_detached_async(
+        self,
+        *,
+        notification_type: NotificationType,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        title: str,
+        body: str,
+        session_mode: str = "normal",
+        run_kind: str = "conversation",
+    ) -> None:
+        task = asyncio.create_task(
+            self._emit_notification_async(
+                notification_type=notification_type,
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=trace_id,
+                title=title,
+                body=body,
+                session_mode=session_mode,
+                run_kind=run_kind,
+            )
+        )
+        self._detached_notification_tasks.add(task)
+        task.add_done_callback(self._detached_notification_tasks.discard)
+        task.add_done_callback(
+            lambda completed: self._log_detached_notification_failure(
+                completed,
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+                notification_type=notification_type,
+            )
+        )
+        await asyncio.sleep(0)
+
+    @staticmethod
+    def _log_detached_notification_failure(
+        task: asyncio.Task[None],
+        *,
+        trace_id: str,
+        run_id: str,
+        session_id: str,
+        notification_type: NotificationType,
+    ) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            with bind_trace_context(
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="run.notification.detached_failed",
+                    message="Detached run notification failed",
+                    payload={"notification_type": notification_type.value},
+                    exc_info=exc,
+                )
 
     def _safe_runtime_update(self, run_id: str, **changes: object) -> None:
         self._event_publisher.safe_runtime_update(run_id, **changes)

--- a/src/relay_teams/sessions/runs/run_state_repo.py
+++ b/src/relay_teams/sessions/runs/run_state_repo.py
@@ -234,6 +234,102 @@ class RunStateRepository(SharedSqliteRepository):
         )
         return next_state
 
+    async def apply_events_async(
+        self,
+        *,
+        event_ids: tuple[int, ...],
+        events: tuple[RunEvent, ...],
+    ) -> RunStateRecord | None:
+        if not events:
+            return None
+        states_by_run: dict[str, RunStateRecord | None] = {}
+        for event in events:
+            if event.run_id not in states_by_run:
+                states_by_run[event.run_id] = await self.get_run_state_async(
+                    event.run_id
+                )
+        last_state: RunStateRecord | None = None
+        snapshot_records: list[tuple[RunEventType, RunSnapshotRecord]] = []
+        for event_id, event in zip(event_ids, events, strict=True):
+            next_state = apply_run_event_to_state(
+                states_by_run[event.run_id],
+                event=event,
+                event_id=event_id,
+            )
+            states_by_run[event.run_id] = next_state
+            last_state = next_state
+            if event.event_type in _SNAPSHOT_EVENT_TYPES:
+                snapshot_records.append(
+                    (
+                        event.event_type,
+                        RunSnapshotRecord(
+                            run_id=next_state.run_id,
+                            session_id=next_state.session_id,
+                            checkpoint_event_id=next_state.checkpoint_event_id,
+                            state=next_state,
+                            created_at=next_state.updated_at,
+                        ),
+                    )
+                )
+        final_states = tuple(state for state in states_by_run.values() if state)
+        if not final_states:
+            return None
+
+        state_parameters = tuple(
+            (
+                state.run_id,
+                state.session_id,
+                state.model_dump_json(),
+                state.updated_at.isoformat(),
+            )
+            for state in final_states
+        )
+        snapshot_parameters = tuple(
+            (
+                snapshot.run_id,
+                snapshot.session_id,
+                snapshot.checkpoint_event_id,
+                json.dumps(snapshot.state.model_dump(mode="json")),
+                snapshot.created_at.isoformat(),
+            )
+            for snapshot in _coalesce_batch_snapshots(tuple(snapshot_records))
+        )
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.executemany(
+                """
+                INSERT INTO run_states(run_id, session_id, state_json, updated_at)
+                VALUES(?, ?, ?, ?)
+                ON CONFLICT(run_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    state_json=excluded.state_json,
+                    updated_at=excluded.updated_at
+                """,
+                state_parameters,
+            )
+            await cursor.close()
+            if snapshot_parameters:
+                cursor = await conn.executemany(
+                    """
+                    INSERT INTO run_snapshots(run_id, session_id, checkpoint_event_id, state_json, created_at)
+                    VALUES(?, ?, ?, ?, ?)
+                    ON CONFLICT(run_id, checkpoint_event_id)
+                    DO UPDATE SET
+                        state_json=excluded.state_json,
+                        created_at=excluded.created_at
+                    """,
+                    snapshot_parameters,
+                )
+                await cursor.close()
+
+        await self._run_async_write(
+            operation_name="apply_events_async",
+            operation=lambda _conn: operation(),
+        )
+        return last_state
+
     def upsert(self, state: RunStateRecord) -> None:
         self._run_write(
             operation_name="upsert",
@@ -490,3 +586,26 @@ def _recoverable_states_from_rows(
             result.append(state)
     result.sort(key=lambda item: item.updated_at, reverse=True)
     return tuple(result)
+
+
+def _coalesce_batch_snapshots(
+    records: tuple[tuple[RunEventType, RunSnapshotRecord], ...],
+) -> tuple[RunSnapshotRecord, ...]:
+    snapshots: list[RunSnapshotRecord] = []
+    pending_tool_result: RunSnapshotRecord | None = None
+    for event_type, snapshot in records:
+        if event_type is RunEventType.TOOL_RESULT:
+            if (
+                pending_tool_result is not None
+                and pending_tool_result.run_id != snapshot.run_id
+            ):
+                snapshots.append(pending_tool_result)
+            pending_tool_result = snapshot
+            continue
+        if pending_tool_result is not None:
+            snapshots.append(pending_tool_result)
+            pending_tool_result = None
+        snapshots.append(snapshot)
+    if pending_tool_result is not None:
+        snapshots.append(pending_tool_result)
+    return tuple(snapshots)

--- a/tests/unit_tests/agent_runtimes/test_cli_client.py
+++ b/tests/unit_tests/agent_runtimes/test_cli_client.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from io import BytesIO
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import cast
@@ -17,11 +19,16 @@ from relay_teams.agent_runtimes.clients.cli import (
     _StdioCliJsonRpcClient,
     _build_command_args,
     _cli_command_exists,
+    _resolve_cli_command_path,
+    _resolve_cli_process_command,
+    _resolve_windows_pathext_candidate,
+    _read_next_blocking_stdio_message,
     _read_next_stdio_message,
     _start_cli_thread,
     _start_cli_turn,
     _stdio_transport,
     _wait_for_cli_turn_output,
+    _write_blocking_stdio_message,
     probe_cli_agent,
     run_cli_agent_prompt,
 )
@@ -135,6 +142,53 @@ for raw_line in sys.stdin:
             flush=True,
         )
 """
+
+
+class _BlockingPipe:
+    def __init__(self, initial: bytes = b"") -> None:
+        self._reader = BytesIO(initial)
+        self.written = bytearray()
+
+    def readline(self) -> bytes:
+        return self._reader.readline()
+
+    def read(self, size: int = -1) -> bytes:
+        return self._reader.read(size)
+
+    def write(self, payload: bytes) -> int:
+        self.written.extend(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+
+class _FakeBlockingProcess:
+    def __init__(
+        self,
+        *,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+    ) -> None:
+        self.stdin: _BlockingPipe | None = _BlockingPipe()
+        self.stdout: _BlockingPipe | None = _BlockingPipe(stdout)
+        self.stderr: _BlockingPipe | None = _BlockingPipe(stderr)
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return 0 if self.terminated or self.killed else None
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def wait(self) -> int:
+        self.terminated = True
+        return 0
+
 
 _JSON_RPC_ITEM_COMPLETED_RUNTIME_SCRIPT = r"""
 import json
@@ -608,6 +662,150 @@ def test_cli_command_exists_checks_windows_pathext(
     assert tmp_path / "runtime-agent.EXE" in checked_paths
 
 
+def test_cli_command_lookup_prefers_windows_pathext_wrapper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_paths: list[Path] = []
+
+    def fake_executable_path_exists(path: Path) -> bool:
+        checked_paths.append(path)
+        return path.name == "runtime-agent.CMD"
+
+    monkeypatch.setattr(
+        cli_client_module,
+        "_executable_path_exists",
+        fake_executable_path_exists,
+    )
+    monkeypatch.setattr(cli_client_module, "Path", type(tmp_path))
+    monkeypatch.setattr(cli_client_module.os, "name", "nt")
+
+    result = _resolve_cli_command_path(
+        "runtime-agent",
+        env={"PATH": str(tmp_path), "PATHEXT": ".EXE;.CMD"},
+    )
+
+    assert result == tmp_path / "runtime-agent.CMD"
+    assert checked_paths[:2] == [
+        tmp_path / "runtime-agent.EXE",
+        tmp_path / "runtime-agent.CMD",
+    ]
+    assert tmp_path / "runtime-agent" not in checked_paths
+
+
+def test_cli_command_lookup_uses_default_windows_pathext(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_paths: list[Path] = []
+
+    def fake_executable_path_exists(path: Path) -> bool:
+        checked_paths.append(path)
+        return path.name == "runtime-agent.CMD"
+
+    monkeypatch.setattr(
+        cli_client_module,
+        "_executable_path_exists",
+        fake_executable_path_exists,
+    )
+    monkeypatch.setattr(cli_client_module, "Path", type(tmp_path))
+    monkeypatch.setattr(cli_client_module.os, "name", "nt")
+
+    result = _resolve_cli_command_path(
+        "runtime-agent",
+        env={"PATH": str(tmp_path)},
+    )
+
+    assert result == tmp_path / "runtime-agent.CMD"
+    assert checked_paths == [
+        tmp_path / "runtime-agent.COM",
+        tmp_path / "runtime-agent.EXE",
+        tmp_path / "runtime-agent.BAT",
+        tmp_path / "runtime-agent.CMD",
+    ]
+
+
+def test_cli_direct_command_lookup_checks_windows_pathext_first(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_paths: list[Path] = []
+
+    def fake_executable_path_exists(path: Path) -> bool:
+        checked_paths.append(path)
+        return path.name == "runtime-agent.CMD"
+
+    monkeypatch.setattr(
+        cli_client_module,
+        "_executable_path_exists",
+        fake_executable_path_exists,
+    )
+    monkeypatch.setattr(cli_client_module, "Path", type(tmp_path))
+    monkeypatch.setattr(cli_client_module.os, "name", "nt")
+
+    result = _resolve_cli_command_path(
+        "./runtime-agent",
+        runtime_cwd=tmp_path,
+        env={"PATHEXT": ".CMD"},
+    )
+
+    assert result == tmp_path / "runtime-agent.CMD"
+    assert checked_paths == [tmp_path / "runtime-agent.CMD"]
+
+
+def test_windows_pathext_candidate_ignores_empty_suffixes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_paths: list[Path] = []
+
+    def fake_executable_path_exists(path: Path) -> bool:
+        checked_paths.append(path)
+        return path.name == "runtime-agent.CMD"
+
+    monkeypatch.setattr(
+        cli_client_module,
+        "_executable_path_exists",
+        fake_executable_path_exists,
+    )
+    monkeypatch.setattr(cli_client_module, "Path", type(tmp_path))
+
+    result = _resolve_windows_pathext_candidate(
+        tmp_path,
+        "runtime-agent",
+        {"pathext": ".EXE;;.CMD"},
+    )
+
+    assert result == tmp_path / "runtime-agent.CMD"
+    assert checked_paths == [
+        tmp_path / "runtime-agent.EXE",
+        tmp_path / "runtime-agent.CMD",
+    ]
+
+
+def test_windows_pathext_candidate_skips_commands_with_suffix(tmp_path: Path) -> None:
+    result = _resolve_windows_pathext_candidate(
+        tmp_path,
+        "runtime-agent.exe",
+        {"PATHEXT": ".CMD"},
+    )
+
+    assert result is None
+
+
+def test_cli_process_command_returns_original_when_lookup_missing(
+    tmp_path: Path,
+) -> None:
+    command, args = _resolve_cli_process_command(
+        "missing-runtime",
+        runtime_cwd=None,
+        env={"PATH": str(tmp_path), "PATHEXT": ".CMD"},
+    )
+
+    assert command == "missing-runtime"
+    assert args == ()
+
+
 def test_codex_command_uses_app_server_stdio_runtime() -> None:
     args = _build_command_args(
         transport=StdioTransportConfig(command="codex", args=()),
@@ -916,3 +1114,110 @@ async def test_read_next_stdio_message_rejects_invalid_content_length() -> None:
 
     with pytest.raises(CliAgentError, match="Invalid Content-Length"):
         await _read_next_stdio_message(reader)
+
+
+@pytest.mark.asyncio
+async def test_stdio_client_uses_blocking_process_fallback_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created_processes: list[_FakeBlockingProcess] = []
+
+    async def fake_create_subprocess_exec(*args: object, **kwargs: object) -> object:
+        _ = (args, kwargs)
+        raise NotImplementedError
+
+    def fake_popen(
+        args: tuple[str, ...],
+        *,
+        stdin: int,
+        stdout: int,
+        stderr: int,
+        cwd: Path | None,
+        env: dict[str, str],
+    ) -> _FakeBlockingProcess:
+        _ = (args, stdin, stdout, stderr, cwd, env)
+        process = _FakeBlockingProcess(stderr=b"runtime warning\n")
+        created_processes.append(process)
+        return process
+
+    monkeypatch.setattr(
+        cli_client_module.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(cli_client_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cli_client_module.os, "name", "nt")
+
+    client = _StdioCliJsonRpcClient(
+        command=sys.executable,
+        args=("-c", "print('unused')"),
+        runtime_cwd=tmp_path,
+        transport=StdioTransportConfig(command=sys.executable),
+    )
+
+    await client.start()
+    await client._send_raw({"jsonrpc": "2.0", "method": "initialized"})
+    await client.close()
+
+    process = created_processes[0]
+    assert process.stdin is not None
+    assert b'"method":"initialized"' in process.stdin.written
+    assert process.terminated is True
+
+
+@pytest.mark.asyncio
+async def test_blocking_stdout_loop_delivers_json_rpc_response() -> None:
+    client = _StdioCliJsonRpcClient(
+        command="runtime",
+        args=(),
+        runtime_cwd=None,
+        transport=StdioTransportConfig(command="runtime"),
+    )
+    process = _FakeBlockingProcess(stdout=b'{"id":1,"result":{"ok":true}}\n')
+    client._blocking_process = cast(subprocess.Popen[bytes], process)
+    future: asyncio.Future[dict[str, JsonValue]] = (
+        asyncio.get_running_loop().create_future()
+    )
+    client._pending[1] = future
+
+    await client._read_blocking_stdout_loop()
+
+    assert await future == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_blocking_stderr_loop_drains_lines() -> None:
+    client = _StdioCliJsonRpcClient(
+        command="runtime",
+        args=(),
+        runtime_cwd=None,
+        transport=StdioTransportConfig(command="runtime"),
+    )
+    client._blocking_process = cast(
+        subprocess.Popen[bytes],
+        _FakeBlockingProcess(stderr=b"\nruntime warning\n"),
+    )
+
+    await client._drain_blocking_stderr_loop()
+
+
+def test_read_next_blocking_stdio_message_supports_content_length() -> None:
+    stream = BytesIO(b"Content-Length: 5\r\n\r\nhello")
+
+    assert _read_next_blocking_stdio_message(stream) == b"hello"
+
+
+def test_read_next_blocking_stdio_message_rejects_short_payload() -> None:
+    stream = BytesIO(b"Content-Length: 5\r\n\r\nhi")
+
+    with pytest.raises(CliAgentError, match="closed stdout"):
+        _ = _read_next_blocking_stdio_message(stream)
+
+
+def test_write_blocking_stdio_message_flushes_payload() -> None:
+    stream = BytesIO()
+
+    _write_blocking_stdio_message(stream, b'{"jsonrpc":"2.0"}\n')
+
+    assert stream.getvalue() == b'{"jsonrpc":"2.0"}\n'

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -27,7 +27,11 @@ from relay_teams.agents.tasks.artifact_repository import TaskArtifactRepository
 from relay_teams.agents.tasks.enums import TaskStatus
 from relay_teams.agents.tasks.enums import TaskArtifactPhase
 from relay_teams.agents.tasks.events import EventType
-from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
+from relay_teams.agents.tasks.models import (
+    TaskArtifactEntry,
+    TaskEnvelope,
+    VerificationPlan,
+)
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.hooks import HookDecisionBundle, HookDecisionType, HookService
 from relay_teams.media import (
@@ -573,16 +577,79 @@ async def test_execute_records_task_artifact_entries(
         task=task,
     )
 
+    assert artifact_repo.drain_write_queue(timeout_seconds=2.0) is True
     artifact = artifact_repo.get_artifact(task.task_id)
+    metrics = artifact_repo.write_metrics()
     assert result.output == "ok"
     assert artifact is not None
     assert artifact.summary == "ok"
+    assert metrics.enqueued >= 5
+    assert metrics.completed == metrics.enqueued
     assert tuple(entry.phase for entry in artifact.entries) == (
         TaskArtifactPhase.SPEC,
         TaskArtifactPhase.EXECUTION,
         TaskArtifactPhase.VERIFICATION,
         TaskArtifactPhase.DELIVERY,
     )
+
+
+@pytest.mark.asyncio
+async def test_execute_skips_artifact_entries_when_container_enqueue_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "task_execution_service_artifact_queue_full.db"
+    artifact_repo = TaskArtifactRepository(tmp_path / "task_artifacts.db")
+    appended_entries: list[str] = []
+
+    def fail_artifact_container_enqueue(
+        *,
+        task_id: str,
+        spec_artifact_id: str,
+    ) -> bool:
+        _ = task_id
+        _ = spec_artifact_id
+        return False
+
+    def record_artifact_append(
+        *,
+        task_id: str,
+        entry: TaskArtifactEntry,
+    ) -> bool:
+        _ = task_id
+        appended_entries.append(entry.entry_id)
+        return True
+
+    monkeypatch.setattr(
+        artifact_repo,
+        "enqueue_ensure_artifact",
+        fail_artifact_container_enqueue,
+    )
+    monkeypatch.setattr(
+        artifact_repo,
+        "enqueue_append_entry",
+        record_artifact_append,
+    )
+    provider = _CapturingProvider()
+    service, task_repo, agent_repo, message_repo = _build_service(
+        db_path,
+        provider,
+        artifact_repo=artifact_repo,
+    )
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+    )
+
+    result = await service.execute(
+        instance_id=instance_id,
+        role_id="time",
+        task=task,
+    )
+
+    assert result.output == "ok"
+    assert appended_entries == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -1293,6 +1293,51 @@ def test_verify_task_required_file_rejects_workspace_escape(
     assert "escapes the workspace" in structure_check.details
 
 
+def test_verify_task_required_file_rejects_symlink_workspace_escape(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_required_file_symlink_escape.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "artifact.txt"
+    outside_file.write_text("not task evidence", encoding="utf-8")
+    link = workspace / "linked"
+    try:
+        link.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Return artifact",
+        verification=VerificationPlan(
+            required_files=(Path("linked") / outside_file.name,)
+        ),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        workspace_root=workspace,
+    )
+
+    assert result.passed is False
+    assert result.report is not None
+    structure_check = next(
+        check for check in result.report.checks if check.name.endswith("artifact.txt")
+    )
+    assert structure_check.passed is False
+    assert "escapes the workspace" in structure_check.details
+
+
 def test_verify_task_reports_incomplete_task(tmp_path: Path) -> None:
     db_path = tmp_path / "verification_incomplete.db"
     task_repo = TaskRepository(db_path)
@@ -2266,7 +2311,7 @@ def test_resolve_command_cwd_returns_none_when_no_cwd_and_no_workspace() -> None
 def test_resolve_command_cwd_resolves_custom_cwd() -> None:
     cmd = VerificationCommand(command=("echo", "hi"), cwd=Path("subdir"))
     result = verification_module._resolve_command_cwd(cmd, workspace_root=Path("/ws"))
-    assert result == Path("/ws/subdir").resolve()
+    assert result == (Path("/ws") / "subdir").resolve(strict=False)
 
 
 def test_wrap_cross_evaluation_evaluator_returns_none_when_no_evaluator() -> None:

--- a/tests/unit_tests/agents/tasks/test_artifact_repository.py
+++ b/tests/unit_tests/agents/tasks/test_artifact_repository.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from queue import Queue
 import sqlite3
+from threading import Event
+import time
 from typing import cast
 
 import pytest
 
 from relay_teams.agents.tasks.artifact_repository import (
     TaskArtifactRepository,
+    _TaskArtifactWriteJob,
     _enable_wal_if_available,
     _last_insert_row_id,
 )
@@ -233,6 +237,169 @@ def test_concurrent_append_entry_uses_sqlite_retry_coordination(tmp_path: Path) 
     assert all(row_id > 0 for row_id in row_ids)
     assert total == 36
     assert len(entries) == 36
+
+
+def test_queued_artifact_writes_are_persisted(repo: TaskArtifactRepository) -> None:
+    accepted = repo.enqueue_ensure_artifact(
+        task_id="task-queued",
+        spec_artifact_id="spec-queued",
+    )
+    accepted_entry = repo.enqueue_append_entry(
+        task_id="task-queued",
+        entry=TaskArtifactEntry(
+            entry_id="entry-queued",
+            phase=TaskArtifactPhase.EXECUTION,
+            timestamp="2024-01-01T00:00:00",
+            event_type="tool_call",
+            description="Queued write",
+        ),
+    )
+
+    drained = repo.drain_write_queue(timeout_seconds=2.0)
+    artifact = repo.get_artifact("task-queued")
+    metrics = repo.write_metrics()
+
+    assert accepted is True
+    assert accepted_entry is True
+    assert drained is True
+    assert artifact is not None
+    assert artifact.spec_artifact_id == "spec-queued"
+    assert tuple(entry.entry_id for entry in artifact.entries) == ("entry-queued",)
+    assert metrics.enqueued == 2
+    assert metrics.completed == 2
+
+
+def test_queued_artifact_summary_and_evidence_updates_are_persisted(
+    repo: TaskArtifactRepository,
+) -> None:
+    repo.ensure_artifact("task-queued-evidence", "spec-queued")
+    bundle = VerificationEvidenceBundle(
+        task_id="task-queued-evidence",
+        items=(
+            VerificationEvidenceItem(
+                evidence_id="ev-queued",
+                kind=VerificationEvidenceKind.TASK_RESULT,
+                summary="Queued evidence",
+            ),
+        ),
+    )
+
+    accepted_summary = repo.enqueue_update_summary(
+        task_id="task-queued-evidence",
+        summary="Queued summary",
+    )
+    accepted_evidence = repo.enqueue_update_evidence_bundle(
+        task_id="task-queued-evidence",
+        bundle=bundle,
+    )
+    repo.close()
+
+    artifact = repo.get_artifact("task-queued-evidence")
+    metrics = repo.write_metrics()
+
+    assert accepted_summary is True
+    assert accepted_evidence is True
+    assert artifact is not None
+    assert artifact.summary == "Queued summary"
+    assert artifact.evidence_bundle is not None
+    assert artifact.evidence_bundle.items[0].evidence_id == "ev-queued"
+    assert metrics.completed == 2
+
+
+def test_close_drains_accepted_artifact_writes_before_stopping_worker(
+    repo: TaskArtifactRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_execute = repo._execute_queued_job
+    first_job_started = Event()
+
+    def slow_execute(job: _TaskArtifactWriteJob) -> None:
+        first_job_started.set()
+        time.sleep(0.05)
+        original_execute(job)
+
+    monkeypatch.setattr(repo, "_execute_queued_job", slow_execute)
+
+    accepted_first = repo.enqueue_ensure_artifact(
+        task_id="task-close-first",
+        spec_artifact_id="spec-close",
+    )
+    accepted_second = repo.enqueue_ensure_artifact(
+        task_id="task-close-second",
+        spec_artifact_id="spec-close",
+    )
+
+    assert first_job_started.wait(timeout=1.0) is True
+    repo.close(drain_timeout_seconds=0.001)
+
+    metrics = repo.write_metrics()
+    assert accepted_first is True
+    assert accepted_second is True
+    assert repo.get_artifact("task-close-first") is not None
+    assert repo.get_artifact("task-close-second") is not None
+    assert metrics.completed == 2
+
+
+def test_queued_artifact_write_failure_is_recorded(
+    repo: TaskArtifactRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_job(_job: object) -> None:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(repo, "_execute_queued_job", fail_job)
+
+    accepted = repo.enqueue_ensure_artifact(
+        task_id="task-failed",
+        spec_artifact_id="",
+    )
+    drained = repo.drain_write_queue(timeout_seconds=2.0)
+    metrics = repo.write_metrics()
+
+    assert accepted is True
+    assert drained is True
+    assert metrics.failed == 1
+    assert metrics.sqlite_lock_timeout_count == 1
+
+
+def test_queued_artifact_write_drop_is_recorded(
+    repo: TaskArtifactRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(repo, "_queue", Queue(maxsize=1))
+    monkeypatch.setattr(repo, "_ensure_write_worker_started", lambda: None)
+
+    first = repo.enqueue_ensure_artifact(task_id="task-1", spec_artifact_id="")
+    second = repo.enqueue_ensure_artifact(task_id="task-2", spec_artifact_id="")
+    metrics = repo.write_metrics()
+
+    assert first is True
+    assert second is False
+    assert metrics.enqueued == 1
+    assert metrics.dropped == 1
+    assert metrics.queue_length == 1
+
+
+def test_queued_artifact_job_validation_failures_are_recorded(
+    repo: TaskArtifactRepository,
+) -> None:
+    with pytest.raises(ValueError, match="missing entry"):
+        repo._execute_queued_job(
+            _TaskArtifactWriteJob(
+                operation="append",
+                task_id="task-invalid-append",
+                enqueued_monotonic=0.0,
+            )
+        )
+
+    with pytest.raises(ValueError, match="missing bundle"):
+        repo._execute_queued_job(
+            _TaskArtifactWriteJob(
+                operation="update_evidence_bundle",
+                task_id="task-invalid-evidence",
+                enqueued_monotonic=0.0,
+            )
+        )
 
 
 def test_get_artifact_with_entries(repo: TaskArtifactRepository):

--- a/tests/unit_tests/persistence/test_db.py
+++ b/tests/unit_tests/persistence/test_db.py
@@ -15,11 +15,13 @@ from relay_teams.persistence.db import (
     async_sqlite_supports_fts5,
     is_retryable_sqlite_error,
     open_async_sqlite,
+    reset_sqlite_write_metrics,
     run_async_blocking,
     run_async_sqlite_write_with_retry,
     run_sqlite_write_with_retry,
     sqlite_compile_options,
     sqlite_supports_fts5,
+    sqlite_write_metrics,
 )
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
@@ -64,6 +66,25 @@ def test_sqlite_compile_options_reports_fts5_support(tmp_path: Path) -> None:
         assert sqlite_supports_fts5(repo._conn) is True
     finally:
         run_async_blocking(repo.close_async())
+
+
+def test_sqlite_write_metrics_record_success(tmp_path: Path) -> None:
+    reset_sqlite_write_metrics()
+    repo = SharedSqliteRepository(tmp_path / "metrics.db")
+    try:
+        repo._run_write(
+            operation_name="create_table",
+            operation=lambda: repo._conn.execute(
+                "CREATE TABLE metric_items(value TEXT NOT NULL)"
+            ),
+        )
+        metrics = sqlite_write_metrics()
+    finally:
+        run_async_blocking(repo.close_async())
+
+    assert metrics.queued >= 1
+    assert metrics.completed >= 1
+    assert metrics.failed == 0
 
 
 def test_is_retryable_sqlite_error_matches_lock_contention() -> None:

--- a/tests/unit_tests/persistence/test_shared_state_repo.py
+++ b/tests/unit_tests/persistence/test_shared_state_repo.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 
@@ -62,3 +64,51 @@ def test_delete_by_scope_key_prefix_removes_only_matching_scope_and_prefix(
     assert repository.snapshot(other_session_scope) == (
         ("workspace_read:conversation-1:/repo/file.py", '"value"'),
     )
+
+
+@pytest.mark.asyncio
+async def test_manage_states_and_get_states_preserve_requested_order(
+    tmp_path: Path,
+) -> None:
+    repository = SharedStateRepository(tmp_path / "state.db")
+    scope = ScopeRef(scope_type=ScopeType.TASK, scope_id="task-1")
+
+    await repository.manage_states_async(
+        (
+            StateMutation(scope=scope, key="b", value_json='"two"'),
+            StateMutation(scope=scope, key="a", value_json='"one"'),
+            StateMutation(scope=scope, key="c", value_json='"three"'),
+        )
+    )
+
+    values = await repository.get_states_async(scope, (" c ", "a", "", "c", "missing"))
+
+    assert values == (("c", '"three"'), ("a", '"one"'))
+
+
+@pytest.mark.asyncio
+async def test_manage_states_respects_ttl(tmp_path: Path) -> None:
+    repository = SharedStateRepository(tmp_path / "state.db")
+    scope = ScopeRef(scope_type=ScopeType.TASK, scope_id="task-ttl")
+
+    await repository.manage_states_async(
+        (StateMutation(scope=scope, key="short", value_json='"gone"'),),
+        ttl_seconds=-60,
+    )
+    await repository.manage_states_async(
+        (StateMutation(scope=scope, key="long", value_json='"kept"'),),
+        ttl_seconds=60,
+    )
+    assert await repository.get_states_async(scope, ("short", "long")) == (
+        ("long", '"kept"'),
+    )
+
+
+@pytest.mark.asyncio
+async def test_manage_states_empty_input_is_noop(tmp_path: Path) -> None:
+    repository = SharedStateRepository(tmp_path / "state.db")
+    scope = ScopeRef(scope_type=ScopeType.TASK, scope_id="task-empty")
+
+    await repository.manage_states_async(())
+
+    assert await repository.get_states_async(scope, ()) == ()

--- a/tests/unit_tests/sessions/runs/test_event_log.py
+++ b/tests/unit_tests/sessions/runs/test_event_log.py
@@ -41,6 +41,56 @@ async def test_event_log_async_methods_share_persisted_state(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_event_log_emits_run_events_in_one_ordered_batch(
+    tmp_path: Path,
+) -> None:
+    event_log = EventLog(tmp_path / "event_log_batch.db")
+    events = tuple(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            instance_id="instance-1",
+            event_type=event_type,
+            payload_json="{}",
+        )
+        for event_type in (
+            RunEventType.RUN_STARTED,
+            RunEventType.MODEL_STEP_STARTED,
+            RunEventType.RUN_COMPLETED,
+        )
+    )
+
+    try:
+        event_ids = await event_log.emit_run_events_async(events)
+        by_trace = await event_log.list_by_trace_with_ids_async("run-1")
+    finally:
+        await event_log.close_async()
+
+    assert event_ids == tuple(range(event_ids[0], event_ids[0] + len(events)))
+    assert tuple(row["id"] for row in by_trace) == event_ids
+    assert tuple(row["event_type"] for row in by_trace) == (
+        RunEventType.RUN_STARTED.value,
+        RunEventType.MODEL_STEP_STARTED.value,
+        RunEventType.RUN_COMPLETED.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_log_emit_run_events_async_returns_empty_for_empty_batch(
+    tmp_path: Path,
+) -> None:
+    event_log = EventLog(tmp_path / "event_log_empty_batch.db")
+    try:
+        event_ids = await event_log.emit_run_events_async(())
+    finally:
+        await event_log.close_async()
+
+    assert event_ids == ()
+
+
+@pytest.mark.asyncio
 async def test_event_log_async_hot_paths_do_not_reinitialize_schema(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/sessions/runs/test_event_stream.py
+++ b/tests/unit_tests/sessions/runs/test_event_stream.py
@@ -32,6 +32,14 @@ class _SequencedEventLog:
             self._next_event_id += 1
             return self._next_event_id
 
+    async def emit_run_events_async(
+        self, events: tuple[RunEvent, ...]
+    ) -> tuple[int, ...]:
+        with self._lock:
+            first_event_id = self._next_event_id + 1
+            self._next_event_id += len(events)
+            return tuple(range(first_event_id, self._next_event_id + 1))
+
 
 class _ObservedRunStateRepository:
     def __init__(self) -> None:
@@ -61,6 +69,17 @@ class _ObservedRunStateRepository:
             return self._state_record(event_id=event_id, event=event)
         finally:
             self._finish_update()
+
+    async def apply_events_async(
+        self,
+        *,
+        event_ids: tuple[int, ...],
+        events: tuple[RunEvent, ...],
+    ) -> RunStateRecord | None:
+        result: RunStateRecord | None = None
+        for event_id, event in zip(event_ids, events, strict=True):
+            result = await self.apply_event_async(event_id=event_id, event=event)
+        return result
 
     def _begin_update(self, event_id: int) -> None:
         with self._lock:
@@ -117,6 +136,78 @@ async def test_run_event_hub_publish_async_serializes_state_updates() -> None:
     assert published_event_ids == [1, 2]
     assert first.event_id == 1
     assert second.event_id == 2
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_publish_many_persists_state_and_delivers_in_order() -> (
+    None
+):
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    run_queue = hub.subscribe("run-1")
+    session_queue = hub.subscribe_session("session-1")
+
+    event_ids = await hub.publish_many_async(
+        (
+            _event(RunEventType.RUN_STARTED),
+            _event(RunEventType.MODEL_STEP_STARTED),
+            _event(RunEventType.RUN_COMPLETED),
+        )
+    )
+
+    assert event_ids == (1, 2, 3)
+    assert run_state_repo.applied_event_ids == [1, 2, 3]
+    assert tuple(run_queue.get_nowait().event_id for _index in range(3)) == event_ids
+    assert (
+        tuple(session_queue.get_nowait().event_id for _index in range(3)) == event_ids
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_publish_many_returns_empty_for_empty_batch() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+
+    event_ids = await hub.publish_many_async(())
+
+    assert event_ids == ()
+    assert run_state_repo.applied_event_ids == []
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_publish_many_finishes_when_cancelled() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    task = asyncio.create_task(
+        hub.publish_many_async(
+            (
+                _event(RunEventType.RUN_STARTED),
+                _event(RunEventType.MODEL_STEP_STARTED),
+            )
+        )
+    )
+    await run_state_repo.async_update_entered.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1)
+
+    assert run_state_repo.applied_event_ids == [1, 2]
+    assert tuple(queue.get_nowait().event_id for _index in range(2)) == (1, 2)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_run_service_stop_semantics.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_stop_semantics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sqlite3
 from typing import cast
 
@@ -485,6 +486,112 @@ def test_completed_notification_uses_final_run_output() -> None:
 
     assert notification_payload is not None
     assert notification_payload["body"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_terminal_notification_is_emitted_detached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionRunService.__new__(SessionRunService)
+    manager._detached_notification_tasks = set()
+    calls: list[dict[str, object]] = []
+
+    async def fake_emit_notification_async(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        manager,
+        "_emit_notification_async",
+        fake_emit_notification_async,
+    )
+
+    await manager._emit_terminal_notification_detached_async(
+        notification_type=NotificationType.RUN_COMPLETED,
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        title="Run Completed",
+        body="done",
+    )
+    await asyncio.sleep(0)
+
+    assert calls == [
+        {
+            "notification_type": NotificationType.RUN_COMPLETED,
+            "session_id": "session-1",
+            "run_id": "run-1",
+            "trace_id": "trace-1",
+            "title": "Run Completed",
+            "body": "done",
+            "session_mode": "normal",
+            "run_kind": "conversation",
+        }
+    ]
+    assert manager._detached_notification_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_drain_detached_notifications_waits_for_pending_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionRunService.__new__(SessionRunService)
+    manager._detached_notification_tasks = set()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls: list[dict[str, object]] = []
+
+    async def fake_emit_notification_async(**kwargs: object) -> None:
+        started.set()
+        await release.wait()
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        manager,
+        "_emit_notification_async",
+        fake_emit_notification_async,
+    )
+
+    await manager._emit_terminal_notification_detached_async(
+        notification_type=NotificationType.RUN_COMPLETED,
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        title="Run Completed",
+        body="done",
+    )
+    await started.wait()
+    drain_task = asyncio.create_task(manager.drain_detached_notifications_async())
+    await asyncio.sleep(0)
+
+    assert drain_task.done() is False
+
+    release.set()
+    await asyncio.wait_for(drain_task, timeout=1.0)
+
+    assert calls
+    assert manager._detached_notification_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_detached_notification_failure_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fail_notification() -> None:
+        raise RuntimeError("delivery failed")
+
+    task = asyncio.create_task(fail_notification())
+    await asyncio.sleep(0)
+
+    with caplog.at_level(logging.ERROR):
+        SessionRunService._log_detached_notification_failure(
+            task,
+            trace_id="trace-1",
+            run_id="run-1",
+            session_id="session-1",
+            notification_type=NotificationType.RUN_FAILED,
+        )
+
+    assert "Detached run notification failed" in caplog.text
 
 
 def test_assistant_error_notification_uses_failed_channel() -> None:

--- a/tests/unit_tests/sessions/runs/test_run_state_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_state_repo.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -132,3 +133,161 @@ async def test_run_state_async_schema_init_and_snapshot_upserts(
     assert latest_snapshot is not None
     assert latest_snapshot.checkpoint_event_id == 3
     assert tuple(item.run_id for item in recoverable) == ("run-1",)
+
+
+@pytest.mark.asyncio
+async def test_run_state_applies_event_batch_and_coalesces_tool_snapshots(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_state_repo_batch.db"
+    repository = RunStateRepository(db_path)
+    events = (
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json="{}",
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json='{"tool_name": "read"}',
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json='{"tool_name": "grep"}',
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json="{}",
+        ),
+    )
+
+    try:
+        state = await repository.apply_events_async(
+            event_ids=(1, 2, 3, 4),
+            events=events,
+        )
+        latest_snapshot = await repository.get_latest_snapshot_async("run-1")
+    finally:
+        await repository.close_async()
+
+    with sqlite3.connect(db_path) as conn:
+        snapshot_count = conn.execute("SELECT COUNT(*) FROM run_snapshots").fetchone()
+
+    assert state is not None
+    assert state.status == RunStateStatus.COMPLETED
+    assert state.last_event_id == 4
+    assert latest_snapshot is not None
+    assert latest_snapshot.checkpoint_event_id == 4
+    assert snapshot_count is not None
+    assert snapshot_count[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_run_state_apply_events_async_handles_mixed_runs(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_state_repo_batch_mixed_runs.db"
+    repository = RunStateRepository(db_path)
+    events = (
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json="{}",
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-2",
+            trace_id="run-2",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json="{}",
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json='{"tool_name": "read"}',
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-2",
+            trace_id="run-2",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json='{"tool_name": "grep"}',
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json="{}",
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-2",
+            trace_id="run-2",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json="{}",
+        ),
+    )
+
+    try:
+        state = await repository.apply_events_async(
+            event_ids=(1, 2, 3, 4, 5, 6),
+            events=events,
+        )
+        run_1 = await repository.get_run_state_async("run-1")
+        run_2 = await repository.get_run_state_async("run-2")
+    finally:
+        await repository.close_async()
+
+    with sqlite3.connect(db_path) as conn:
+        snapshot_rows = conn.execute(
+            "SELECT run_id, checkpoint_event_id FROM run_snapshots "
+            "ORDER BY checkpoint_event_id"
+        ).fetchall()
+
+    assert state is not None
+    assert state.run_id == "run-2"
+    assert run_1 is not None
+    assert run_1.run_id == "run-1"
+    assert run_1.status == RunStateStatus.COMPLETED
+    assert run_1.last_event_id == 5
+    assert run_2 is not None
+    assert run_2.run_id == "run-2"
+    assert run_2.status == RunStateStatus.COMPLETED
+    assert run_2.last_event_id == 6
+    assert snapshot_rows == [
+        ("run-1", 1),
+        ("run-2", 2),
+        ("run-1", 3),
+        ("run-2", 4),
+        ("run-1", 5),
+        ("run-2", 6),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_state_apply_events_async_returns_none_for_empty_batch(
+    tmp_path: Path,
+) -> None:
+    repository = RunStateRepository(tmp_path / "run_state_repo_empty_batch.db")
+    try:
+        state = await repository.apply_events_async(event_ids=(), events=())
+    finally:
+        await repository.close_async()
+
+    assert state is None


### PR DESCRIPTION
## Summary
- Add coordinated SQLite write metrics/retry observability for shared write helpers.
- Batch shared state, event log, run state, and run event hub writes to reduce hot-path lock pressure.
- Move task artifact writes behind a low-priority background queue with drain/close test hooks.
- Keep terminal run event publication ahead of external notification dispatch so slow delivery cannot block event streams.

Fixes #787

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q --basetemp=.pytest-tmp-final2-unit tests/unit_tests` (`6722 passed, 3 skipped`)
- `uv run --extra dev pytest -q --basetemp=.pytest-tmp-final2-integration tests/integration_tests` (`131 passed, 8 skipped`)