### PR TITLE
Fix orchestration subagent progress display

### DIFF
--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -47,7 +47,14 @@ import {
 } from './scrollController.js';
 import { roundsState } from './state.js';
 import { areRoundTodoSnapshotsEqual, normalizeRoundTodoSnapshot } from './todo.js';
-import { roundSectionId, esc, roundStateLabel, roundStateTone } from './utils.js';
+import {
+    effectiveRoundStatus,
+    roundIsRunning,
+    roundSectionId,
+    esc,
+    roundStateLabel,
+    roundStateTone,
+} from './utils.js';
 import { errorToPayload, logError } from '../../utils/logger.js';
 import { formatMessage, t } from '../../utils/i18n.js';
 
@@ -1893,7 +1900,7 @@ function renderRoundSection(round, index) {
             <div class="round-detail-mainline">
                 <div class="round-detail-meta">
                     <div class="round-detail-time">${time}</div>
-                    ${round.run_status === 'running' ? '<span class="live-badge">LIVE</span>' : ''}
+                    ${roundIsRunning(round) ? '<span class="live-badge">LIVE</span>' : ''}
                     <div class="round-detail-token-host"></div>
                 </div>
             </div>
@@ -1923,7 +1930,7 @@ function renderRoundSection(round, index) {
             pendingToolApprovals: pendingCoordinatorApprovals,
             primaryRoleLabel,
             runId: round.run_id,
-            runStatus: round.run_status,
+            runStatus: effectiveRoundStatus(round),
             runPhase: round.run_phase,
             hasFinalOutput: round.has_final_output === true,
             isLatestRound,
@@ -1937,7 +1944,7 @@ function renderRoundSection(round, index) {
             pendingToolApprovals: pendingCoordinatorApprovals,
             primaryRoleLabel,
             runId: round.run_id,
-            runStatus: round.run_status,
+            runStatus: effectiveRoundStatus(round),
             runPhase: round.run_phase,
             hasFinalOutput: round.has_final_output === true,
             isLatestRound,
@@ -2965,13 +2972,13 @@ function patchRoundHeader(round, _roundIndex) {
 
     const metaEl = section.querySelector('.round-detail-meta');
     const liveBadge = metaEl?.querySelector?.('.live-badge');
-    if (metaEl && round.run_status === 'running' && !liveBadge) {
+    if (metaEl && roundIsRunning(round) && !liveBadge) {
         const badge = document.createElement('span');
         badge.className = 'live-badge';
         badge.textContent = 'LIVE';
         const tokenHost = metaEl.querySelector('.round-detail-token-host');
         metaEl.insertBefore(badge, tokenHost || null);
-    } else if (liveBadge && round.run_status !== 'running') {
+    } else if (liveBadge && !roundIsRunning(round)) {
         liveBadge.remove();
     }
 

--- a/frontend/dist/js/components/rounds/utils.js
+++ b/frontend/dist/js/components/rounds/utils.js
@@ -3,6 +3,7 @@
  * Shared utility helpers for rounds timeline rendering.
  */
 import { t } from '../../utils/i18n.js';
+import { state } from '../../core/state.js';
 
 export function roundSectionId(runId) {
     return `round-${String(runId).replace(/[^a-zA-Z0-9_-]/g, '_')}`;
@@ -17,7 +18,7 @@ export function esc(text) {
 
 export function roundStateTone(round) {
     const phase = String(round?.run_phase || '');
-    const status = String(round?.run_status || '');
+    const status = effectiveRoundStatus(round);
     if (
         phase === 'awaiting_tool_approval'
         || phase === 'awaiting_subagent_followup'
@@ -41,7 +42,7 @@ export function roundStateTone(round) {
 
 export function roundStateLabel(round) {
     const phase = String(round?.run_phase || '');
-    const status = String(round?.run_status || '');
+    const status = effectiveRoundStatus(round);
     if (phase === 'awaiting_tool_approval') return t('rounds.state.awaiting_approval');
     if (phase === 'awaiting_manual_action') return t('rounds.state.awaiting_manual_action');
     if (phase === 'awaiting_subagent_followup') return t('rounds.state.awaiting_followup');
@@ -61,4 +62,33 @@ export function roundStateLabel(round) {
         default:
             return '';
     }
+}
+
+export function roundIsRunning(round) {
+    return effectiveRoundStatus(round) === 'running';
+}
+
+export function effectiveRoundStatus(round) {
+    if (hasRunningDelegatedTask(round)) {
+        return 'running';
+    }
+    return String(round?.run_status || '');
+}
+
+function hasRunningDelegatedTask(round) {
+    const runId = String(round?.run_id || '').trim();
+    if (!runId) {
+        return false;
+    }
+    const tasks = Array.isArray(state.sessionTasks) ? state.sessionTasks : [];
+    return tasks.some(task => {
+        if (!task || typeof task !== 'object') {
+            return false;
+        }
+        return (
+            String(task.run_id || '').trim() === runId
+            && String(task.status || '').trim().toLowerCase() === 'running'
+            && !!String(task.assigned_instance_id || task.instance_id || '').trim()
+        );
+    });
 }

--- a/frontend/dist/js/components/subagentRail.js
+++ b/frontend/dist/js/components/subagentRail.js
@@ -78,8 +78,11 @@ export async function refreshSubagentRail(
         if (signal?.aborted) return;
         if (state.currentSessionId !== safeSessionId) return;
 
-        state.sessionAgents = normalizeSessionAgents(agentsPayload);
         state.sessionTasks = normalizeSessionTasks(tasksPayload);
+        state.sessionAgents = reconcileSessionAgentsWithTasks(
+            normalizeSessionAgents(agentsPayload),
+            state.sessionTasks,
+        );
         subagentRailLoadingSessionId = '';
         renderSubagentRail({ preserveSelection, syncPanel: preserveSelection });
     } catch (e) {
@@ -203,10 +206,10 @@ function renderSubagentRail({ preserveSelection = true, syncPanel = true } = {})
 }
 
 function updateSubagentSummary() {
-    const roles = Array.isArray(state.sessionAgents) ? state.sessionAgents : [];
+    const roles = getDisplaySessionAgents();
     const isLoading = subagentRailLoadingSessionId
         && subagentRailLoadingSessionId === String(state.currentSessionId || '').trim();
-    const runningCount = roles.filter(agent => String(agent.status || '') === 'running').length;
+    const runningCount = countRunningSubagentInstances(roles);
     const summary = isLoading && roles.length === 0
         ? t('settings.system.loading_state')
         : roles.length === 0
@@ -229,7 +232,7 @@ function renderRoleSelector({ preserveSelection = true } = {}) {
     const select = els.subagentRoleSelect;
     if (!select) return;
 
-    const roles = Array.isArray(state.sessionAgents) ? state.sessionAgents : [];
+    const roles = getDisplaySessionAgents();
     const selectedRoleId = preserveSelection ? resolveSelectedRoleId() : resolveDefaultRoleId();
     const isLoading = subagentRailLoadingSessionId
         && subagentRailLoadingSessionId === String(state.currentSessionId || '').trim();
@@ -279,7 +282,7 @@ function resolveSelectedRoleId() {
 }
 
 function resolveDefaultRoleId() {
-    const roles = Array.isArray(state.sessionAgents) ? state.sessionAgents : [];
+    const roles = getDisplaySessionAgents();
     if (roles.length === 0) return null;
 
     const activeRoleId = String(
@@ -297,7 +300,7 @@ function resolveDefaultRoleId() {
 function findAgentByRole(roleId) {
     const safeRoleId = String(roleId || '').trim();
     if (!safeRoleId) return null;
-    return (state.sessionAgents || []).find(agent => agent.role_id === safeRoleId) || null;
+    return getDisplaySessionAgents().find(agent => agent.role_id === safeRoleId) || null;
 }
 
 function normalizeSessionAgents(payload) {
@@ -354,6 +357,120 @@ function normalizeSessionTasks(payload) {
                 ? item.evidence_bundle
                 : null,
         }));
+}
+
+function getDisplaySessionAgents() {
+    return reconcileSessionAgentsWithTasks(state.sessionAgents, state.sessionTasks);
+}
+
+function reconcileSessionAgentsWithTasks(agentsPayload, tasksPayload) {
+    const rows = normalizeSessionAgents(agentsPayload);
+    const activeTasks = activeRunningTasks(tasksPayload);
+    if (activeTasks.length === 0) {
+        return rows;
+    }
+
+    const latestByRole = new Map(rows.map(agent => [agent.role_id, agent]));
+    activeTasks.forEach(task => {
+        const roleId = String(task.assigned_role_id || task.role_id || '').trim();
+        const instanceId = String(
+            task.assigned_instance_id || task.instance_id || '',
+        ).trim();
+        if (!roleId || !instanceId || isPrimaryOrReservedRoleId(roleId)) {
+            return;
+        }
+        const existing = latestByRole.get(roleId);
+        if (!shouldProjectRunningTask(existing, task, instanceId)) {
+            return;
+        }
+        latestByRole.set(roleId, {
+            instance_id: instanceId,
+            role_id: roleId,
+            status: 'running',
+            created_at: existing?.created_at || task.created_at || '',
+            updated_at: latestTimestamp(existing?.updated_at || '', task.updated_at || ''),
+            runtime_system_prompt: existing?.runtime_system_prompt || '',
+            runtime_tools_json: existing?.runtime_tools_json || '',
+        });
+    });
+
+    return Array.from(latestByRole.values()).sort((left, right) =>
+        String(left.role_id || '').localeCompare(String(right.role_id || ''))
+    );
+}
+
+function activeRunningTasks(tasksPayload) {
+    const rows = Array.isArray(tasksPayload) ? tasksPayload : [];
+    return rows.filter(task => {
+        if (!task || typeof task !== 'object') {
+            return false;
+        }
+        const status = String(task.status || '').trim().toLowerCase();
+        const roleId = String(task.assigned_role_id || task.role_id || '').trim();
+        const instanceId = String(
+            task.assigned_instance_id || task.instance_id || '',
+        ).trim();
+        return (
+            status === 'running'
+            && !!roleId
+            && !!instanceId
+            && !isPrimaryOrReservedRoleId(roleId)
+        );
+    });
+}
+
+function shouldProjectRunningTask(existing, task, instanceId) {
+    if (!existing) {
+        return true;
+    }
+    if (String(existing.status || '').trim().toLowerCase() === 'running') {
+        return String(existing.instance_id || '').trim() === instanceId
+            || timestampIsAfter(
+                task.updated_at || task.created_at || '',
+                existing.updated_at || existing.created_at || '',
+            );
+    }
+    return timestampIsAfter(
+        task.updated_at || task.created_at || '',
+        existing.updated_at || existing.created_at || '',
+    );
+}
+
+function countRunningSubagentInstances(agents) {
+    const runningInstanceIds = new Set();
+    const rows = Array.isArray(agents) ? agents : [];
+    rows.forEach(agent => {
+        if (String(agent?.status || '').trim().toLowerCase() !== 'running') {
+            return;
+        }
+        const instanceId = String(agent?.instance_id || '').trim();
+        if (instanceId) {
+            runningInstanceIds.add(instanceId);
+        }
+    });
+    return runningInstanceIds.size;
+}
+
+function latestTimestamp(left, right) {
+    const safeLeft = String(left || '');
+    const safeRight = String(right || '');
+    if (!safeLeft) return safeRight;
+    if (!safeRight) return safeLeft;
+    return timestampIsAfter(safeRight, safeLeft) ? safeRight : safeLeft;
+}
+
+function timestampIsAfter(left, right) {
+    const safeLeft = String(left || '').trim();
+    const safeRight = String(right || '').trim();
+    if (!safeLeft) return false;
+    if (!safeRight) return true;
+
+    const leftMs = Date.parse(safeLeft);
+    const rightMs = Date.parse(safeRight);
+    if (!Number.isNaN(leftMs) && !Number.isNaN(rightMs)) {
+        return leftMs > rightMs;
+    }
+    return safeLeft.localeCompare(safeRight) > 0;
 }
 
 function humanizeStatus(value) {

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -431,7 +431,11 @@ export function handleModelStepFinished(eventMeta, instanceId, roleIdOverride = 
         }
     }
     finalizeStream(key, isPrimary ? getRunPrimaryRoleId(runId) : roleId, { runId });
-    if (instanceId && !isPrimary) {
+    if (
+        instanceId
+        && !isPrimary
+        && !isOrchestrationDelegatedSubagent(roleId, runId)
+    ) {
         markSubagentStatus(instanceId, 'completed');
     }
     if (!instanceId || state.activeAgentInstanceId === instanceId) {
@@ -795,6 +799,15 @@ function isNormalModeSubagentRun(runId, roleId) {
         && safeRunId.startsWith('subagent_run_')
         && safeRoleId
         && !isRunPrimaryRoleId(safeRoleId, safeRunId)
+    );
+}
+
+function isOrchestrationDelegatedSubagent(roleId, runId) {
+    const safeRoleId = String(roleId || '').trim();
+    return !!(
+        state.currentSessionMode === 'orchestration'
+        && safeRoleId
+        && !isRunPrimaryRoleId(safeRoleId, runId)
     );
 }
 

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -280,7 +280,7 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert (
         "if (!shouldPreserveSubagentView(state.currentSessionId)) {" in timeline_script
     )
-    assert "runStatus: round.run_status," in timeline_script
+    assert "runStatus: effectiveRoundStatus(round)," in timeline_script
     assert "runPhase: round.run_phase," in timeline_script
     assert "isLatestRound," in timeline_script
     assert (

--- a/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
+++ b/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
@@ -1133,6 +1133,14 @@ export function roundStateLabel() {
 export function roundStateTone() {
     return 'idle';
 }
+
+export function effectiveRoundStatus(round) {
+    return String(round?.run_status || '');
+}
+
+export function roundIsRunning(round) {
+    return effectiveRoundStatus(round) === 'running';
+}
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/unit_tests/frontend/test_round_state_ui.py
+++ b/tests/unit_tests/frontend/test_round_state_ui.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+def test_round_state_uses_running_delegated_tasks(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "rounds" / "utils.js"
+    )
+    module_under_test_path = tmp_path / "roundUtils.mjs"
+    runner_path = tmp_path / "runner.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../../core/state.js", "./mockState.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+const translations = {
+    'rounds.state.running': 'Running',
+    'rounds.state.completed': 'Completed',
+};
+
+export function t(key) {
+    return translations[key] || key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    sessionTasks: [],
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    runner_path.write_text(
+        """
+const { state } = await import('./mockState.mjs');
+const {
+    effectiveRoundStatus,
+    roundIsRunning,
+    roundStateLabel,
+    roundStateTone,
+} = await import('./roundUtils.mjs');
+
+const round = {
+    run_id: 'run-1',
+    run_status: 'completed',
+    run_phase: 'terminal',
+};
+
+state.sessionTasks = [
+    {
+        task_id: 'task-writer',
+        run_id: 'run-1',
+        status: 'running',
+        assigned_instance_id: 'writer-1',
+        assigned_role_id: 'writer',
+    },
+];
+
+console.log(JSON.stringify({
+    status: effectiveRoundStatus(round),
+    running: roundIsRunning(round),
+    label: roundStateLabel(round),
+    tone: roundStateTone(round),
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        timeout=3,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+    assert payload == {
+        "status": "running",
+        "running": True,
+        "label": "Running",
+        "tone": "running",
+    }

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -969,6 +969,42 @@ console.log(JSON.stringify({
     assert payload["statusCalls"] == []
 
 
+def test_handle_model_step_finished_keeps_orchestration_subagent_running(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleModelStepFinished } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+state.currentSessionMode = 'orchestration';
+state.coordinatorRoleId = 'Coordinator';
+state.instanceRoleMap['writer-1'] = 'writer';
+
+handleModelStepFinished(
+    { run_id: 'run-parent', trace_id: 'run-parent' },
+    'writer-1',
+);
+
+console.log(JSON.stringify({
+    finalizeCalls: globalThis.__finalizeStreamCalls,
+    statusCalls: globalThis.__markSubagentStatusCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["finalizeCalls"] == [
+        {
+            "instanceId": "writer-1",
+            "roleId": "writer",
+            "options": {"runId": "run-parent"},
+        }
+    ]
+    assert payload["statusCalls"] == []
+
+
 def _run_run_events_script(tmp_path: Path, runner_source: str) -> dict[str, object]:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = (
@@ -1095,8 +1131,8 @@ export async function refreshSubagentRail(sessionId, options = {}) {
     globalThis.__refreshSubagentRailCalls.push({ sessionId, options });
 }
 
-export function markSubagentStatus() {
-    return undefined;
+export function markSubagentStatus(instanceId, status) {
+    globalThis.__markSubagentStatusCalls.push({ instanceId, status });
 }
 """.strip(),
         encoding="utf-8",
@@ -1276,6 +1312,7 @@ export async function markSessionTerminalRunViewed(sessionId) {
         f"""
 globalThis.__rememberLiveSubagentCalls = [];
 globalThis.__refreshSubagentRailCalls = [];
+globalThis.__markSubagentStatusCalls = [];
 globalThis.__openAgentPanelCalls = [];
 globalThis.__rememberNormalModeSubagentSessionCalls = [];
 globalThis.__renderActiveSubagentSessionCalls = [];

--- a/tests/unit_tests/frontend/test_subagent_rail_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_rail_ui.py
@@ -113,6 +113,308 @@ console.log(JSON.stringify({
     assert payload["clearPanelCalls"] == 1
 
 
+def test_subagent_rail_keeps_agent_running_when_assigned_task_runs(
+    tmp_path: Path,
+) -> None:
+    payload = _run_subagent_rail_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { refreshSubagentRail } = await import("./subagentRail.mjs");
+const { state } = await import("./mockState.mjs");
+
+state.currentSessionId = "session-1";
+state.coordinatorRoleId = "Coordinator";
+state.mainAgentRoleId = "MainAgent";
+globalThis.__fetchSessionAgentsPayload = [
+    {
+        instance_id: "writer-1",
+        role_id: "writer",
+        status: "idle",
+        created_at: "2026-03-13T00:01:00Z",
+        updated_at: "2026-03-13T00:03:00Z",
+    },
+];
+globalThis.__fetchSessionTasksPayload = [
+    {
+        task_id: "task-writer",
+        role_id: "writer",
+        status: "running",
+        instance_id: "writer-1",
+        run_id: "run-1",
+        created_at: "2026-03-13T00:02:00Z",
+        updated_at: "2026-03-13T00:04:00Z",
+    },
+];
+
+await refreshSubagentRail("session-1");
+
+console.log(JSON.stringify({
+    sessionAgents: state.sessionAgents,
+    summaryText: globalThis.__elements.subagentStatusSummary.textContent,
+}));
+""".strip(),
+    )
+
+    assert payload["sessionAgents"] == [
+        {
+            "instance_id": "writer-1",
+            "role_id": "writer",
+            "status": "running",
+            "created_at": "2026-03-13T00:01:00Z",
+            "updated_at": "2026-03-13T00:04:00Z",
+            "runtime_system_prompt": "",
+            "runtime_tools_json": "",
+        }
+    ]
+    assert payload["summaryText"] == "1 running / 1 roles"
+
+
+def test_subagent_rail_preserves_newer_terminal_state_over_stale_running_task(
+    tmp_path: Path,
+) -> None:
+    payload = _run_subagent_rail_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { markSubagentStatus, refreshSubagentRail } = await import("./subagentRail.mjs");
+const { state } = await import("./mockState.mjs");
+
+state.currentSessionId = "session-1";
+state.coordinatorRoleId = "Coordinator";
+state.mainAgentRoleId = "MainAgent";
+globalThis.__fetchSessionAgentsPayload = [
+    {
+        instance_id: "writer-1",
+        role_id: "writer",
+        status: "running",
+        created_at: "2026-03-13T00:01:00Z",
+        updated_at: "2026-03-13T00:01:00Z",
+    },
+];
+globalThis.__fetchSessionTasksPayload = [
+    {
+        task_id: "task-writer",
+        role_id: "writer",
+        status: "running",
+        instance_id: "writer-1",
+        run_id: "run-1",
+        created_at: "2026-03-13T00:01:10Z",
+        updated_at: "2026-03-13T00:01:40Z",
+    },
+];
+
+await refreshSubagentRail("session-1");
+markSubagentStatus("writer-1", "completed");
+
+console.log(JSON.stringify({
+    sessionAgents: state.sessionAgents,
+    sessionTasks: state.sessionTasks,
+    summaryText: globalThis.__elements.subagentStatusSummary.textContent,
+}));
+""".strip(),
+    )
+
+    assert payload["sessionAgents"] == [
+        {
+            "instance_id": "writer-1",
+            "role_id": "writer",
+            "status": "completed",
+            "created_at": "2026-03-13T00:01:00Z",
+            "updated_at": "2026-03-13T00:02:00.000Z",
+            "runtime_system_prompt": "",
+            "runtime_tools_json": "",
+        }
+    ]
+    assert payload["sessionTasks"] == [
+        {
+            "task_id": "task-writer",
+            "title": "task-writer",
+            "assigned_role_id": "writer",
+            "role_id": "writer",
+            "status": "running",
+            "assigned_instance_id": "writer-1",
+            "instance_id": "writer-1",
+            "run_id": "run-1",
+            "created_at": "2026-03-13T00:01:10Z",
+            "updated_at": "2026-03-13T00:01:40Z",
+            "spec_artifact_id": "",
+            "spec_source_task_id": "",
+            "spec_summary": "",
+            "spec_strictness": "",
+            "evidence_bundle": None,
+        }
+    ]
+    assert payload["summaryText"] == "0 running / 1 roles"
+
+
+def test_subagent_rail_preserves_newer_role_record_over_stale_task_instance(
+    tmp_path: Path,
+) -> None:
+    payload = _run_subagent_rail_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { refreshSubagentRail } = await import("./subagentRail.mjs");
+const { state } = await import("./mockState.mjs");
+
+state.currentSessionId = "session-1";
+state.coordinatorRoleId = "Coordinator";
+state.mainAgentRoleId = "MainAgent";
+globalThis.__fetchSessionAgentsPayload = [
+    {
+        instance_id: "writer-2",
+        role_id: "writer",
+        status: "completed",
+        created_at: "2026-03-13T00:01:50Z",
+        updated_at: "2026-03-13T00:02:00Z",
+    },
+];
+globalThis.__fetchSessionTasksPayload = [
+    {
+        task_id: "task-writer",
+        role_id: "writer",
+        status: "running",
+        instance_id: "writer-1",
+        run_id: "run-1",
+        created_at: "2026-03-13T00:01:10Z",
+        updated_at: "2026-03-13T00:01:40Z",
+    },
+];
+
+await refreshSubagentRail("session-1");
+
+console.log(JSON.stringify({
+    sessionAgents: state.sessionAgents,
+    summaryText: globalThis.__elements.subagentStatusSummary.textContent,
+    openAgentPanelCalls: globalThis.__openAgentPanelCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["sessionAgents"] == [
+        {
+            "instance_id": "writer-2",
+            "role_id": "writer",
+            "status": "completed",
+            "created_at": "2026-03-13T00:01:50Z",
+            "updated_at": "2026-03-13T00:02:00Z",
+            "runtime_system_prompt": "",
+            "runtime_tools_json": "",
+        }
+    ]
+    assert payload["summaryText"] == "0 running / 1 roles"
+    assert payload["openAgentPanelCalls"] == [
+        {
+            "instanceId": "writer-2",
+            "roleId": "writer",
+            "options": {
+                "reveal": False,
+                "forceRefresh": False,
+            },
+        },
+    ]
+
+
+def test_subagent_rail_projects_running_task_without_agent_snapshot(
+    tmp_path: Path,
+) -> None:
+    payload = _run_subagent_rail_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { refreshSubagentRail } = await import("./subagentRail.mjs");
+const { state } = await import("./mockState.mjs");
+
+state.currentSessionId = "session-1";
+state.coordinatorRoleId = "Coordinator";
+state.mainAgentRoleId = "MainAgent";
+globalThis.__fetchSessionAgentsPayload = [];
+globalThis.__fetchSessionTasksPayload = [
+    {
+        task_id: "task-writer",
+        assigned_role_id: "writer",
+        status: "running",
+        assigned_instance_id: "writer-1",
+        run_id: "run-1",
+        created_at: "2026-03-13T00:02:00Z",
+        updated_at: "2026-03-13T00:04:00Z",
+    },
+];
+
+await refreshSubagentRail("session-1");
+
+console.log(JSON.stringify({
+    sessionAgents: state.sessionAgents,
+    selectedRoleId: state.selectedRoleId,
+    summaryText: globalThis.__elements.subagentStatusSummary.textContent,
+    openAgentPanelCalls: globalThis.__openAgentPanelCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["sessionAgents"] == [
+        {
+            "instance_id": "writer-1",
+            "role_id": "writer",
+            "status": "running",
+            "created_at": "2026-03-13T00:02:00Z",
+            "updated_at": "2026-03-13T00:04:00Z",
+            "runtime_system_prompt": "",
+            "runtime_tools_json": "",
+        }
+    ]
+    assert payload["selectedRoleId"] == "writer"
+    assert payload["summaryText"] == "1 running / 1 roles"
+    assert payload["openAgentPanelCalls"] == [
+        {
+            "instanceId": "writer-1",
+            "roleId": "writer",
+            "options": {
+                "reveal": False,
+                "forceRefresh": False,
+            },
+        },
+    ]
+
+
+def test_subagent_rail_counts_unique_running_instances(tmp_path: Path) -> None:
+    payload = _run_subagent_rail_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { refreshSubagentRail } = await import("./subagentRail.mjs");
+const { state } = await import("./mockState.mjs");
+
+state.currentSessionId = "session-1";
+state.coordinatorRoleId = "Coordinator";
+state.mainAgentRoleId = "MainAgent";
+globalThis.__fetchSessionAgentsPayload = [];
+globalThis.__fetchSessionTasksPayload = [
+    {
+        task_id: "task-writer",
+        role_id: "writer",
+        status: "running",
+        instance_id: "shared-1",
+        run_id: "run-1",
+    },
+    {
+        task_id: "task-reviewer",
+        role_id: "reviewer",
+        status: "running",
+        instance_id: "shared-1",
+        run_id: "run-1",
+    },
+];
+
+await refreshSubagentRail("session-1");
+
+console.log(JSON.stringify({
+    sessionAgents: state.sessionAgents,
+    summaryText: globalThis.__elements.subagentStatusSummary.textContent,
+}));
+""".strip(),
+    )
+
+    assert len(cast(list[object], payload["sessionAgents"])) == 2
+    assert payload["summaryText"] == "1 running / 2 roles"
+
+
 def _run_subagent_rail_script(tmp_path: Path, runner_source: str) -> dict[str, object]:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = (
@@ -131,7 +433,7 @@ def _run_subagent_rail_script(tmp_path: Path, runner_source: str) -> dict[str, o
     mock_api_path.write_text(
         """
 export async function fetchSessionAgents() {
-    return [
+    return globalThis.__fetchSessionAgentsPayload || [
         {
             instance_id: "coord-1",
             role_id: "Coordinator",
@@ -159,7 +461,7 @@ export async function fetchSessionAgents() {
 }
 
 export async function fetchSessionTasks() {
-    return [
+    return globalThis.__fetchSessionTasksPayload || [
         {
             task_id: "task-coordinator",
             title: "Coordinate run",


### PR DESCRIPTION
## Summary
- Keep orchestration subagent rail status derived from running delegated tasks, even when agent snapshots are idle or missing.
- Keep round/timeline progress visible while delegated tasks for the round are still running.
- Avoid marking orchestration delegated agents completed on model step finish before task terminal state arrives.

Fixes #562

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_subagent_rail_ui.py tests/unit_tests/frontend/test_run_events_ui.py tests/unit_tests/frontend/test_round_state_ui.py
- uv run --extra dev pytest -q tests/unit_tests/frontend
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/tmp/relay-teams-playwright-browsers uv run --extra dev pytest -q tests/integration_tests