### PR TITLE
Make built-in orchestration planner-first

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -83,9 +83,11 @@ Notes:
   `DelegationPlanner` task. The planner returns a bounded lane plan; Coordinator
   validates it, creates or reuses temporary roles, creates lane task nodes, and
   lets the runtime execute ready nodes concurrently.
-- Fixed `graph` presets provide an explicit DAG template. Automatic
-  `DelegationPlanner` planning does not inject extra planner nodes into fixed
-  graph presets unless the preset itself includes a planner node.
+- Fixed `graph` presets provide an explicit DAG template. When automatic
+  `DelegationPlanner` planning is enabled and the planner role is allowed by the
+  preset, Coordinator first gives the planner a chance to produce a dynamic
+  bounded DAG. If the planner declines decomposition or planning fails, the
+  fixed graph template runs as the fallback path.
 - A delegated task binds to exactly one delegated role and one subagent instance on first dispatch.
 - Re-dispatching an `assigned` or `stopped` task reuses its bound instance.
 - `completed`, `failed`, and `timeout` tasks must be replaced instead of re-dispatched.
@@ -923,9 +925,13 @@ Rules:
 - `presets[].policy.max_parallel_delegated_tasks` accepts `0..16`; `0` disables automatic delegated task execution for simple direct-answer presets.
 - `presets[].policy.planner_role_id` defaults to `DelegationPlanner`; when automatic planning is enabled, this role is executed through the normal delegated task runtime path.
 - `presets[].policy.max_temporary_roles_per_run` accepts `0..16` and bounds automatic DelegationPlanner temporary role proposals.
-- `graph` presets are fixed DAG templates. Non-graph presets can still produce
-  a dynamic task DAG through automatic `DelegationPlanner` planning or through
-  Coordinator-created task nodes.
+- `graph` presets are fixed DAG templates with planner-first preflight when
+  `auto_plan_long_tasks` is enabled and `planner_role_id` is listed in
+  `role_ids`. Non-graph presets can still produce a dynamic task DAG through
+  automatic `DelegationPlanner` planning or through Coordinator-created task
+  nodes.
+- `graph.nodes[].node_id` must not use the reserved `auto_lane_` prefix, which
+  identifies dynamic DelegationPlanner lane tasks during resume.
 - The default preset id must match one existing preset.
 - `MainAgent` and `Coordinator` base role prompts are edited through `/roles/configs/*`, not this config.
 - `orchestration_prompt` is appended only for `Coordinator` in `orchestration` session mode.

--- a/src/relay_teams/agents/orchestration/coordinator.py
+++ b/src/relay_teams/agents/orchestration/coordinator.py
@@ -22,6 +22,7 @@ from relay_teams.agents.orchestration.graph_models import (
     OrchestrationGraphNode,
 )
 from relay_teams.agents.orchestration.delegation_planning import (
+    AUTO_LANE_NODE_PREFIX,
     DelegationPlanningService,
 )
 from relay_teams.agents.orchestration.policy_models import OrchestrationPolicy
@@ -106,6 +107,9 @@ from relay_teams.agents.tasks.wakeup_models import AgentWakeupEntry
 from relay_teams.roles.tool_diet_validation import should_reject
 
 LOGGER = get_logger(__name__)
+_AUTO_DELEGATION_TERMINAL_STATUSES = frozenset(
+    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.TIMEOUT}
+)
 
 _TASK_ID_PREFIX_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:"
@@ -172,6 +176,13 @@ class CoordinatorRunResult(BaseModel):
     completion_reason: RunCompletionReason = RunCompletionReason.ASSISTANT_RESPONSE
     error_code: str | None = None
     error_message: str | None = None
+
+
+class _AutoDelegationLaneState(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    has_lanes: bool = False
+    has_nonterminal_lanes: bool = False
 
 
 class DelegatedTaskExecutionDisabledError(RuntimeError):
@@ -532,42 +543,115 @@ class CoordinatorGraph(BaseModel):
         initial_result: str = "",
         topology: RunTopologySnapshot | None = None,
     ) -> TaskExecutionResult:
-        if topology is not None and topology.orchestration_graph is not None:
-            return await self._run_graph_mode(
-                trace_id=trace_id,
-                root_task=root_task,
-                coordinator_instance_id=coordinator_instance_id,
-                topology=topology,
-                initial_result=initial_result,
-            )
         policy = _orchestration_policy(topology)
         coordinator_result = TaskExecutionResult(output=initial_result)
         coordinator_role_id = _require_task_role_id(root_task)
         if coordinator_first:
