### PR TITLE
Fix DeepSeek thinking replay history

### DIFF
--- a/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
+++ b/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
@@ -11,10 +11,7 @@ from openai.types.chat.chat_completion_message_function_tool_call_param import (
 from pydantic_ai._utils import guard_tool_call_id
 from pydantic_ai.messages import (
     ModelMessage,
-    ModelResponse,
     ModelRequestPart,
-    TextPart,
-    ThinkingPart,
     ToolCallPart,
 )
 from pydantic_ai.models import ModelRequestParameters
@@ -77,7 +74,7 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
         messages: Sequence[ModelMessage],
     ) -> list[ModelMessage]:
         return normalize_replayed_messages(
-            _drop_provider_empty_responses(messages),
+            messages,
             on_drop=cls._log_dropped_tool_result,
         )
 
@@ -101,32 +98,3 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
                 "tool_name": str(getattr(part, "tool_name", "") or ""),
             },
         )
-
-
-def _drop_provider_empty_responses(
-    messages: Sequence[ModelMessage],
-) -> list[ModelMessage]:
-    sanitized: list[ModelMessage] = []
-    for message in messages:
-        if not isinstance(message, ModelResponse):
-            sanitized.append(message)
-            continue
-        if _is_thinking_only_response(message):
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="llm.history.dropped_thinking_only_response",
-                message="Dropped thinking-only assistant response before provider replay",
-                payload={},
-            )
-            continue
-        sanitized.append(message)
-    return sanitized
-
-
-def _is_thinking_only_response(message: ModelResponse) -> bool:
-    if not message.parts:
-        return False
-    if any(isinstance(part, (TextPart, ToolCallPart)) for part in message.parts):
-        return False
-    return all(isinstance(part, ThinkingPart) for part in message.parts)

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -20,8 +20,6 @@ from pydantic_ai.messages import (
     PartEndEvent,
     PartStartEvent,
     RetryPromptPart,
-    TextPart,
-    ThinkingPart,
     ToolCallPart,
     ToolCallPartDelta,
     ToolReturnPart,
@@ -336,14 +334,6 @@ def _tool_result_error_code(result: dict[str, JsonValue]) -> str:
     if isinstance(visible_result, dict):
         return _tool_result_error_code(visible_result)
     return ""
-
-
-def _is_thinking_only_response(message: ModelResponse) -> bool:
-    if not message.parts:
-        return False
-    if any(isinstance(part, (TextPart, ToolCallPart)) for part in message.parts):
-        return False
-    return all(isinstance(part, ThinkingPart) for part in message.parts)
 
 
 def _tool_args_from_preview(value: str) -> dict[str, JsonValue] | str:
@@ -921,23 +911,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
     def _filter_model_messages(
         self, messages: Sequence[ModelRequest | ModelResponse]
     ) -> list[ModelRequest | ModelResponse]:
-        filtered: list[ModelRequest | ModelResponse] = []
-        for message in messages:
-            if isinstance(message, ModelResponse) and _is_thinking_only_response(
-                message
-            ):
-                log_event(
-                    LOGGER,
-                    logging.WARNING,
-                    event="llm.history.dropped_thinking_only_response",
-                    message=(
-                        "Dropped thinking-only assistant response before prompt replay"
-                    ),
-                    payload={},
-                )
-                continue
-            filtered.append(message)
-        return filtered
+        return list(messages)
 
     def _collect_pending_tool_calls(
         self, messages: Sequence[ModelRequest | ModelResponse]

--- a/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
+++ b/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
@@ -172,7 +172,7 @@ def test_sanitize_replayed_messages_drops_duplicate_late_tool_results() -> None:
     assert sanitized[2].parts[0].content == "optimize it"
 
 
-def test_sanitize_replayed_messages_drops_thinking_only_response() -> None:
+def test_sanitize_replayed_messages_keeps_thinking_only_response() -> None:
     messages = [
         ModelRequest(parts=[UserPromptPart(content="continue")]),
         ModelResponse(parts=[ThinkingPart(content="internal notes")]),
@@ -183,10 +183,51 @@ def test_sanitize_replayed_messages_drops_thinking_only_response() -> None:
 
     sanitized = RecoverableOpenAIChatModel._sanitize_replayed_messages(messages)
 
-    assert len(sanitized) == 2
+    assert len(sanitized) == 3
     assert isinstance(sanitized[0], ModelRequest)
     assert isinstance(sanitized[1], ModelResponse)
-    assert isinstance(sanitized[1].parts[0], ToolCallPart)
+    assert isinstance(sanitized[1].parts[0], ThinkingPart)
+    assert isinstance(sanitized[2], ModelResponse)
+    assert isinstance(sanitized[2].parts[0], ToolCallPart)
+
+
+@pytest.mark.asyncio
+async def test_map_messages_replays_deepseek_reasoning_content() -> None:
+    http_client = httpx.AsyncClient(trust_env=False)
+    try:
+        model = RecoverableOpenAIChatModel(
+            "deepseek-v4-pro",
+            provider=OpenAIProvider(
+                base_url="https://api.deepseek.example/v1",
+                api_key="test",
+                http_client=http_client,
+            ),
+        )
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="continue")]),
+            ModelResponse(
+                parts=[
+                    ThinkingPart(
+                        id="reasoning_content",
+                        content="internal notes",
+                        provider_name=model.system,
+                    )
+                ]
+            ),
+        ]
+
+        mapped = await model._map_messages(messages, ModelRequestParameters())
+    finally:
+        await http_client.aclose()
+
+    assistant_messages = [
+        message
+        for message in mapped
+        if isinstance(message, dict) and message.get("role") == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].get("reasoning_content") == "internal notes"
+    assert assistant_messages[0].get("content") == ""
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_session_support.py
+++ b/tests/unit_tests/agents/execution/test_session_support.py
@@ -402,7 +402,7 @@ async def test_tool_result_state_checks_async_runtime_event_id_path() -> None:
     )
 
 
-def test_filter_model_messages_drops_thinking_only_response() -> None:
+def test_filter_model_messages_keeps_thinking_only_response() -> None:
     session = object.__new__(AgentLlmSession)
     filtered = AgentLlmSession._filter_model_messages(
         session,
@@ -412,8 +412,10 @@ def test_filter_model_messages_drops_thinking_only_response() -> None:
         ],
     )
 
-    assert len(filtered) == 1
+    assert len(filtered) == 2
     assert isinstance(filtered[0], ModelResponse)
+    assert isinstance(filtered[0].parts[0], ThinkingPart)
+    assert isinstance(filtered[1], ModelResponse)
 
 
 def test_tool_args_from_preview_handles_empty_invalid_and_scalar_json() -> None:


### PR DESCRIPTION
## Summary
- preserve thinking-only assistant responses during prompt and provider replay
- keep DeepSeek reasoning_content available for follow-up thinking-mode requests
- update regression tests for replay sanitization and DeepSeek-style message mapping

## Tests
- uv run --extra dev ruff check
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_session_support.py tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
- uv run --extra dev pytest -q tests/unit_tests/providers/test_llm_multi_turn_prompt.py
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/opt/workspace/relay-teams-main/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests

Closes #804