-            planned_delegation = await self._run_auto_delegation_planning_async(
-                root_task=root_task,
-                topology=topology,
-                policy=policy,
+            auto_lane_state = await self._run_auto_delegation_lane_state_async(
+                trace_id=trace_id
             )
-            if not planned_delegation:
-                coordinator_result = await self._task_executor(
-                    instance_id=coordinator_instance_id,
-                    role_id=coordinator_role_id,
-                    task=root_task,
+            if auto_lane_state.has_nonterminal_lanes:
+                return await self._run_dynamic_delegation_cycles_async(
+                    trace_id=trace_id,
+                    root_task=root_task,
+                    coordinator_instance_id=coordinator_instance_id,
+                    policy=policy,
+                    coordinator_result=coordinator_result,
                 )
-                log_event(
-                    LOGGER,
-                    logging.DEBUG,
-                    event="coord.cycle.first_pass.completed",
-                    message="Coordinator first pass completed",
-                    payload={
-                        "max_orchestration_cycles": policy.max_orchestration_cycles,
-                        "max_parallel_delegated_tasks": (
-                            policy.max_parallel_delegated_tasks
-                        ),
-                    },
+            if not auto_lane_state.has_lanes:
+                if topology is not None and topology.orchestration_graph is not None:
+                    if await self._run_has_fixed_graph_nodes_async(
+                        trace_id=trace_id,
+                        graph=topology.orchestration_graph,
+                    ):
+                        return await self._run_graph_mode(
+                            trace_id=trace_id,
+                            root_task=root_task,
+                            coordinator_instance_id=coordinator_instance_id,
+                            topology=topology,
+                            initial_result=initial_result,
+                        )
+                if await self._run_auto_delegation_planning_async(
+                    root_task=root_task,
+                    topology=topology,
+                    policy=policy,
+                ):
+                    return await self._run_dynamic_delegation_cycles_async(
+                        trace_id=trace_id,
+                        root_task=root_task,
+                        coordinator_instance_id=coordinator_instance_id,
+                        policy=policy,
+                        coordinator_result=coordinator_result,
+                    )
+                if topology is not None and topology.orchestration_graph is not None:
+                    return await self._run_graph_mode(
+                        trace_id=trace_id,
+                        root_task=root_task,
+                        coordinator_instance_id=coordinator_instance_id,
+                        topology=topology,
+                        initial_result=initial_result,
+                    )
+            coordinator_result = await self._task_executor(
+                instance_id=coordinator_instance_id,
+                role_id=coordinator_role_id,
+                task=root_task,
+            )
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="coord.cycle.first_pass.completed",
+                message="Coordinator first pass completed",
+                payload={
+                    "max_orchestration_cycles": policy.max_orchestration_cycles,
+                    "max_parallel_delegated_tasks": (
+                        policy.max_parallel_delegated_tasks
+                    ),
+                },
+            )
+        elif topology is not None and topology.orchestration_graph is not None:
+            auto_lane_state = await self._run_auto_delegation_lane_state_async(
+                trace_id=trace_id
+            )
+            if auto_lane_state.has_nonterminal_lanes:
+                return await self._run_dynamic_delegation_cycles_async(
+                    trace_id=trace_id,
+                    root_task=root_task,
+                    coordinator_instance_id=coordinator_instance_id,
+                    policy=policy,
+                    coordinator_result=coordinator_result,
                 )
+            if not auto_lane_state.has_lanes:
+                return await self._run_graph_mode(
+                    trace_id=trace_id,
+                    root_task=root_task,
+                    coordinator_instance_id=coordinator_instance_id,
+                    topology=topology,
+                    initial_result=initial_result,
+                )
+            coordinator_result = await self._task_executor(
+                instance_id=coordinator_instance_id,
+                role_id=coordinator_role_id,
+                task=root_task,
+            )
 
+        return await self._run_dynamic_delegation_cycles_async(
+            trace_id=trace_id,
+            root_task=root_task,
+            coordinator_instance_id=coordinator_instance_id,
+            policy=policy,
+            coordinator_result=coordinator_result,
+        )
+
+    async def _run_dynamic_delegation_cycles_async(
+        self,
+        *,
+        trace_id: str,
+        root_task: TaskEnvelope,
+        coordinator_instance_id: str,
+        policy: OrchestrationPolicy,
+        coordinator_result: TaskExecutionResult,
+    ) -> TaskExecutionResult:
+        coordinator_role_id = _require_task_role_id(root_task)
         if policy.max_orchestration_cycles < 1:
             pending_task_count = await self._pending_delegated_task_count_async(
                 trace_id=trace_id,
@@ -681,7 +765,75 @@ class CoordinatorGraph(BaseModel):
                 payload={"cycle": cycle},
             )
 
+        pending_task_count = await self._pending_delegated_task_count_async(
+            trace_id=trace_id,
+            root_task_id=root_task.task_id,
+        )
+        if pending_task_count:
+            error_message = (
+                "Orchestration policy exhausted "
+                f"{policy.max_orchestration_cycles} cycle(s) while "
+                f"{pending_task_count} delegated task(s) are still pending."
+            )
+            assistant_message = build_assistant_error_message(
+                error_code="orchestration_cycles_exhausted",
+                error_message=error_message,
+            )
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="coord.cycle.exhausted",
+                message="Coordinator cycle budget exhausted with pending tasks",
+                payload={
+                    "trace_id": trace_id,
+                    "root_task_id": root_task.task_id,
+                    "pending_task_count": pending_task_count,
+                    "max_orchestration_cycles": policy.max_orchestration_cycles,
+                },
+            )
+            await self._fail_root_task_async(
+                trace_id=trace_id,
+                root_task=root_task,
+                coordinator_instance_id=coordinator_instance_id,
+                error_code="orchestration_cycles_exhausted",
+                error_message=error_message,
+            )
+            return TaskExecutionResult(
+                output=assistant_message,
+                completion_reason=RunCompletionReason.ASSISTANT_ERROR,
+                error_code="orchestration_cycles_exhausted",
+                error_message=error_message,
+            )
+
         return coordinator_result
+
+    async def _run_auto_delegation_lane_state_async(
+        self, *, trace_id: str
+    ) -> _AutoDelegationLaneState:
+        has_lanes = False
+        has_nonterminal_lanes = False
+        for record in await self.task_repo.list_by_trace_async(trace_id):
+            node_id = record.envelope.orchestration_node_id or ""
+            if node_id.startswith(AUTO_LANE_NODE_PREFIX):
+                has_lanes = True
+                if record.status not in _AUTO_DELEGATION_TERMINAL_STATUSES:
+                    has_nonterminal_lanes = True
+        return _AutoDelegationLaneState(
+            has_lanes=has_lanes,
+            has_nonterminal_lanes=has_nonterminal_lanes,
+        )
+
+    async def _run_has_fixed_graph_nodes_async(
+        self,
+        *,
+        trace_id: str,
+        graph: OrchestrationGraph,
+    ) -> bool:
+        records_by_node = await self._graph_records_by_node_async(
+            trace_id=trace_id,
+            graph=graph,
+        )
+        return bool(records_by_node)
 
     async def _run_auto_delegation_planning_async(
         self,
@@ -1347,6 +1499,7 @@ class CoordinatorGraph(BaseModel):
         max_parallel_tasks: int | None = None,
     ) -> bool:
         records = await self.task_repo.list_by_trace_async(trace_id)
+        runtime = await self.run_runtime_repo.get_async(trace_id)
         records_by_task_id = {record.envelope.task_id: record for record in records}
         lanes: dict[str, list[TaskRecord]] = {}
         instances: dict[str, AgentRuntimeRecord] = {}
@@ -1366,16 +1519,16 @@ class CoordinatorGraph(BaseModel):
                 records_by_task_id=records_by_task_id,
             ):
                 continue
+            if self._is_paused_pending_delegated_task(
+                runtime=runtime,
+                record=record,
+            ):
+                continue
             if record.assigned_instance_id is None:
                 continue
             if await self._fail_task_if_role_contract_preconditions_async(
                 record=record,
                 records_by_task_id=records_by_task_id,
-            ):
-                continue
-            if self.run_control_manager.is_subagent_paused(
-                session_id=task.session_id,
-                instance_id=record.assigned_instance_id,
             ):
                 continue
             try:
@@ -1476,12 +1629,43 @@ class CoordinatorGraph(BaseModel):
         root_task_id: str,
     ) -> int:
         records = await self.task_repo.list_by_trace_async(trace_id)
+        records_by_task_id = {record.envelope.task_id: record for record in records}
+        runtime = await self.run_runtime_repo.get_async(trace_id)
         pending_statuses = {TaskStatus.ASSIGNED, TaskStatus.CREATED}
         return sum(
             1
             for record in records
             if record.envelope.task_id != root_task_id
             and record.status in pending_statuses
+            and _dependencies_completed(
+                record=record,
+                records_by_task_id=records_by_task_id,
+            )
+            and not self._is_paused_pending_delegated_task(
+                runtime=runtime,
+                record=record,
+            )
+        )
+
+    def _is_paused_pending_delegated_task(
+        self,
+        *,
+        runtime: RunRuntimeRecord | None,
+        record: TaskRecord,
+    ) -> bool:
+        task = record.envelope
+        assigned_instance_id = record.assigned_instance_id
+        if self._is_paused_subagent_task(
+            runtime=runtime,
+            task_id=task.task_id,
+            assigned_instance_id=assigned_instance_id,
+        ):
+            return True
+        if assigned_instance_id is None:
+            return False
+        return self.run_control_manager.is_subagent_paused(
+            session_id=task.session_id,
+            instance_id=assigned_instance_id,
         )
 
     async def _fail_task_if_dependency_failed_async(

--- a/src/relay_teams/agents/orchestration/delegation_planning.py
+++ b/src/relay_teams/agents/orchestration/delegation_planning.py
@@ -322,8 +322,6 @@ class DelegationPlanningService:
             return False
         if policy.max_parallel_delegated_tasks < 1:
             return False
-        if topology is not None and topology.orchestration_graph is not None:
-            return False
         allowed_role_ids = _topology_allowed_role_ids(topology)
         if allowed_role_ids and policy.planner_role_id not in allowed_role_ids:
             return False

--- a/src/relay_teams/agents/orchestration/graph_models.py
+++ b/src/relay_teams/agents/orchestration/graph_models.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from relay_teams.agents.tasks.models import VerificationPlan
 from relay_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
+_RESERVED_NODE_ID_PREFIXES = ("auto_lane_",)
+
 
 class OrchestrationGraphNode(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -24,6 +26,16 @@ class OrchestrationGraphNode(BaseModel):
         if value is None:
             return ""
         return str(value).strip()
+
+    @field_validator("node_id")
+    @classmethod
+    def _reject_reserved_node_id_prefixes(cls, value: str) -> str:
+        for prefix in _RESERVED_NODE_ID_PREFIXES:
+            if value.startswith(prefix):
+                raise ValueError(
+                    "orchestration graph node_id uses reserved prefix: " + prefix
+                )
+        return value
 
 
 class OrchestrationGraphEdge(BaseModel):

--- a/src/relay_teams/builtin/config/orchestration.json
+++ b/src/relay_teams/builtin/config/orchestration.json
@@ -18,7 +18,7 @@
         "max_parallel_delegated_tasks": 4,
         "auto_plan_long_tasks": true,
         "planner_role_id": "DelegationPlanner",
-        "coordinator_inline_budget_steps": 2,
+        "coordinator_inline_budget_steps": 0,
         "max_temporary_roles_per_run": 5,
         "prefer_temporary_roles_for_long_tasks": true
       }
@@ -28,13 +28,17 @@
       "name": "Fast Graph",
       "description": "Template DAG for straightforward implementation plus verification.",
       "role_ids": [
+        "DelegationPlanner",
         "Crafter",
         "Gater"
       ],
-      "orchestration_prompt": "Run the fixed graph template. Crafter implements the task, then Gater verifies the completed work before Coordinator returns the final answer.",
+      "orchestration_prompt": "Give DelegationPlanner the first opportunity to decide whether the task should become a bounded parallel DAG. If DelegationPlanner returns no decomposition plan, run the fixed graph template: Crafter implements the task, then Gater verifies the completed work before Coordinator returns the final answer.",
       "policy": {
-        "max_orchestration_cycles": 2,
-        "max_parallel_delegated_tasks": 2
+        "max_orchestration_cycles": 8,
+        "max_parallel_delegated_tasks": 2,
+        "auto_plan_long_tasks": true,
+        "planner_role_id": "DelegationPlanner",
+        "coordinator_inline_budget_steps": 0
       },
       "graph": {
         "max_parallel_tasks": 4,
@@ -71,10 +75,13 @@
         "Crafter",
         "Gater"
       ],
-      "orchestration_prompt": "Run the fixed graph template. Designer defines the approach, Crafter implements it, and Gater verifies the result before Coordinator returns the final answer.",
+      "orchestration_prompt": "Give DelegationPlanner the first opportunity to decide whether the task should become a bounded parallel DAG. If DelegationPlanner returns no decomposition plan, run the fixed graph template: Designer defines the approach, Crafter implements it, and Gater verifies the result before Coordinator returns the final answer.",
       "policy": {
         "max_orchestration_cycles": 8,
-        "max_parallel_delegated_tasks": 4
+        "max_parallel_delegated_tasks": 4,
+        "auto_plan_long_tasks": true,
+        "planner_role_id": "DelegationPlanner",
+        "coordinator_inline_budget_steps": 0
       },
       "graph": {
         "max_parallel_tasks": 4,

--- a/tests/integration_tests/api/test_orchestration_async_performance.py
+++ b/tests/integration_tests/api/test_orchestration_async_performance.py
@@ -8,6 +8,8 @@ import httpx
 from pydantic import BaseModel, ConfigDict
 import pytest
 
+from relay_teams.agents.orchestration.delegation_planning import AUTO_PLANNER_NODE_ID
+
 from integration_tests.support.api_helpers import (
     create_run,
     create_session,
@@ -160,7 +162,9 @@ def _run_orchestration_clone_benchmark(
     completed_tasks = [
         task
         for task in task_items
-        if isinstance(task, dict) and task.get("status") == "completed"
+        if isinstance(task, dict)
+        and task.get("status") == "completed"
+        and task.get("orchestration_node_id") != AUTO_PLANNER_NODE_ID
     ]
     return _BenchmarkResult(
         duration_seconds=duration_seconds,

--- a/tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py
+++ b/tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py
@@ -10,6 +10,11 @@ from relay_teams.media import content_parts_from_text
 from relay_teams.agent_runtimes.instances.enums import InstanceStatus
 from relay_teams.agent_runtimes.instances.models import create_subagent_instance
 from relay_teams.agents.orchestration.coordinator import CoordinatorGraph
+from relay_teams.agents.orchestration.delegation_planning import (
+    AUTO_LANE_NODE_PREFIX,
+    DelegationPlan,
+    DelegationPlanningService,
+)
 from relay_teams.agents.orchestration.graph_models import (
     OrchestrationGraph,
     OrchestrationGraphEdge,
@@ -262,6 +267,66 @@ class _CancellingTaskExecutionService:
         _ = instance_id, role_id
         self.calls.append(task.task_id)
         raise asyncio.CancelledError
+
+
+class _CreatingPlanningService:
+    def __init__(
+        self,
+        *,
+        task_repo: TaskRepository,
+        agent_repo: AgentInstanceRepository,
+        plan: DelegationPlan | None,
+    ) -> None:
+        self._task_repo = task_repo
+        self._agent_repo = agent_repo
+        self._plan = plan
+        self.calls = 0
+
+    async def plan_and_create_tasks_async(
+        self,
+        *,
+        root_task: TaskEnvelope,
+        topology: RunTopologySnapshot | None,
+        policy: OrchestrationPolicy,
+    ) -> DelegationPlan | None:
+        _ = topology, policy
+        self.calls += 1
+        if self._plan is None or not self._plan.should_decompose:
+            return self._plan
+        for lane in self._plan.lanes:
+            instance = create_subagent_instance(
+                lane.role_id,
+                workspace_id="workspace-1",
+                conversation_id=f"conversation-{lane.lane_id}",
+            )
+            self._agent_repo.upsert_instance(
+                run_id=root_task.trace_id,
+                trace_id=root_task.trace_id,
+                session_id=root_task.session_id,
+                instance_id=instance.instance_id,
+                role_id=lane.role_id,
+                workspace_id=instance.workspace_id,
+                conversation_id=instance.conversation_id,
+                status=InstanceStatus.IDLE,
+            )
+            task = TaskEnvelope(
+                task_id=f"task-auto-{lane.lane_id}",
+                session_id=root_task.session_id,
+                parent_task_id=root_task.task_id,
+                trace_id=root_task.trace_id,
+                role_id=lane.role_id,
+                title=lane.title,
+                objective=lane.objective,
+                verification=VerificationPlan(checklist=("non_empty_response",)),
+                orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}{lane.lane_id}",
+            )
+            _ = await self._task_repo.create_async(task)
+            await self._task_repo.update_status_async(
+                task.task_id,
+                TaskStatus.ASSIGNED,
+                assigned_instance_id=instance.instance_id,
+            )
+        return self._plan
 
 
 class _CapturingHookService:
@@ -1321,6 +1386,861 @@ async def test_graph_mode_runs_fanout_then_join_before_final_coordinator(
     assert right_record.result is not None
     assert left_record.result in join_record.envelope.objective
     assert right_record.result in join_record.envelope.objective
+
+
+@pytest.mark.asyncio
+async def test_graph_mode_uses_auto_delegation_plan_before_fixed_graph(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="ship the graph feature",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    graph = OrchestrationGraph(
+        nodes=(
+            OrchestrationGraphNode(
+                node_id="implement",
+                role_id="time",
+                objective="Run the fixed implementation fallback.",
+            ),
+        )
+    )
+    topology = RunTopologySnapshot(
+        session_mode=SessionMode.ORCHESTRATION,
+        main_agent_role_id="Coordinator",
+        normal_root_role_id="time",
+        coordinator_role_id="Coordinator",
+        orchestration_preset_id="graph",
+        orchestration_prompt="Run graph.",
+        allowed_role_ids=("DelegationPlanner", "time"),
+        orchestration_policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+        orchestration_graph=graph,
+    )
+    planning_service = _CreatingPlanningService(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        plan=DelegationPlan.model_validate(
+            {
+                "should_decompose": True,
+                "lanes": [
+                    {
+                        "lane_id": "implementation",
+                        "title": "Planned implementation",
+                        "role_id": "time",
+                        "objective": "Run the planner-created implementation lane.",
+                    }
+                ],
+            }
+        ),
+    )
+    coordinator.planning_service = cast(DelegationPlanningService, planning_service)
+
+    result = await coordinator._run_ai_mode(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        topology=topology,
+    )
+
+    records = await task_repo.list_by_trace_async("run-1")
+    records_by_node = {
+        record.envelope.orchestration_node_id: record
+        for record in records
+        if record.envelope.orchestration_node_id is not None
+    }
+    auto_record = records_by_node[f"{AUTO_LANE_NODE_PREFIX}implementation"]
+
+    assert planning_service.calls == 1
+    assert "implement" not in records_by_node
+    assert auto_record.status == TaskStatus.COMPLETED
+    assert task_execution_service.calls == [
+        auto_record.envelope.task_id,
+        root_task.task_id,
+    ]
+    assert result.output == "task-root-1 done"
+
+
+@pytest.mark.asyncio
+async def test_graph_mode_resume_existing_auto_lanes_uses_dynamic_cycle(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="ship the graph feature",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    lane_instance = create_subagent_instance(
+        "time",
+        workspace_id="workspace-1",
+        conversation_id="conversation-auto-lane",
+    )
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=lane_instance.instance_id,
+        role_id="time",
+        workspace_id=lane_instance.workspace_id,
+        conversation_id=lane_instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+    auto_task = TaskEnvelope(
+        task_id="task-auto-implementation",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        title="Planned implementation",
+        objective="Resume the planner-created implementation lane.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}implementation",
+    )
+    _ = task_repo.create(auto_task)
+    task_repo.update_status(
+        auto_task.task_id,
+        TaskStatus.ASSIGNED,
+        assigned_instance_id=lane_instance.instance_id,
+    )
+    graph = OrchestrationGraph(
+        nodes=(
+            OrchestrationGraphNode(
+                node_id="implement",
+                role_id="time",
+                objective="Run the fixed implementation fallback.",
+            ),
+        )
+    )
+    topology = RunTopologySnapshot(
+        session_mode=SessionMode.ORCHESTRATION,
+        main_agent_role_id="Coordinator",
+        normal_root_role_id="time",
+        coordinator_role_id="Coordinator",
+        orchestration_preset_id="graph",
+        orchestration_prompt="Run graph.",
+        allowed_role_ids=("DelegationPlanner", "time"),
+        orchestration_policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+        orchestration_graph=graph,
+    )
+
+    result = await coordinator._run_ai_mode(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        coordinator_first=False,
+        topology=topology,
+    )
+
+    records = await task_repo.list_by_trace_async("run-1")
+    records_by_node = {
+        record.envelope.orchestration_node_id: record
+        for record in records
+        if record.envelope.orchestration_node_id is not None
+    }
+
+    assert "implement" not in records_by_node
+    assert records_by_node[f"{AUTO_LANE_NODE_PREFIX}implementation"].status == (
+        TaskStatus.COMPLETED
+    )
+    assert task_execution_service.calls == [auto_task.task_id, root_task.task_id]
+    assert result.output == "task-root-1 done"
+
+
+@pytest.mark.asyncio
+async def test_graph_mode_resume_terminal_auto_lanes_runs_coordinator_synthesis(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="summarize completed planner lanes",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    auto_task = TaskEnvelope(
+        task_id="task-auto-implementation",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        title="Planned implementation",
+        objective="Already finished planner-created work.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}implementation",
+    )
+    _ = task_repo.create(auto_task)
+    task_repo.update_status(
+        auto_task.task_id,
+        TaskStatus.COMPLETED,
+        result="implementation already done",
+    )
+    graph = OrchestrationGraph(
+        nodes=(
+            OrchestrationGraphNode(
+                node_id="implement",
+                role_id="time",
+                objective="Run the fixed implementation fallback.",
+            ),
+        )
+    )
+    topology = RunTopologySnapshot(
+        session_mode=SessionMode.ORCHESTRATION,
+        main_agent_role_id="Coordinator",
+        normal_root_role_id="time",
+        coordinator_role_id="Coordinator",
+        orchestration_preset_id="graph",
+        orchestration_prompt="Run graph.",
+        allowed_role_ids=("DelegationPlanner", "time"),
+        orchestration_policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+        orchestration_graph=graph,
+    )
+    planning_service = _CreatingPlanningService(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        plan=DelegationPlan.model_validate(
+            {
+                "should_decompose": True,
+                "lanes": [
+                    {
+                        "lane_id": "new_implementation",
+                        "title": "Duplicate planner lane",
+                        "role_id": "time",
+                        "objective": "This lane must not be created on resume.",
+                    }
+                ],
+            }
+        ),
+    )
+    coordinator.planning_service = cast(DelegationPlanningService, planning_service)
+
+    result = await coordinator._run_ai_mode(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        topology=topology,
+    )
+
+    records = await task_repo.list_by_trace_async("run-1")
+    records_by_node = {
+        record.envelope.orchestration_node_id: record
+        for record in records
+        if record.envelope.orchestration_node_id is not None
+    }
+
+    assert planning_service.calls == 0
+    assert "implement" not in records_by_node
+    assert f"{AUTO_LANE_NODE_PREFIX}new_implementation" not in records_by_node
+    assert task_execution_service.calls == [root_task.task_id]
+    assert result.output == "task-root-1 done"
+
+
+@pytest.mark.asyncio
+async def test_graph_mode_resume_paused_auto_lanes_skips_coordinator_prepass(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="resume the paused planner lane",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    lane_instance = create_subagent_instance(
+        "time",
+        workspace_id="workspace-1",
+        conversation_id="conversation-auto-lane",
+    )
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=lane_instance.instance_id,
+        role_id="time",
+        workspace_id=lane_instance.workspace_id,
+        conversation_id=lane_instance.conversation_id,
+        status=InstanceStatus.STOPPED,
+    )
+    auto_task = TaskEnvelope(
+        task_id="task-auto-implementation",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        title="Planned implementation",
+        objective="Wait for manual input before continuing.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}implementation",
+    )
+    _ = task_repo.create(auto_task)
+    task_repo.update_status(
+        auto_task.task_id,
+        TaskStatus.ASSIGNED,
+        assigned_instance_id=lane_instance.instance_id,
+    )
+    run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-1",
+            session_id="session-1",
+            root_task_id=root_task.task_id,
+            status=RunRuntimeStatus.PAUSED,
+            phase=RunRuntimePhase.AWAITING_MANUAL_ACTION,
+            active_task_id=auto_task.task_id,
+            active_role_id="time",
+            active_subagent_instance_id=lane_instance.instance_id,
+            last_error="Waiting for manual action",
+        )
+    )
+    graph = OrchestrationGraph(
+        nodes=(
+            OrchestrationGraphNode(
+                node_id="implement",
+                role_id="time",
+                objective="Run the fixed implementation fallback.",
+            ),
+        )
+    )
+    topology = RunTopologySnapshot(
+        session_mode=SessionMode.ORCHESTRATION,
+        main_agent_role_id="Coordinator",
+        normal_root_role_id="time",
+        coordinator_role_id="Coordinator",
+        orchestration_preset_id="graph",
+        orchestration_prompt="Run graph.",
+        allowed_role_ids=("DelegationPlanner", "time"),
+        orchestration_policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+        orchestration_graph=graph,
+    )
+
+    result = await coordinator._run_ai_mode(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        topology=topology,
+    )
+
+    root_record = await task_repo.get_async(root_task.task_id)
+    auto_record = await task_repo.get_async(auto_task.task_id)
+    assert result.output == ""
+    assert task_execution_service.calls == []
+    assert root_record.status != TaskStatus.COMPLETED
+    assert auto_record.status == TaskStatus.ASSIGNED
+
+
+@pytest.mark.asyncio
+async def test_graph_mode_resume_existing_fixed_nodes_skips_planner_preflight(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="resume the fixed graph feature",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    implement_task = TaskEnvelope(
+        task_id="task-graph-implement",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        title="Implementation",
+        objective="Already completed fixed graph implementation.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id="implement",
+    )
+    _ = task_repo.create(implement_task)
+    task_repo.update_status(
+        implement_task.task_id,
+        TaskStatus.COMPLETED,
+        result="implementation already done",
+    )
+    graph = OrchestrationGraph(
+        nodes=(
+            OrchestrationGraphNode(
+                node_id="implement",
+                role_id="time",
+                objective="Run the fixed implementation fallback.",
+            ),
+            OrchestrationGraphNode(
+                node_id="verify",
+                role_id="time",
+                objective="Verify the resumed fixed graph work.",
+            ),
+        ),
+        edges=(
+            OrchestrationGraphEdge(
+                from_node_id="implement",
+                to_node_id="verify",
+            ),
+        ),
+        final_response_node_id="verify",
+    )
+    topology = RunTopologySnapshot(
+        session_mode=SessionMode.ORCHESTRATION,
+        main_agent_role_id="Coordinator",
+        normal_root_role_id="time",
+        coordinator_role_id="Coordinator",
+        orchestration_preset_id="graph",
+        orchestration_prompt="Run graph.",
+        allowed_role_ids=("DelegationPlanner", "time"),
+        orchestration_policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+        orchestration_graph=graph,
+    )
+    planning_service = _CreatingPlanningService(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        plan=DelegationPlan.model_validate(
+            {
+                "should_decompose": True,
+                "lanes": [
+                    {
+                        "lane_id": "implementation",
+                        "title": "Planned implementation",
+                        "role_id": "time",
+                        "objective": "This auto lane must not be created on resume.",
+                    }
+                ],
+            }
+        ),
+    )
+    coordinator.planning_service = cast(DelegationPlanningService, planning_service)
+
+    result = await coordinator._run_ai_mode(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        topology=topology,
+    )
+
+    records = await task_repo.list_by_trace_async("run-1")
+    records_by_node = {
+        record.envelope.orchestration_node_id: record
+        for record in records
+        if record.envelope.orchestration_node_id is not None
+    }
+
+    assert planning_service.calls == 0
+    assert f"{AUTO_LANE_NODE_PREFIX}implementation" not in records_by_node
+    assert records_by_node["implement"].status == TaskStatus.COMPLETED
+    assert records_by_node["verify"].status == TaskStatus.COMPLETED
+    assert task_execution_service.calls == [records_by_node["verify"].envelope.task_id]
+    assert result.output.startswith("Graph-based orchestration completed.")
+
+
+@pytest.mark.asyncio
+async def test_dynamic_cycles_report_exhausted_budget_with_pending_dependencies(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="ship dependent lanes",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    first_instance = create_subagent_instance(
+        "time",
+        workspace_id="workspace-1",
+        conversation_id="conversation-first-lane",
+    )
+    second_instance = create_subagent_instance(
+        "time",
+        workspace_id="workspace-1",
+        conversation_id="conversation-second-lane",
+    )
+    for instance in (first_instance, second_instance):
+        agent_repo.upsert_instance(
+            run_id="run-1",
+            trace_id="run-1",
+            session_id="session-1",
+            instance_id=instance.instance_id,
+            role_id="time",
+            workspace_id=instance.workspace_id,
+            conversation_id=instance.conversation_id,
+            status=InstanceStatus.IDLE,
+        )
+    first_task = TaskEnvelope(
+        task_id="task-auto-first",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        objective="Run the first lane.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}first",
+    )
+    second_task = TaskEnvelope(
+        task_id="task-auto-second",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        objective="Run the second lane after the first lane.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}second",
+        depends_on_task_ids=(first_task.task_id,),
+    )
+    _ = task_repo.create(first_task)
+    _ = task_repo.create(second_task)
+    task_repo.update_status(
+        first_task.task_id,
+        TaskStatus.ASSIGNED,
+        assigned_instance_id=first_instance.instance_id,
+    )
+    task_repo.update_status(
+        second_task.task_id,
+        TaskStatus.ASSIGNED,
+        assigned_instance_id=second_instance.instance_id,
+    )
+
+    result = await coordinator._run_dynamic_delegation_cycles_async(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        policy=OrchestrationPolicy(max_orchestration_cycles=1),
+        coordinator_result=TaskExecutionResult(output=""),
+    )
+
+    root_record = await task_repo.get_async(root_task.task_id)
+    first_record = await task_repo.get_async(first_task.task_id)
+    second_record = await task_repo.get_async(second_task.task_id)
+
+    assert result.completion_reason == RunCompletionReason.ASSISTANT_ERROR
+    assert result.error_code == "orchestration_cycles_exhausted"
+    assert root_record.status == TaskStatus.FAILED
+    assert first_record.status == TaskStatus.COMPLETED
+    assert second_record.status == TaskStatus.ASSIGNED
+    assert task_execution_service.calls == [first_task.task_id, root_task.task_id]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_cycles_do_not_exhaust_budget_for_paused_lane(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="resume paused planner lane later",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    paused_instance = create_subagent_instance(
+        "time",
+        workspace_id="workspace-1",
+        conversation_id="conversation-time",
+    )
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=paused_instance.instance_id,
+        role_id="time",
+        workspace_id=paused_instance.workspace_id,
+        conversation_id=paused_instance.conversation_id,
+        status=InstanceStatus.STOPPED,
+    )
+    paused_task = TaskEnvelope(
+        task_id="task-auto-paused",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        objective="Wait for manual input before continuing.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}paused",
+    )
+    downstream_task = TaskEnvelope(
+        task_id="task-auto-downstream",
+        session_id="session-1",
+        parent_task_id=root_task.task_id,
+        trace_id="run-1",
+        role_id="time",
+        objective="Continue after manual input is handled.",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+        orchestration_node_id=f"{AUTO_LANE_NODE_PREFIX}downstream",
+        depends_on_task_ids=(paused_task.task_id,),
+    )
+    _ = task_repo.create(paused_task)
+    _ = task_repo.create(downstream_task)
+    task_repo.update_status(
+        paused_task.task_id,
+        TaskStatus.ASSIGNED,
+        assigned_instance_id=paused_instance.instance_id,
+    )
+    task_repo.update_status(
+        downstream_task.task_id,
+        TaskStatus.ASSIGNED,
+        assigned_instance_id=paused_instance.instance_id,
+    )
+    run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-1",
+            session_id="session-1",
+            root_task_id=root_task.task_id,
+            status=RunRuntimeStatus.PAUSED,
+            phase=RunRuntimePhase.AWAITING_MANUAL_ACTION,
+            active_task_id=paused_task.task_id,
+            active_role_id="time",
+            active_subagent_instance_id=paused_instance.instance_id,
+            last_error="Waiting for manual action",
+        )
+    )
+
+    result = await coordinator._run_dynamic_delegation_cycles_async(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        policy=OrchestrationPolicy(max_orchestration_cycles=1),
+        coordinator_result=TaskExecutionResult(output="waiting for resume"),
+    )
+
+    root_record = await task_repo.get_async(root_task.task_id)
+    paused_record = await task_repo.get_async(paused_task.task_id)
+    downstream_record = await task_repo.get_async(downstream_task.task_id)
+    assert result.completion_reason == RunCompletionReason.ASSISTANT_RESPONSE
+    assert result.output == "waiting for resume"
+    assert root_record.status != TaskStatus.FAILED
+    assert paused_record.status == TaskStatus.ASSIGNED
+    assert downstream_record.status == TaskStatus.ASSIGNED
+    assert task_execution_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_graph_mode_falls_back_to_fixed_graph_when_planner_declines(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="ship the graph feature",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    graph = OrchestrationGraph(
+        nodes=(
+            OrchestrationGraphNode(
+                node_id="implement",
+                role_id="time",
+                objective="Run the fixed implementation fallback.",
+            ),
+        )
+    )
+    topology = RunTopologySnapshot(
+        session_mode=SessionMode.ORCHESTRATION,
+        main_agent_role_id="Coordinator",
+        normal_root_role_id="time",
+        coordinator_role_id="Coordinator",
+        orchestration_preset_id="graph",
+        orchestration_prompt="Run graph.",
+        allowed_role_ids=("DelegationPlanner", "time"),
+        orchestration_policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+        orchestration_graph=graph,
+    )
+    planning_service = _CreatingPlanningService(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        plan=DelegationPlan(should_decompose=False, rationale="simple graph"),
+    )
+    coordinator.planning_service = cast(DelegationPlanningService, planning_service)
+
+    result = await coordinator._run_ai_mode(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        topology=topology,
+    )
+
+    records = await task_repo.list_by_trace_async("run-1")
+    records_by_node = {
+        record.envelope.orchestration_node_id: record
+        for record in records
+        if record.envelope.orchestration_node_id is not None
+    }
+
+    assert planning_service.calls == 1
+    assert "implement" in records_by_node
+    assert not any(
+        str(node_id).startswith(AUTO_LANE_NODE_PREFIX) for node_id in records_by_node
+    )
+    assert task_execution_service.calls == [
+        records_by_node["implement"].envelope.task_id
+    ]
+    assert result.output.startswith("Graph-based orchestration completed.")
+
+
+@pytest.mark.asyncio
+async def test_graph_mode_falls_back_to_fixed_graph_when_planner_unavailable(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, task_execution_service = (
+        _build_coordinator(tmp_path)
+    )
+    root_task = TaskEnvelope(
+        task_id="task-root-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="Coordinator",
+        objective="ship the graph feature",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(root_task)
+    coordinator_instance_id = await coordinator._ensure_root_instance_async(
+        session_id="session-1",
+        trace_id="run-1",
+        root_task=root_task,
+        reuse_existing_instance=False,
+    )
+    graph = OrchestrationGraph(
+        nodes=(
+            OrchestrationGraphNode(
+                node_id="implement",
+                role_id="time",
+                objective="Run the fixed implementation fallback.",
+            ),
+        )
+    )
+    topology = RunTopologySnapshot(
+        session_mode=SessionMode.ORCHESTRATION,
+        main_agent_role_id="Coordinator",
+        normal_root_role_id="time",
+        coordinator_role_id="Coordinator",
+        orchestration_preset_id="graph",
+        orchestration_prompt="Run graph.",
+        allowed_role_ids=("DelegationPlanner", "time"),
+        orchestration_policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+        orchestration_graph=graph,
+    )
+    planning_service = _CreatingPlanningService(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        plan=None,
+    )
+    coordinator.planning_service = cast(DelegationPlanningService, planning_service)
+
+    result = await coordinator._run_ai_mode(
+        trace_id="run-1",
+        root_task=root_task,
+        coordinator_instance_id=coordinator_instance_id,
+        topology=topology,
+    )
+
+    records = await task_repo.list_by_trace_async("run-1")
+    records_by_node = {
+        record.envelope.orchestration_node_id: record
+        for record in records
+        if record.envelope.orchestration_node_id is not None
+    }
+
+    assert planning_service.calls == 1
+    assert "implement" in records_by_node
+    assert not any(
+        str(node_id).startswith(AUTO_LANE_NODE_PREFIX) for node_id in records_by_node
+    )
+    assert task_execution_service.calls == [
+        records_by_node["implement"].envelope.task_id
+    ]
+    assert result.output.startswith("Graph-based orchestration completed.")
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/test_delegation_planning.py
+++ b/tests/unit_tests/agents/orchestration/test_delegation_planning.py
@@ -436,6 +436,11 @@ async def test_planning_service_skip_and_fallback_paths(tmp_path: Path) -> None:
         topology=_topology_with_graph(),
         policy=OrchestrationPolicy(),
     )
+    assert await service.should_plan_async(
+        root_task=root_task,
+        topology=_topology_with_graph(),
+        policy=OrchestrationPolicy(coordinator_inline_budget_steps=0),
+    )
     assert not await service.should_plan_async(
         root_task=root_task,
         topology=None,

--- a/tests/unit_tests/agents/orchestration/test_graph_models.py
+++ b/tests/unit_tests/agents/orchestration/test_graph_models.py
@@ -88,6 +88,15 @@ def test_orchestration_graph_normalizes_optional_text_fields() -> None:
 
 
 def test_orchestration_graph_rejects_invalid_node_and_edge_references() -> None:
+    with pytest.raises(ValueError, match="reserved prefix: auto_lane_"):
+        OrchestrationGraphNode.model_validate(
+            {
+                "node_id": "auto_lane_build",
+                "role_id": "Writer",
+                "objective": "Build.",
+            }
+        )
+
     with pytest.raises(ValueError, match="cannot target the same node"):
         OrchestrationGraphEdge.model_validate(
             {"from_node_id": "write", "to_node_id": "write"}

--- a/tests/unit_tests/builtin/test_resources.py
+++ b/tests/unit_tests/builtin/test_resources.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from relay_teams.agents.orchestration.settings_models import OrchestrationSettings
 from relay_teams.builtin.resources import (
     ensure_app_config_bootstrap,
+    get_builtin_orchestration_config_path,
     get_builtin_roles_dir,
     get_builtin_skills_dir,
 )
@@ -31,6 +33,25 @@ def test_primary_builtin_runtime_roles_allow_all_mcp_servers_and_skills() -> Non
         role = registry.get(role_id)
         assert role.mcp_servers == ("*",)
         assert role.skills == ("*",)
+
+
+def test_builtin_orchestration_presets_are_planner_first() -> None:
+    settings = OrchestrationSettings.model_validate_json(
+        get_builtin_orchestration_config_path().read_text(encoding="utf-8")
+    )
+    presets = {preset.preset_id: preset for preset in settings.presets}
+    default_cycle_budget = presets["default"].policy.max_orchestration_cycles
+
+    for preset_id in ("default", "fast_graph", "standard_graph"):
+        preset = presets[preset_id]
+        policy = preset.policy
+        assert policy.auto_plan_long_tasks is True
+        assert policy.planner_role_id == "DelegationPlanner"
+        assert policy.coordinator_inline_budget_steps == 0
+        assert "DelegationPlanner" in preset.role_ids
+
+        if preset.graph is not None:
+            assert policy.max_orchestration_cycles >= default_cycle_budget
 
 
 def test_deepresearch_news_sources_include_block_ai_source_entries() -> None:


### PR DESCRIPTION
## Summary
- Run automatic DelegationPlanner preflight before fixed graph orchestration when the planner is enabled and allowed.
- Make built-in default, fast_graph, and standard_graph presets planner-first so concise requests can still decompose into dynamic DAG lanes.
- Preserve fixed graph templates as fallback when planning declines or is unavailable.

Closes #808

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests`
- Rebase onto latest `origin/main`, then reran `ruff check --fix`, `basedpyright`, and focused orchestration/resource/API tests.