### PR TITLE
docs: expand workspace TODO board design

### DIFF
--- a/docs/modules/boards/workspace-todo-board-agent-handoff.md
+++ b/docs/modules/boards/workspace-todo-board-agent-handoff.md
@@ -1,0 +1,805 @@
+# Workspace TODO Board AGENTS Handoff Design
+
+## 背景
+
+当前 TODO Board 的 Start 行为自由度不足：
+
+- 前端点击 Start 后直接调用 `startBoardTodo(todoId, {})`。
+- 后端如果没有收到 `prompt`，使用 `_build_start_prompt(item)` 内置拼接。
+- 用户看不到最终交给 AGENTS 的 prompt，也不能在启动前调整上下文、验收标准或执行方式。
+- request changes 只收集 feedback，后端仍使用固定 `_build_request_changes_prompt()`。
+
+目标设计是：用户必须能在交付前查看、编辑并确认最终 prompt；模板可以由用户配置，且不同 source 可以有不同模板。
+
+## 设计原则
+
+- 最终交给 AGENTS 的内容必须是用户确认过的 final prompt。
+- 模板用于生成默认 prompt，不是不可见系统指令。
+- 后端可以提供安全的 fallback 模板，但不应在 Start 时再次隐式拼接关键任务描述。
+- Start 和 request changes 使用同一套 preview/edit/confirm 交互模型。
+- 模板覆盖支持 source 粒度，便于 GitHub issue、manual TODO、Linear issue 使用不同上下文结构。
+- Handoff 入口必须区分 `view_workspace_id` 与 `board_workspace_id`；fork workspace 页面上看到的是 root board 的 TODO，但 execution workspace 策略仍按每次 TODO handoff 独立决定。
+- Handoff 必须同时声明 execution workspace 策略，默认用独立 Git worktree fork 隔离代码修改，避免多个 AGENTS run 共享同一个可写工作树。
+- Handoff 必须同时声明 runtime target 和 review policy。TODO Board 只选择本地 role、外部 agent role 或 orchestration preset，不直接调用外部 agent runtime。
+- AI 发放也必须经过同一套 preview/render/final prompt/start 语义；`ai_auto_start` 只是自动确认策略，不是绕过 handoff。
+
+## 用户流程
+
+### Start
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Frontend
+    participant API as Boards API
+    participant H as HandoffService
+    participant W as WorkspaceService
+    participant Q as ExecutionQueueService
+    participant R as RunService
+    participant B as BoardTodoService
+
+    U->>FE: Click Start on TODO card
+    FE->>API: POST preview start handoff
+    API->>H: render template, runtime target and execution plan
+    H-->>API: rendered prompt + execution policy + runtime options
+    API-->>FE: preview response
+    FE->>U: Show prompt editor, runtime, queue and review options
+    U->>FE: Edit and confirm
+    FE->>API: POST start with final_prompt + execution_policy + runtime_target
+    API->>B: reserve item
+    B->>Q: acquire workspace/runtime slot or enqueue
+    alt slot unavailable and queue_if_full
+        Q-->>B: queue ticket
+        B-->>API: item in_progress with active queue ticket
+    else slot acquired
+    alt execution_policy == fork_git_worktree
+        B->>W: fork source workspace
+        W-->>B: execution workspace
+    end
+        B->>R: create session/run in execution workspace and runtime target
+        B-->>API: updated item in_progress
+    end
+    API-->>FE: BoardTodoItem
+```
+
+### Request Changes
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Frontend
+    participant API as Boards API
+    participant H as HandoffService
+    participant Q as ExecutionQueueService
+    participant R as RunService
+    participant B as BoardTodoService
+
+    U->>FE: Click Request changes
+    FE->>U: Collect feedback
+    FE->>API: POST preview request-changes handoff
+    API->>H: render request template with feedback
+    H-->>API: rendered prompt
+    API-->>FE: preview response
+    FE->>U: Show editable prompt
+    U->>FE: Confirm final prompt
+    FE->>API: POST request-changes with final_prompt
+    B->>Q: acquire workspace/runtime slot or enqueue
+    alt slot unavailable and queue_if_full
+        Q-->>B: request changes queue ticket
+        B-->>API: item in_progress with active request changes queue ticket
+    else slot acquired
+        B->>R: create new run in existing execution workspace
+        B-->>API: updated item in_progress
+    end
+```
+
+### AI 发放
+
+AI 发放分两类：
+
+| Mode | 行为 |
+| --- | --- |
+| `ai_suggested` | AI 生成建议 prompt、runtime target、execution policy、review policy，用户打开 Start editor 后确认或修改 |
+| `ai_auto` | AI 根据策略自动提交 final prompt，但仍要通过 runtime target 校验、execution workspace 策略和并发限制 |
+
+约束：
+
+- AI 只能选择 source/workspace policy 允许的 runtime target。
+- AI auto start 必须保存 `handoff_initiator = ai_auto`、`start_policy = ai_auto_start`、template source 和 final prompt metadata。
+- AI auto start 默认 `queue_if_full = true`；并发满时进入 `in_progress` 并创建可审计 queue ticket。
+- AI auto start 和人工 Start 一样必须保存完整 final prompt snapshot/ref；如果进入队列，后续 queue worker 只能使用该 snapshot 创建 run。
+- AI 创建的新 TODO 是线性独立 TODO，必须携带 `idempotency_key`，不形成 parent/child dependency。
+- preview/render 失败时 AI 不得直接启动，应记录 diagnostics 并保持 item 在 `todo`。
+
+## Execution Workspace
+
+Handoff 不只包含 `final_prompt`，还必须包含执行 workspace 策略。原因是 TODO Board 经常会同时启动多个代码修改任务，如果这些 run 都直接在同一个 workspace root 中修改文件，会造成工作树污染、diff 混杂、测试结果互相影响和 PR 归因困难。
+
+### Execution Policy
+
+首版支持两种策略：
+
+| Policy | 含义 | 默认使用场景 |
+| --- | --- | --- |
+| `fork_git_worktree` | 先通过 workspace fork 创建独立 Git worktree，再在 fork workspace 中创建 session/run | 默认推荐，适合可能修改代码的 TODO |
+| `current_workspace` | 直接在当前页面的 `view_workspace_id` 中创建 session/run；fork view 中即用户当前打开的 fork workspace，不回退到 TODO 所属 root workspace | 仅用于明确不修改代码的任务，或用户显式选择 |
+
+默认策略：
+
+- GitHub issue 和 manual TODO 只要可能涉及代码修改，preview 默认推荐 `fork_git_worktree`。
+- source 可以通过 metadata 标记某类 TODO 不需要隔离，但 UI 仍应展示当前策略。
+- 用户可以在 Start prompt editor 中切换策略；选择 `current_workspace` 时，UI 必须提示多个 AGENTS run 可能共享同一个可写工作树，并明确显示将使用当前 `view_workspace_id` 作为 execution workspace。
+
+### Fork 行为
+
+当用户确认 `fork_git_worktree`：
+
+1. Board service 先 reserve item，防止重复启动。
+2. Board service 调用 workspace 模块已有 `POST /api/workspaces/{workspace_id}:fork` 对应服务能力。
+3. Workspace service 创建 `git_worktree` backend 的 fork workspace。
+4. Board service 创建 session/run 时使用 fork 后的 `execution_workspace_id`。
+5. Board item 仍显示在 `board_workspace_id` 对应的 TODO board 中，但详情记录 execution workspace。
+
+Boards 模块不重新实现 Git worktree 操作。它只声明执行策略、调用 workspace 服务、保存引用和展示关系。
+
+### Fork View 下的 Handoff
+
+用户可能在 fork 出来的 `git_worktree` workspace 中打开 TODO 页面。此时页面展示的是 root workspace 的同一套 board，而不是 fork-local board。Start/Request Changes 必须遵循以下规则：
+
+- Preview response 返回 `board_workspace_id`、`view_workspace_id`、`is_fork_view` 和 `forked_from_workspace_id`，并把 source/board context 与 execution context 分开展示。
+- 对尚无 `execution_workspace_id` 的 TODO，即使用户当前在某个 fork workspace 页面点击 Start，默认仍从 root/source workspace 按 `fork_git_worktree` 创建新的 execution workspace，保持“一次 TODO handoff 一个隔离工作树”的并发安全策略。
+- 如果当前 fork workspace 已经等于该 TODO 的 `execution_workspace_id`，Request Changes 默认复用当前 fork workspace。
+- 如果用户显式选择 `current_workspace` 且当前 `view_workspace_id` 是 fork workspace，UI 必须警告该 fork 可能被多个 TODO/run 共享，默认不推荐。
+- `view_workspace_id` 不写入 item 主行，只写入 attempt/event audit metadata，例如 `initiated_from_workspace_id`。
+
+### Workspace 引用
+
+Board item 目标设计增加执行引用：
+
+| 字段 | 说明 |
+| --- | --- |
+| `board_workspace_id` | TODO board 的真正归属 workspace；fork view 解析到 root workspace |
+| `source_workspace_id` | TODO 所属原 workspace；现有 `workspace_id` 语义应迁移或明确为 source workspace |
+| `view_workspace_id` | 当前操作发生的 workspace；不写入 item 主行，可写入 attempt/event metadata |
+| `execution_workspace_id` | AGENTS 实际执行的 workspace |
+| `execution_branch_name` | fork branch，例如 `fork/{workspace_id}` |
+| `execution_policy` | `fork_git_worktree` 或 `current_workspace` |
+| `current_attempt_id` | 最近一次 start/request changes/review attempt |
+| `active_attempt_id` | 当前 active attempt |
+| `queue_ticket_id` | 并发满时的 queue ticket；等待事实不作为 board 状态 |
+| `diagnostic_count` | 未清理 diagnostics 数量 |
+
+Card detail 同时展示 source workspace 和 execution workspace：
+
+- Board workspace 用于 board list、revision、source settings、template 和 sync。
+- Source workspace 用于 source sync 和 card source scope。
+- Current/view workspace 用于说明用户当前从哪个 workspace 操作。
+- Execution workspace 用于 session/run、文件修改、diff、测试和后续 PR 准备。
+
+### Request Changes 复用
+
+`request changes` 默认复用该 TODO 已绑定的 execution workspace：
+
+- 如果 item 已有 `execution_workspace_id`，新 run 继续绑定该 workspace。
+- 默认复用原 executor runtime target；用户显式换 runtime target 时必须重新校验 allowed targets 和并发上限。
+- 不默认重新 fork，避免 review 修改与前一次实现分裂到不同工作树。
+- 如果未来支持“重新 fork 修改”，应作为显式高级操作，而不是首版默认。
+
+Legacy 迁移：
+
+- 旧实现创建的 `review` item 可能只有 `workspace_id/session_id/run_id`，没有 `execution_workspace_id`。
+- 这类 item 首次 request changes 时只能从旧 session workspace 或旧 completed attempt workspace 推导 execution workspace；不能使用当前 fork view 的 `view_workspace_id`。无法证明原执行 workspace 时返回 conflict，避免已有 review item 被返工到无关 fork。
+- 新目标数据必须在 Start/request changes 时写入明确的 execution workspace 引用。
+
+### 生命周期
+
+- Session 删除不删除 fork worktree。
+- Archive/done 不自动删除 fork worktree。
+- Fork workspace 生命周期归 workspace 模块管理，用户通过 workspace 删除流程清理。
+- Board item 只保存 execution workspace 引用和状态 reason，不能私自移除 worktree。
+- Workspace 删除事件必须进入 board lifecycle bridge：如果被删除的是 `execution_workspace_id`，item 保持当前 board status 但写 `execution_workspace_missing` diagnostic；`in_progress` 释放或等待 terminal 的 active slot 按 run/session 状态 reconcile，`review` 的 Request Changes/AI Review 在缺少 execution context 时返回 conflict。
+
+## Runtime Target
+
+Handoff preview 必须返回可选 runtime target，Start request 必须提交最终 runtime target。
+
+| Runtime target kind | 含义 |
+| --- | --- |
+| `local_role` | 使用未绑定外部 agent 的 Agent Teams role |
+| `external_role` | 使用绑定了 `bound_agent_id` 的 role，底层由 `agent_runtimes` 走 `acp`、`a2a` 或 `cli` |
+| `orchestration_preset` | 使用 orchestration preset 创建 orchestration session/run |
+
+Handoff 层只选择 target，不直接处理 external agent secret、transport 或 protocol。实际执行仍由 sessions/runs 和 agent runtime/provider 层负责。
+
+模板变量补充：
+
+| 变量 | 说明 |
+| --- | --- |
+| `runtime.target_id` | 选中的 runtime target |
+| `runtime.target_kind` | `local_role`、`external_role`、`orchestration_preset` |
+| `runtime.display_name` | 展示名 |
+| `runtime.role_id` | role target 的 role id |
+| `runtime.orchestration_preset_id` | orchestration target 的 preset id |
+| `runtime.bound_agent_id` | external role 绑定的 agent id |
+| `runtime.external_protocol` | `acp`、`a2a` 或 `cli` |
+| `runtime.external_transport` | `stdio`、`streamable_http` 或 `custom` |
+
+## Review Policy
+
+Start 时可以同时选择 review policy：
+
+| review_policy | 行为 |
+| --- | --- |
+| `human_required` | run completed 后进入 `review`，等待用户确认 |
+| `ai_pre_review` | 进入 `review` 后先启动 AI review，AI 结论展示给用户，最终仍由人确认 |
+| `ai_auto_done` | AI review 通过后可直接进入 `done` |
+
+AI review 可以选择独立 reviewer runtime target。reviewer runtime target 与 executor runtime target 分开计入并发上限。
+
+模板变量补充：
+
+| 变量 | 说明 |
+| --- | --- |
+| `review.policy` | `human_required`、`ai_pre_review`、`ai_auto_done` |
+| `review.runtime_target_id` | reviewer runtime target |
+| `review.state` | AI review 的归一化状态，例如 waiting/running/approved/changes requested/needs human/failed |
+| `review.decision` | AI review decision |
+
+## 模板层级
+
+模板优先级：
+
+1. source template override。
+2. workspace template override。
+3. global default template。
+4. built-in fallback template。
+
+解释：
+
+- source template 最贴近不同数据来源，例如 GitHub issue 要包含 repo/issue URL，manual TODO 可能只需要正文和验收标准。
+- workspace template 适合团队统一格式。
+- global default template 适合全局默认偏好。
+- built-in fallback 只保证系统可用，不作为用户主要配置入口。
+
+模板类型：
+
+| Template kind | 用途 |
+| --- | --- |
+| `start` | 从 `todo` 启动处理 |
+| `request_changes` | 从 `review` 请求修改 |
+| `ai_review` | run completed 后由 reviewer runtime 进行 AI review |
+
+未来可扩展：
+
+- `review_summary`：生成验收摘要。
+- `source_comment`：向外部 tracker 写评论。
+- `done_note`：完成时生成交付说明。
+
+## 模板变量
+
+模板变量必须是显式、稳定、可预览的。变量缺失时应渲染为空字符串或明确 diagnostics，不能抛出导致 Start 不可用，除非 final prompt 为空。
+
+通用变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `todo.id` | Board TODO id |
+| `todo.title` | 标题 |
+| `todo.body` | 正文 |
+| `todo.status` | 当前 board 状态 |
+| `todo.status_reason` | 最近状态原因 |
+| `workspace.id` | workspace id |
+| `workspace.board_id` | TODO board 归属 workspace id |
+| `workspace.view_id` | 用户当前打开或发起操作的 workspace id |
+| `workspace.is_fork_view` | 当前 view workspace 是否为 fork workspace |
+| `workspace.source_id` | TODO 所属原 workspace id |
+| `workspace.execution_id` | AGENTS 实际执行 workspace id |
+| `workspace.execution_root` | execution workspace root path 或 root reference |
+| `workspace.execution_backend` | `project`、`git_worktree` 等执行后端 |
+| `workspace.branch_name` | execution workspace 分支名 |
+| `workspace.forked_from_workspace_id` | fork 来源 workspace id |
+| `source.provider` | `local`、`github` 等 |
+| `source.kind` | `manual`、`github_issues` 等 |
+| `source.display_name` | source 名称 |
+| `source.url` | 外部 source URL |
+| `session.id` | 已绑定 session，可能为空 |
+| `run.id` | 当前或上一次 run，可能为空 |
+| `handoff.execution_policy` | `current_workspace` 或 `fork_git_worktree` |
+| `handoff.requires_isolation` | 是否建议隔离执行 |
+| `handoff.feedback` | request changes 用户反馈 |
+| `handoff.initiator` | `human`、`ai_suggested`、`ai_auto` |
+| `handoff.start_policy` | `human_required`、`ai_suggest_then_confirm`、`ai_auto_start` |
+| `handoff.queue_if_full` | 并发满时是否进入 queued |
+| `handoff.queue_ticket_id` | 当前 queue ticket，可能为空 |
+| `attempt.previous_summaries` | 最近 attempt 摘要 |
+| `attempt.previous_errors` | 最近失败原因 |
+| `attempt.last_verification` | 最近验证结果 |
+| `attempt.last_changed_files` | 最近一次 attempt 的 changed files 摘要 |
+| `diagnostics.open_count` | 未清理 diagnostic 数量 |
+
+GitHub 变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `github.repository` | `owner/repo` |
+| `github.issue_number` | issue number |
+| `github.issue_url` | issue URL |
+| `github.pull_request_number` | linked PR number |
+| `github.pull_request_url` | linked PR URL |
+
+系统变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `now` | 渲染时间 |
+| `template.source` | 当前命中的模板来源 |
+
+## 默认 Start 模板
+
+默认模板应清楚表达任务、来源和完成期望，但不规定过多实现策略。
+
+示例：
+
+```text
+Please work on this Workspace TODO item.
+
+Title: {{ todo.title }}
+Source: {{ source.provider }}/{{ source.kind }}
+Repository: {{ github.repository }}
+Issue: #{{ github.issue_number }}
+URL: {{ source.url }}
+
+Execution workspace:
+- Board workspace: {{ workspace.board_id }}
+- Current view workspace: {{ workspace.view_id }}
+- Fork view: {{ workspace.is_fork_view }}
+- Source workspace: {{ workspace.source_id }}
+- Execution workspace: {{ workspace.execution_id }}
+- Execution backend: {{ workspace.execution_backend }}
+- Branch: {{ workspace.branch_name }}
+- Forked from: {{ workspace.forked_from_workspace_id }}
+- Execution policy: {{ handoff.execution_policy }}
+
+Runtime:
+- Runtime target: {{ runtime.display_name }} ({{ runtime.target_kind }})
+- Role: {{ runtime.role_id }}
+- External agent: {{ runtime.bound_agent_id }}
+
+Review:
+- Review policy: {{ review.policy }}
+- Reviewer runtime: {{ review.runtime_target_id }}
+
+Work only in the execution workspace. If the execution policy is
+fork_git_worktree, do not modify files in the source workspace directly.
+
+Details:
+{{ todo.body }}
+
+When finished, summarize:
+- Execution workspace and branch used
+- changed_files
+- verification
+- created_todos, if you create follow-up TODOs. Each item must include an idempotency key and is a separate linear TODO, not a dependency.
+- blocked_reason, only if you cannot continue
+- retry_notes
+- residual_risk
+```
+
+如果变量为空，渲染器应删除明显空行或保留为空值，具体实现可选择一种稳定策略，但 preview 和 final 渲染必须一致。
+
+## 默认 Request Changes 模板
+
+示例：
+
+```text
+Please revise the work for this Workspace TODO item.
+
+Title: {{ todo.title }}
+Board TODO ID: {{ todo.id }}
+Original source: {{ source.url }}
+
+Requested changes:
+{{ handoff.feedback }}
+
+Prior attempt context:
+- Previous summaries: {{ attempt.previous_summaries }}
+- Previous errors: {{ attempt.previous_errors }}
+- Last verification: {{ attempt.last_verification }}
+- Last changed files: {{ attempt.last_changed_files }}
+
+Keep the final response focused on what changed and how it was verified.
+
+Include structured completion metadata:
+- changed_files
+- verification
+- blocked_reason, if any
+- retry_notes
+- residual_risk
+```
+
+## Structured Completion Metadata
+
+Start、Request Changes 和 AI Review 模板都应要求 AGENTS 输出结构化完成信息。Board 不要求运行时强制输出 JSON，但 handoff 模板和 review UI 需要围绕这些字段设计：
+
+| 字段 | 说明 |
+| --- | --- |
+| `changed_files` | 文件变更摘要 |
+| `verification` | 测试、检查或未验证原因 |
+| `created_todos` | AGENTS 创建的线性后续 TODO；不表达依赖关系 |
+| `blocked_reason` | 本次 attempt 无法继续的原因；仅作为 attempt metadata 或 diagnostic |
+| `retry_notes` | 后续 request changes 或 retry 应注意的内容 |
+| `residual_risk` | 人工 review 重点和剩余风险 |
+
+这些字段写入 `BoardTodoAttempt.metadata`，并在 card detail、AI review prompt 和 request-changes preview 中可见。
+
+## Handoff Prompt Snapshot
+
+Start、Request Changes、AI auto start 和 AI Review 在确认 final prompt 后必须保存完整 prompt snapshot/ref。这样即使 handoff 或 review 因并发上限进入 queue，还没有创建 run/message history，后续 queue worker 也能可靠使用同一个 final prompt 创建 run。
+
+目标可以新增 `board_todo_handoff_prompts` 表，或使用等价存储。最小字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `prompt_ref` | prompt snapshot id，供 attempt 和 queue ticket 引用 |
+| `todo_id` | 关联 TODO |
+| `attempt_id` | 关联 start、request changes 或 AI review attempt |
+| `template_source` | source/workspace/global/fallback，或 AI suggested source |
+| `final_prompt_snapshot` | 用户或 AI policy 最终确认的完整 prompt |
+| `template_kind` | `start`、`request_changes` 或 `ai_review` |
+| `created_at` | snapshot 创建时间 |
+
+完整 prompt 创建 run 后仍会进入 session history。Board 侧 snapshot 是 queue 恢复、审计和失败诊断所需数据；摘要 metadata 不能替代执行用 prompt。
+
+## TODO-bound Worker Context
+
+TODO-bound session/run 可以获得最小 board context，帮助 AGENTS 理解当前 TODO 的历史和协作记录。该上下文不等于普通 session 的全局工具集。
+
+Preview 和 Start 时应能向模板暴露：
+
+- 当前 TODO 和 source 信息。
+- source workspace 与 execution workspace。
+- active queue ticket 或 runtime slot 决策。
+- prior attempts 摘要、失败原因和 verification。
+- comments 摘要。
+- unresolved diagnostics。
+
+后续实现可以提供最小 TODO-bound 工具集：
+
+| tool | 语义 |
+| --- | --- |
+| `board_todo_show` | 读取当前 TODO、prior attempts、comments、events 和 diagnostics |
+| `board_todo_comment` | 写入当前 TODO 的 comment thread |
+| `board_todo_create` | 创建新的线性 TODO，必须带 idempotency key |
+| `board_todo_report_progress` | 写入进度 comment 或 event |
+
+工具边界：
+
+- 只在 TODO-bound session/run 中暴露。
+- 必须校验当前 session/run 绑定的 `todo_id`。
+- 默认只能操作当前 TODO；`board_todo_create` 创建的新 TODO 不形成依赖关系。
+- 不提供 worker 直接把 TODO 标为 `done` 的默认能力；完成仍由 run terminal、AI review、用户确认或 source evidence 驱动。
+
+## API 方向
+
+目标 API 仅作为设计方向，具体 schema 在实现阶段写入 core API 文档。
+
+### Preview Start
+
+```text
+POST /api/boards/todos/{todo_id}:preview-start
+```
+
+Request：
+
+```json
+{
+  "view_workspace_id": "workspace-current-view",
+  "template_override": null,
+  "execution_policy": null,
+  "runtime_target_id": null,
+  "review_policy": null,
+  "review_runtime_target_id": null,
+  "queue_if_full": true
+}
+```
+
+Preview request 中的 `view_workspace_id` 表示用户当前打开 TODO 页面所在 workspace。runtime、review 和 queue 字段表示用户当前在 Start editor 中选择的候选值。后端必须基于这些候选值重新渲染 runtime options、review options、concurrency snapshot 和 queue preview，避免用户切换 runtime 后仍看到旧 slot 结果。fork view 下，preview 必须使用该 `view_workspace_id` 渲染 `workspace.view_id`、fork warning 和 `current_workspace` execution context，不能只从 `todo_id` 推导 root board workspace。
+
+Response：
+
+```json
+{
+  "todo_id": "btodo_123",
+  "board_workspace_id": "root_workspace",
+  "view_workspace_id": "fork_workspace",
+  "is_fork_view": true,
+  "forked_from_workspace_id": "root_workspace",
+  "template_kind": "start",
+  "template_source": "source",
+  "prompt": "rendered prompt",
+  "recommended_runtime_target": {
+    "runtime_target_id": "role:main_agent",
+    "runtime_target_kind": "local_role",
+    "display_name": "Main Agent"
+  },
+  "runtime_options": [],
+  "recommended_execution_policy": "fork_git_worktree",
+  "execution_workspace_preview": {
+    "source_workspace_id": "workspace",
+    "execution_workspace_id": null,
+    "execution_backend": "git_worktree",
+    "branch_name": null
+  },
+  "fork_name_suggestion": "workspace-btodo-123",
+  "workspace_variables": {
+    "board_id": "root_workspace",
+    "view_id": "fork_workspace",
+    "is_fork_view": true,
+    "source_id": "workspace",
+    "execution_id": "",
+    "execution_root": "",
+    "execution_backend": "git_worktree",
+    "branch_name": "",
+    "forked_from_workspace_id": "workspace"
+  },
+  "review_policy": "human_required",
+  "review_runtime_options": [],
+  "concurrency_snapshot": {
+    "source_workspace": {
+      "limit": 2,
+      "active": 1,
+      "available": 1
+    },
+    "runtime_target": {
+      "limit": 1,
+      "active": 1,
+      "available": 0
+    }
+  },
+  "queue_preview": {
+    "would_queue": true,
+    "reason": "runtime target concurrency limit reached"
+  },
+  "attempt_context": {
+    "previous_summaries": [],
+    "previous_errors": []
+  },
+  "diagnostic_count": 0,
+  "variables": {},
+  "diagnostics": []
+}
+```
+
+### Start With Final Prompt
+
+```text
+POST /api/boards/todos/{todo_id}:start
+```
+
+Request：
+
+```json
+{
+  "final_prompt": "user confirmed prompt",
+  "idempotency_key": "start-btodo-123-attempt-1",
+  "view_workspace_id": "workspace-current-view",
+  "execution_workspace_id": null,
+  "execution_policy": "fork_git_worktree",
+  "runtime_target_id": "role:main_agent",
+  "queue_if_full": true,
+  "start_policy": "human_required",
+  "handoff_initiator": "human",
+  "review_policy": "ai_pre_review",
+  "review_runtime_target_id": "role:reviewer",
+  "fork_name": "workspace-btodo-123",
+  "start_ref": null,
+  "yolo": true
+}
+```
+
+Rules：
+
+- `final_prompt` 必须非空。
+- `idempotency_key` 用于去重 confirmed Start 请求；人工 Start、AI suggested 和 AI auto 都必须提交稳定 key，避免 timeout/retry 在 fork、session 或 run 已创建但响应未返回时产生重复执行。
+- `runtime_target_id` 必须在 allowed runtime targets 中。
+- `review_policy=ai_pre_review` 或 `ai_auto_done` 时，`review_runtime_target_id` 必须存在且在 allowed reviewer runtime targets 中；否则 Start 必须拒绝或显式降级为 `human_required`。
+- `handoff_initiator=ai_auto` 或 `ai_suggested` 时，`yolo=true` 默认拒绝；只有 workspace/source policy 显式允许 AI-initiated yolo 时才可提交，并必须写入 audit event。
+- `execution_policy` 默认为 preview 推荐值；新前端必须显式提交用户确认后的值。
+- `view_workspace_id` 是用户确认 Start 时所在的当前页面 workspace，必须随 confirmed Start 提交，用于审计和解析 `current_workspace`。
+- `execution_workspace_id` 通常由后端在 `fork_git_worktree` 成功后填充；当 `execution_policy=current_workspace` 时，前端可以提交等于 `view_workspace_id` 的值，后端必须校验它确实是当前 view workspace，且不能从 `todo_id` 反推 root board workspace 作为执行 workspace。
+- `queue_if_full=true` 时，并发满则 item 进入 `in_progress` 并创建 queue ticket；不提前 fork workspace，不提前创建 run。
+- 创建 queue ticket 前必须保存完整 handoff snapshot/ref，并把 `prompt_ref`、`view_workspace_id`、`execution_workspace_id`、`execution_policy`、`fork_name`、`start_ref`、`runtime_target_id`、`review_policy`、`review_runtime_target_id`、`yolo`、`handoff_initiator`、`start_policy` 和 yolo authorization source 绑定到 attempt 和 ticket。Queue worker 后续只能使用该 snapshot 创建 fork/session/run，不能重新推导默认 fork 名称、起点、approval mode 或 current-workspace 目标。
+- `queue_if_full=false` 时，并发满返回 conflict，item 保持 `todo`。
+- `handoff_initiator=ai_auto` 必须同时使用允许的 `start_policy=ai_auto_start` 和稳定 `idempotency_key`，并记录审计 metadata。重复 AI auto start 请求返回已有 attempt、queue ticket 或 run 引用，不创建重复执行。
+- `fork_name` 和 `start_ref` 仅在 `fork_git_worktree` 时使用；`start_ref` 为空时沿用 workspace fork API 的默认起点。
+- `fork_git_worktree` 时，后端必须在获得并发 slot 后先成功创建 execution workspace，再创建 session/run。
+- fork 失败时，不创建 run，item 保持或恢复为 `todo`，并返回 diagnostics。
+- 从 fork view 发起 Start 时，除非用户显式选择并确认 `current_workspace`，`fork_git_worktree` 的 fork 来源仍是 `board_workspace_id/source_workspace_id`，不是当前任意 fork workspace。
+- 如果为了兼容保留旧 `prompt` 字段，后端应把它当作 final prompt，而不是 template input。
+- 没有 final prompt 的旧客户端可以短期 fallback 到 preview 渲染结果，但新前端必须总是提交 final prompt。
+
+### Preview Request Changes
+
+```text
+POST /api/boards/todos/{todo_id}:preview-request-changes
+```
+
+Request：
+
+```json
+{
+  "feedback": "user feedback",
+  "view_workspace_id": "workspace-current-view",
+  "template_override": null,
+  "execution_policy": null,
+  "runtime_target_id": "role:main_agent",
+  "queue_if_full": true
+}
+```
+
+Preview request 中的 `view_workspace_id` 表示 Request Changes 打开时的当前页面 workspace，用于渲染 `workspace.view_id`、fork 变量和 execution-workspace shortcut。`runtime_target_id` 和 `queue_if_full` 表示用户在 Request changes editor 中当前选择的候选执行 runtime 与排队策略。后端必须像 Preview Start 一样重新计算 `runtime_options`、`concurrency_snapshot` 和 `queue_preview`，避免用户切换 runtime 后仍看到旧 executor runtime 的 slot 状态。
+
+Response 同 preview start，但 `template_kind` 为 `request_changes`，并且 `execution_workspace_preview` 默认指向 item 已绑定的 `execution_workspace_id`。
+
+### Request Changes With Final Prompt
+
+```text
+POST /api/boards/todos/{todo_id}:request-changes
+```
+
+Request：
+
+```json
+{
+  "feedback": "user feedback",
+  "final_prompt": "user confirmed prompt",
+  "idempotency_key": "request-changes-btodo-123-round-2",
+  "view_workspace_id": "workspace-current-view",
+  "execution_workspace_id": "workspace-exec-existing",
+  "execution_policy": null,
+  "runtime_target_id": "role:main_agent",
+  "queue_if_full": true,
+  "handoff_initiator": "human",
+  "start_policy": "human_required",
+  "yolo": true
+}
+```
+
+Rules：
+
+- `feedback` 作为结构化元数据保存或用于审计。
+- `view_workspace_id` 必须提交，用于审计发起 workspace，并用于识别当前 fork 是否就是该 TODO 的 execution workspace shortcut。
+- `execution_workspace_id` 默认等于 item 已绑定的 execution workspace；从 execution fork 页面发起时可显式提交当前 `view_workspace_id`，后端必须校验它与 item 上的 execution workspace 一致。
+- `final_prompt` 是实际进入 run 的 prompt。
+- `idempotency_key` 用于去重 confirmed Request Changes 请求；human、AI suggested、AI auto 都必须提交稳定 key，避免 retry 创建重复 rework attempt 或 run。
+- `handoff_initiator` 和 `start_policy` 必须随 Request Changes 提交或由服务端从 policy decision snapshot 填充，用于审计和授权。
+- `handoff_initiator=ai_auto` 或 `ai_suggested` 时，`yolo=true` 默认拒绝；只有 workspace/source policy 显式允许 automated rework yolo 时才可提交，并必须写入 audit event。
+- `execution_policy = null` 表示复用 item 已绑定的 `execution_workspace_id`；首版 Request Changes 默认不重新 fork。
+- `request changes` 默认复用已绑定的 `execution_workspace_id`。
+- 如果当前 `view_workspace_id` 已经等于该 TODO 的 `execution_workspace_id`，Request Changes 可以把当前 fork 作为 execution workspace shortcut；否则仍以 item 上的 `execution_workspace_id` 为准。
+- legacy review item 如果缺少 `execution_workspace_id` 但有旧 `session_id`，迁移期只能从旧 session 记录的 workspace 或旧 completed attempt workspace 推导 execution workspace；不能使用当前 fork view 的 `view_workspace_id`。无法证明原执行 workspace 时返回 conflict，要求重新 Start。
+- 如果缺少 `execution_workspace_id` 且不满足 legacy fallback 条件，API 应返回 conflict 并要求重新 Start。
+- `request changes` 默认复用 executor runtime target；换 runtime target 必须显式提交。
+- 并发满且 `queue_if_full=true` 时，item 回到 `in_progress` 并创建 request changes queue ticket。
+- 创建 queue ticket 前必须保存完整 final prompt snapshot/ref，并在 snapshot/ticket 中保存 `yolo`、`handoff_initiator`、`start_policy` 和 yolo authorization source。
+- 如果 `final_prompt` 与 preview 不同，以用户提交为准。
+
+## 模板配置 API 方向
+
+```text
+GET /api/boards/todo-handoff-templates?workspace_id=...
+PUT /api/boards/todo-handoff-templates/workspace/{workspace_id}
+PUT /api/boards/todo-handoff-templates/source/{source_id}
+DELETE /api/boards/todo-handoff-templates/source/{source_id}
+```
+
+`workspace_id` request 参数表示当前页面 `view_workspace_id`；workspace-scope 模板读写前必须解析为 `board_workspace_id`。在 fork workspace 页面编辑 workspace template 时，实际修改 root board workspace template，并在 UI 标明 shared with root workspace。
+
+模板配置字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `scope` | `global`、`workspace`、`source` |
+| `workspace_id` | workspace scope 时需要 |
+| `source_id` | source scope 时需要 |
+| `template_kind` | `start`、`request_changes` 或 `ai_review` |
+| `template` | 模板文本 |
+| `updated_at` | 更新时间 |
+
+global default 可以先由配置文件或内置常量提供，后续再开放 UI 编辑。
+
+## 前端交互
+
+Start editor：
+
+- title：`Start TODO`。
+- textarea：最终 prompt。
+- execution workspace control：默认显示推荐策略 `fork_git_worktree`、fork name suggestion、source workspace。
+- board scope indicator：显示 root board workspace、当前 view workspace；如果是 fork view，提示该 TODO board shared with root workspace。
+- runtime target selector：展示本地 role、外部 agent role 和 orchestration preset。
+- concurrency preview：展示 source workspace 和 runtime target 当前 active/limit，并说明是否会创建 queue ticket。
+- queue control：`queue_if_full`，默认开启。
+- review policy selector：`human_required`、`ai_pre_review`、`ai_auto_done`。
+- reviewer runtime selector：仅启用 AI review 时显示。
+- secondary metadata：template source、source name、repository、execution workspace/branch preview。
+- actions：Cancel、Start。
+- loading state：preview 加载中、start 提交中。
+
+Request changes editor：
+
+- 第一步收集 feedback，或在同一 modal 上方提供 feedback textarea。
+- 根据 feedback 生成 prompt preview。
+- execution workspace control：默认复用当前 TODO 已绑定的 execution workspace。
+- runtime target selector：默认复用 executor runtime target，用户显式切换后重新 preview concurrency/queue 结果。
+- queue control：`queue_if_full`，默认开启。
+- 用户可继续编辑最终 prompt。
+- actions：Cancel、Request changes。
+
+错误处理：
+
+- preview 失败时显示 fallback prompt 或错误信息；用户可以取消。
+- start 失败时保持 modal 内容，避免用户输入丢失。
+- fork 失败时不启动 run，并在 modal 中显示 workspace fork diagnostics。
+- 并发满时如果允许排队，modal 提交后 card 留在 `in_progress` 列，并在详情中展示 active queue ticket。
+- conflict 例如 item 已被其他操作启动时，关闭 modal 并刷新 card。
+
+## 审计和可追踪性
+
+Handoff 层应保留足够诊断信息：
+
+- 使用的 template source。
+- template kind。
+- final prompt 是否由用户编辑过。
+- source id 和 todo id。
+- source workspace id。
+- execution workspace id、branch 和 execution policy。
+- runtime target、handoff initiator、start policy、review policy。
+- queue ticket 和 concurrency decision。
+- prompt snapshot/ref，以及 final prompt 是否已进入 session/run history。
+- 创建的 session/run。
+- 创建或复用的 attempt。
+- comments/events/diagnostics 引用。
+
+不要求保存所有 prompt 历史到 board 表中；实际 prompt 已通过 run/message 持久化进入 session 历史。Board 侧可保存轻量 metadata 供 UI 和诊断使用。
+
+## 测试矩阵
+
+| 场景 | 期望 |
+| --- | --- |
+| source template 存在 | preview 使用 source template |
+| source template 缺失 | fallback 到 workspace template |
+| workspace template 缺失 | fallback 到 global default |
+| 全部模板缺失 | 使用 built-in fallback |
+| GitHub TODO preview | prompt 包含 repo、issue number、URL |
+| manual TODO preview | prompt 不出现空 GitHub 字段造成的脏文本 |
+| 用户编辑 prompt | start 使用 final prompt |
+| final prompt 为空 | API 拒绝 |
+| request changes | prompt 包含 feedback |
+| start API 冲突 | 不创建重复 run |
+| preview 失败 | 前端不直接 start |
+| 代码类 TODO preview | 推荐 `fork_git_worktree` |
+| start 使用 `fork_git_worktree` | 先创建 fork workspace，再创建 session/run |
+| fork 失败 | 不创建 run，TODO 留在 `todo` |
+| 并发启动两个 TODO | 获得两个不同 execution workspaces |
+| request changes | 复用原 execution workspace |
+| legacy review item request changes | 缺少 execution workspace 时 fallback 到 `current_workspace` |
+| prompt preview | 包含 execution workspace 和 branch 变量 |
+| card details | 同时展示 source workspace 与 execution workspace |
+| fork workspace preview | response 包含 `board_workspace_id`、`view_workspace_id`、`is_fork_view` 和 `forked_from_workspace_id` |
+| fork workspace start 新 TODO | 默认仍从 root/source workspace 创建独立 execution workspace |
+| request changes from execution fork | 复用当前 execution workspace |
+| fork view 选择 `current_workspace` | UI 显示该 fork 可能被多个 TODO/run 共享的风险 |
+| structured metadata | Start/Request Changes/AI Review 模板包含 changed_files、verification、created_todos、blocked_reason、retry_notes、residual_risk |
+| AI-created TODO | 必须携带 idempotency key，重复请求返回已有 TODO |
+| TODO-bound worker context | 只能访问当前 TODO 的 context，不能修改其他 TODO |
+| 用户选择 `current_workspace` | 允许启动，但 UI 显示共享工作树风险 |
+| local role runtime target | preview 可选，start 通过 sessions/runs 创建 run |
+| external role runtime target | preview 展示 bound agent 协议和 transport，start 不直接调用外部 runtime |
+| orchestration preset runtime target | start 创建 orchestration session/run |
+| 并发满且 queue_if_full | item 进入 `in_progress` 并创建 queue ticket |
+| 并发满且 queue_if_full | queue ticket 绑定完整 prompt snapshot/ref |
+| 并发满且不允许 queue | API 返回 conflict，item 保持原状态 |
+| AI suggested start | 展示可编辑 prompt/runtime/execution/review 建议 |
+| AI auto start | 自动进入 queue/start，但不绕过并发限制 |
+| AI pre review | AI 通过后仍停在 `review` 等人确认 |
+| AI auto done | AI 通过后可进入 `done` |

--- a/docs/modules/boards/workspace-todo-board-collaboration-design.md
+++ b/docs/modules/boards/workspace-todo-board-collaboration-design.md
@@ -1,0 +1,336 @@
+# Workspace TODO Board Collaboration, Attempts and Diagnostics Design
+
+## 背景
+
+对比 `hermes-agent` Kanban 后，Workspace TODO Board 可以吸收它在 durable audit、run attempts、worker context、diagnostics 和 idempotency 上的经验，但不能照搬它的任务依赖图和状态体系。
+
+Agent Teams 的 TODO Board 是线性任务列表：
+
+- TODO 之间没有 `parent`、`child`、`blocker` 或 `dependent` 调度关系。
+- AI 或人工可以创建新的 TODO，但这些 TODO 是独立工作项，不继承调度依赖。
+- Board 主状态仍是 `todo`、`in_progress`、`review`、`done`、`archived`。
+- UI 展示不新增 `triage`、`ready`、`blocked` 等公共状态。需要表达等待、运行、暂停、review 等信息时，只展示底层事实：queue ticket、run runtime status、review attempt、diagnostics 等。
+
+本设计补充的是 TODO 生命周期周边的协作和审计模型，而不是新的调度模型。
+
+Fork workspace 是 view/execution context，不是独立 TODO board context。由 fork workspace 发起的 comment、attempt、event 或 AI-created TODO 都归属 root `board_workspace_id`；审计字段记录 `initiated_from_workspace_id`，用于说明动作来自哪个 workspace。
+
+## Attempt History
+
+`BoardTodoItem` 是逻辑任务，`BoardTodoAttempt` 是一次执行或 review 尝试。一个 TODO 可以有多次 attempt：
+
+- 第一次 Start。
+- Request changes 后的返工 run。
+- AI review run。
+- AI auto start 创建的执行 run。
+
+### Attempt 类型
+
+| attempt_type | 说明 |
+| --- | --- |
+| `start` | 从 `todo` 发放到 AGENTS 执行 |
+| `request_changes` | 从 `review` 返工 |
+| `ai_review` | executor run 完成后的 AI review |
+
+### Attempt 字段
+
+目标模型：
+
+| 字段 | 说明 |
+| --- | --- |
+| `attempt_id` | attempt id |
+| `todo_id` | 关联 TODO |
+| `board_workspace_id` | TODO board 归属 workspace；fork view 解析到 root workspace |
+| `initiated_from_workspace_id` | 发起该 attempt 的 view workspace，用于审计 |
+| `attempt_type` | `start`、`request_changes`、`ai_review` |
+| `status` | attempt 自身状态，例如 `pending`、`active`、`succeeded`、`failed`、`cancelled` |
+| `source_workspace_id` | TODO 所属 workspace |
+| `execution_workspace_id` | 实际执行 workspace |
+| `execution_policy` | `fork_git_worktree` 或 `current_workspace` |
+| `runtime_target_id` | executor 或 reviewer runtime target |
+| `runtime_target_kind` | `local_role`、`external_role`、`orchestration_preset` |
+| `session_id` | 绑定 session |
+| `run_id` / `executor_run_id` | 绑定 executor run；迁移期可继续使用 `run_id` 字段名 |
+| `review_session_id` | AI review run 所属 session；用于 session deletion callback 定位 reviewer attempt |
+| `review_run_id` | AI review run，不能驱动 executor run 状态映射 |
+| `queue_ticket_id` | 等待并发 slot 时的 ticket |
+| `prompt_ref` | final prompt snapshot 引用 |
+| `summary` | AGENTS 或 AI review 产出的摘要 |
+| `metadata` | structured completion metadata |
+| `error` | 失败原因 |
+| `created_at` / `started_at` / `finished_at` | 时间戳 |
+
+`BoardTodoItem` 只保存当前引用：
+
+- `current_attempt_id`：最近一次 attempt。
+- `active_attempt_id`：当前 active attempt，若没有执行或 review 中的 attempt 则为空。
+- `run_id`/`executor_run_id`：当前 executor run；AI review run 使用 `review_run_id`。
+- `diagnostic_count`：未清理 diagnostics 数量。
+- `idempotency_key`：manual/AI-created TODO 的去重 key。
+
+完整历史通过 attempt 查询展示，不把全部 run history 堆在 item 行上。
+
+### Prior Attempts Context
+
+Start、Request Changes 和 AI Review 的 preview 应能读取 prior attempts，并向模板暴露摘要变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `attempt.current_id` | 当前 attempt id |
+| `attempt.previous_summaries` | 最近若干次 attempt 摘要 |
+| `attempt.previous_errors` | 最近失败原因 |
+| `attempt.last_verification` | 最近一次验证结果 |
+| `attempt.last_changed_files` | 最近一次变更文件摘要 |
+
+Request Changes 必须优先包含 prior attempt 摘要和用户反馈，帮助 AGENTS 避免重复失败路径。
+
+## Structured Completion Metadata
+
+默认 Start、Request Changes 和 AI Review 模板应要求 AGENTS 输出结构化完成信息。该信息进入 attempt metadata，供 review UI、AI review 和后续 retry 使用。
+
+标准字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `changed_files` | 文件变更摘要，允许为空 |
+| `verification` | 执行过的测试、检查或无法验证的原因 |
+| `created_todos` | 新创建的线性 TODO 列表，不表示父子依赖 |
+| `blocked_reason` | 本次 attempt 无法继续的原因，仅作为诊断信息，不引入 `blocked` board 状态 |
+| `retry_notes` | 下次重试应注意的内容 |
+| `residual_risk` | 剩余风险或人工 review 重点 |
+
+`created_todos` 中的每个条目必须支持 `idempotency_key`，避免 AI 重复创建相同 TODO。
+
+## Handoff Prompt Snapshot
+
+Attempt 和 queue ticket 需要引用完整 final prompt snapshot。目标可以新增 `board_todo_handoff_prompts` 表或等价存储，但不能只保存摘要后再依赖尚未创建的 run/message history。
+
+最小字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `prompt_ref` | prompt snapshot id |
+| `todo_id` | 关联 TODO |
+| `attempt_id` | 关联 attempt |
+| `template_source` | source/workspace/global/fallback 或 AI suggested source |
+| `final_prompt_snapshot` | 用户或 AI policy 确认的完整 prompt |
+| `created_at` | 创建时间 |
+
+run 创建成功后，prompt 进入 session history。Board 侧 snapshot 继续用于 queue 恢复、attempt audit 和失败诊断。
+
+## Comments
+
+Board-level comment thread 用于保存 TODO 卡片自己的协作上下文，不替代 session message history。
+
+Comment 来源：
+
+| source | 用途 |
+| --- | --- |
+| `human` | 用户补充说明、review feedback、手工记录 |
+| `agent` | TODO-bound AGENTS 主动报告进度或补充上下文 |
+| `ai_review` | AI review 结论和摘要 |
+| `source_sync` | 外部 source 同步提示 |
+| `system` | 状态机、queue 或 diagnostics 产生的系统说明 |
+
+目标字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `comment_id` | comment id |
+| `todo_id` | 关联 TODO |
+| `board_workspace_id` | TODO board 归属 workspace |
+| `initiated_from_workspace_id` | 可选，comment 从哪个 view workspace 写入 |
+| `source` | comment 来源 |
+| `author_id` | 用户、role、runtime target 或 system |
+| `body` | comment 内容 |
+| `attempt_id` | 可选 attempt 引用 |
+| `run_id` | 可选 run 引用 |
+| `created_at` | 创建时间 |
+
+Request Changes feedback 应同时进入 handoff metadata 和 comment thread，便于 card detail 不打开 session 也能看到返工原因。
+
+## Events
+
+`BoardTodoEvent` 是 append-only audit log。它记录状态变化和重要事实，供 UI timeline、debug 和后续 reconciliation 使用。
+
+事件不替代当前 item 状态；item 状态是可查询 projection，events 是历史。
+
+事件类型：
+
+| event_type | 说明 |
+| --- | --- |
+| `created` | manual 或 AI-created TODO 创建 |
+| `imported` | source sync 导入 |
+| `source_updated` | source record 更新 |
+| `prompt_previewed` | handoff preview 生成 |
+| `queued_for_start` | 并发满，创建 start queue ticket |
+| `queued_for_request_changes` | 并发满，创建 request changes queue ticket |
+| `queue_ticket_claimed` | queue ticket 获得 slot |
+| `workspace_forked` | execution workspace fork 成功 |
+| `run_started` | executor run 创建 |
+| `run_completed` | executor run completed |
+| `run_failed` | executor run failed/stopped/missing |
+| `review_started` | AI review attempt 创建 |
+| `review_completed` | AI review decision 写入 |
+| `done` | TODO 进入 done |
+| `archived` | TODO archived |
+| `restored` | TODO restored |
+| `diagnostic_created` | diagnostic 写入 |
+| `diagnostic_cleared` | diagnostic 清理 |
+
+目标字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `event_id` | event id |
+| `todo_id` | 关联 TODO |
+| `board_workspace_id` | TODO board 归属 workspace |
+| `initiated_from_workspace_id` | 动作发起 workspace；fork 页面操作时记录 fork workspace id |
+| `event_type` | 事件类型 |
+| `actor_type` | `human`、`ai`、`system`、`source`、`runtime` |
+| `actor_id` | actor 引用 |
+| `attempt_id` | 可选 attempt 引用 |
+| `run_id` | 可选 run 引用 |
+| `session_id` | 可选 session 引用 |
+| `source_record_id` | 可选 source record 引用 |
+| `payload` | 小型结构化 payload |
+| `created_at` | 创建时间 |
+
+events 必须按 `created_at` 和单调 event id 稳定排序。list/delta API 可以返回最近 events 摘要；完整 timeline 由 card detail 懒加载。
+
+## Diagnostics
+
+`BoardTodoDiagnostic` 是可恢复的事实提示，不是 board 状态。它用于解释为什么某个 TODO 暂时不能启动、review 或同步，也用于提示用户可采取的动作。
+
+目标字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `diagnostic_id` | diagnostic id |
+| `board_workspace_id` | diagnostic 所属 root board workspace；source/global diagnostics 必填；board scope resolution 失败时可为空 |
+| `initiated_from_workspace_id` | 触发该 diagnostic 的 view workspace，可为空 |
+| `todo_id` | 可为空；source/global diagnostics 可不绑定具体 TODO |
+| `source_id` | 可选 source 引用 |
+| `attempt_id` | 可选 attempt 引用 |
+| `kind` | 诊断类型 |
+| `severity` | `info`、`warning`、`error`、`critical` |
+| `title` | 简短标题 |
+| `detail` | 详细说明 |
+| `suggested_actions` | 可展示动作，例如 re-preview、retry、open settings、choose runtime |
+| `created_at` | 创建时间 |
+| `cleared_at` | 清理时间 |
+
+所有 diagnostics 都必须可查询和清理。正常 source settings、sync 或 board diagnostic 按 `board_workspace_id` 查询；fork view 中产生的诊断仍写入 root `board_workspace_id`，并用 `initiated_from_workspace_id` 记录触发页面。若 board scope resolution 失败导致没有 root `board_workspace_id`，diagnostic 走 `initiated_from_workspace_id` + `kind` 的 view-scoped lookup/clear 路径，不创建 fork-local board。
+
+诊断类型：
+
+| kind | 说明 |
+| --- | --- |
+| `source_sync_failed` | source sync 失败 |
+| `template_render_failed` | 模板渲染失败 |
+| `runtime_target_unavailable` | runtime target 不存在或不可用 |
+| `workspace_fork_failed` | fork git worktree 失败 |
+| `queue_ticket_stale` | queue ticket lease 过期或无法恢复 |
+| `run_missing` | bound run 丢失 |
+| `session_deleted` | bound session 被删除 |
+| `ai_review_failed` | AI review run 失败或输出不可解析 |
+| `duplicate_ai_created_todo` | AI 创建 TODO 被 idempotency 去重 |
+| `continuous_start_failure` | 连续 start/runtime failure 达到阈值 |
+| `board_scope_missing_root` | fork workspace 无法解析到 root board workspace |
+| `board_scope_cycle` | fork ancestry 出现 cycle，无法安全解析 board scope |
+
+Diagnostics 显示在 card detail、source settings 和 start/review modal 中。清理规则由产生方决定，例如 source sync 成功后清理 `source_sync_failed`，用户重新选择 runtime 后清理 `runtime_target_unavailable`。
+
+## Idempotency
+
+去重分三层：
+
+| 场景 | 去重键 |
+| --- | --- |
+| source item | `board_workspace_id/source_workspace_id` + `source_id` + `source_key` |
+| manual/AI-created TODO | `board_workspace_id` + `idempotency_key` |
+| start/request changes/AI review attempt | `todo_id` + `attempt_type` + `idempotency_key` 或 queue ticket id |
+
+规则：
+
+- Source sync 看到同一 source key 时更新现有 TODO，不创建重复 item。
+- `source_provider`、`source_type` 和旧 `source_key` 组合只用于迁移兼容和展示，不再作为目标 source identity。
+- Manual 和 AI-created TODO 的 `idempotency_key` 只在同一个 `board_workspace_id` 内去重；不同 root board workspace 可以安全使用相同业务 key。
+- Manual TODO create 也必须携带稳定 `idempotency_key`；人工创建请求 timeout/retry 时返回已有 TODO 引用，不创建重复 manual item。
+- AI-created TODO 必须携带 `idempotency_key`；同一 `board_workspace_id` 内重复创建返回已有 TODO 引用，并写 `duplicate_ai_created_todo` 诊断或 event。
+- AI auto start 必须有 idempotency key，重复请求不能创建重复 queue ticket 或 run。
+- Automation import 也必须携带 idempotency key。
+
+在目标模型中，source item 去重应按 `board_workspace_id/source_workspace_id + source_id + source_key` 计算。`workspace_id` 旧字段只作为迁移期兼容，不应让 fork view 产生一套新的 source item identity。
+
+## TODO-bound Worker Context
+
+TODO-bound session/run 可以获得一个最小 board 工具集，但工具只在该上下文中暴露，不污染普通 session。
+
+目标工具语义：
+
+| tool | 说明 |
+| --- | --- |
+| `board_todo_show` | 读取当前 TODO、root board source context、execution workspace、prior attempts、comments 和 diagnostics |
+| `board_todo_comment` | 向当前 TODO comment thread 写 comment |
+| `board_todo_create` | 创建新的线性 TODO，必须携带 idempotency key |
+| `board_todo_report_progress` | 写轻量进度 comment 或 event，不改变 board 主状态 |
+
+边界：
+
+- 工具必须校验当前 session/run 绑定的 `todo_id`。
+- TODO-bound worker 默认只能操作当前 TODO。
+- 工具读取 root board context；涉及文件修改、验证和路径时仍指向 execution workspace。
+- `board_todo_create` 创建的是独立线性 TODO，不创建依赖关系。
+- 不提供 worker 直接 `done` 当前 TODO 的默认工具；完成仍由 run terminal、AI review、用户确认或 completion evidence 驱动。
+
+## 前端展示
+
+Card detail drawer 应展示：
+
+- 当前 board status。
+- queue ticket 事实，例如是否等待 slot、排队时间、queue kind。
+- 当前 run runtime status。
+- review policy、review state 和 AI review decision。
+- source workspace、execution workspace 和 branch。
+- board workspace、当前 view workspace；fork view 中要提示 TODO board shared with root workspace。
+- attempt history。
+- comments。
+- events。
+- diagnostics。
+
+主卡片展示应尽量使用具体事实文案，不引入独立状态体系。例如：
+
+- `Waiting for runtime slot` 来自 active queue ticket。
+- `Run paused` 来自 `RunRuntimeStatus=paused`。
+- `AI review pending` 来自 review attempt 或 review state。
+- `Needs attention` 来自未清理 error/critical diagnostic。
+
+这些文案是派生展示，不是 board domain 的新增状态。
+
+## 测试矩阵
+
+| 场景 | 期望 |
+| --- | --- |
+| Start 成功 | 创建 `start` attempt，绑定 run/session/runtime/execution workspace |
+| Request changes 成功 | 创建 `request_changes` attempt，并可读取 prior attempts |
+| AI review | 创建 `ai_review` attempt，记录 decision 和 summary |
+| run failed | attempt 记录 failed/error，event 写入 `run_failed` |
+| 用户反馈 | 同时保存 handoff feedback metadata 和 comment |
+| AI-created TODO | 使用 idempotency key 去重 |
+| duplicate AI create | 返回已有 TODO，写 event 或 diagnostic |
+| source sync 失败 | 写 source diagnostic，不影响 manual TODO |
+| fork 失败 | 写 attempt error、event、diagnostic，不创建 run |
+| queue ticket stale | 释放 ticket，写 diagnostic |
+| TODO-bound tool 操作其他 TODO | 拒绝并记录诊断上下文 |
+| card detail | 能展示 attempt、comment、event、diagnostic、source workspace、execution workspace |
+| fork 页面 manual/AI create TODO | TODO 归属 root board，event 记录 fork 为 initiator |
+| fork 页面 comment | comment 写入 root board TODO thread，metadata 记录 fork workspace |
+| TODO-bound worker context in fork execution workspace | 读取 root board context，但 execution path 指向 execution workspace |
+
+## 非目标
+
+- 不设计 TODO dependency graph。
+- 不设计 `triage`、`ready`、`blocked` 等 Hermes Kanban 状态。
+- 不让 comments/events 成为外部 tracker 的 source of truth。
+- 不让 Boards 模块直接执行 ACP/A2A/CLI runtime。

--- a/docs/modules/boards/workspace-todo-board-design.md
+++ b/docs/modules/boards/workspace-todo-board-design.md
@@ -1,192 +1,50 @@
 # Workspace TODO Board Design
 
-## Purpose
+本文档是 Workspace TODO Board 设计文档索引。详细设计已拆分到多个文件，避免单一文档继续承载产品目标、数据来源、状态机、AGENTS 交付和模块结构等不同层面的内容。
 
-Workspace TODO Board is the Agent Teams-owned kanban for workspace work items. It
-uses external systems only as sources of truth for evidence, not for board column
-state. In v1, GitHub issues are imported as TODO items. Pull requests are linked
-to review items and are used as evidence for completion.
+当前阶段只定义目标设计，不表示所有 API、数据库表或前端交互已经实现。实现阶段如果修改公共 API 或持久化结构，必须同步更新 `docs/core/api-design.md` 和 `docs/core/database-schema.md`。
 
-The feature is owned by the `boards` domain. It is intentionally separate from
-the connector overview: connectors report availability and health, while boards
-own TODO persistence, session binding, status transitions, and archive semantics.
+## 文档入口
 
-## User Experience
+- [整体设计](workspace-todo-board-overview.md)
+  - 说明 TODO 看板的产品目标、核心概念、系统边界和端到端用户流程。
+  - 给出从 source sync 到 AGENTS handoff、session/run、review/done 的完整流程。
 
-The frontend exposes a dedicated `Boards` feature page alongside Skills,
-Automation, and Connectors. The main board shows four workflow columns:
+- [数据来源设计](workspace-todo-board-source-design.md)
+  - 说明 source 配置模型、GitHub 显式配置、自动探测 fallback、多 source 同步和未来扩展方式。
+  - 定义 `source_id` 目标 identity、legacy provider/type/key 兼容边界，以及旧 `TaskBoardAdapter` 可复用逻辑迁移后删除的方向。
 
-- `todo`
-- `in_progress`
-- `review`
-- `done`
+- [状态机设计](workspace-todo-board-state-machine.md)
+  - 定义 board 状态、run runtime 状态、session 删除、PR merged、issue closed/reopened、archive/restore 之间的关系。
+  - 包含状态表、事件表和 Mermaid 状态图。
 
-`archived` is a separate view. Archived items can be restored to `todo`; restore
-does not recover the pre-archive status because that would bypass the
-session/PR-driven state machine.
+- [AGENTS 交付设计](workspace-todo-board-agent-handoff.md)
+  - 说明用户点击 Start 后如何先编辑 prompt，再确认交给 AGENTS 执行。
+  - 定义模板优先级、模板变量、preview API、start API 和 request changes 语义。
 
-Each card shows source, title, repository, session, linked PR, source update
-time, and actions. GitHub issue cards use GitHub issue `updated_at`; manual TODOs
-fall back to the local board row update time. Details open in a modal with the
-full body, issue URL, linked PR URL, session/run ids, source update time, board
-update time, and status reason. The card also has a direct source-link action for
-the GitHub issue. Source links are icon-only external links. The details modal
-paginates long bodies by paragraph so large issue descriptions remain readable
-without losing the metadata context.
+- [执行 Runtime、AI 发放和并发设计](workspace-todo-board-execution-runtime-design.md)
+  - 说明 TODO handoff 如何绑定本地 role、外部 agent runtime 或 orchestration preset。
+  - 定义 AI start、AI review、AI auto done、queue ticket、attempt phase 和 Workspace+Runtime 并发限制。
 
-Each column has its own client-side search and sort controls. Search matches the
-title, body, repository, issue/PR numbers, and session id. Sort modes are newest,
-oldest, title A-Z, and title Z-A. Time sort uses `source_updated_at || updated_at`
-so GitHub issue ordering follows issue activity rather than the time Agent Teams
-persisted the row. These controls are view state only; they do not change board
-persistence or revision.
+- [协作审计、Attempt 和诊断设计](workspace-todo-board-collaboration-design.md)
+  - 说明 TODO 的 attempt/run history、comments/events、structured completion metadata、diagnostics、idempotency 和 TODO-bound worker context。
+  - 明确 TODO 是线性列表，不引入 parent/child dependency graph，也不照搬 Hermes Kanban 的 `triage`、`ready`、`blocked` 等状态体系。
 
-Small screens keep the kanban interaction instead of collapsing the workflow
-into a single list. The board uses horizontal snap columns, compact spacing, a
-stacked toolbar, fixed column headers, independently scrolling card lists, and a
-near-fullscreen details modal.
+- [模块目录结构设计](workspace-todo-board-module-layout.md)
+  - 规划 `src/relay_teams/boards/` 的目标目录结构、职责拆分、依赖方向和迁移策略。
+  - 明确旧空 API 与旧 dispatcher 语义的迁移边界。
 
-## State Machine
+## 设计原则
 
-The board status is owned by Agent Teams:
-
-- `todo`: new manual item or imported GitHub issue.
-- `in_progress`: a user starts processing; the backend creates a dedicated
-  session/run and stores `session_id/run_id`.
-- `review`: the bound run completes.
-- `done`: the item has a linked PR and the PR is merged.
-- `archived`: soft delete; hidden from the main board.
-
-GitHub PRs are not TODO cards. During sync/reconcile, review GitHub issue items
-may query issue timeline events to discover linked PRs. A merged linked PR moves
-the issue TODO to `done`.
-
-If a bound session is deleted, active board items cannot remain in
-`in_progress` or `review` with a dead session reference. Non-archived,
-non-`done` items bound to the deleted session return to `todo`, clear
-`session_id/run_id`, and record `Bound session deleted`. `done` items keep their
-status but clear the stale session reference.
-
-## API
-
-Full board APIs remain available for cold start and compatibility:
-
-- `GET /api/boards/todos`
-- `POST /api/boards/todos:sync`
-
-Incremental APIs support cached frontend views:
-
-- `GET /api/boards/todos:changes`
-- `POST /api/boards/todos:sync-changes`
-
-Delta requests include `workspace_id`, `include_archived`, and
-`after_revision`. Sync delta also accepts `force_full`. Delta responses include
-changed items, removed active-view ids, status counts, diagnostics, synced time,
-and the latest workspace revision.
-
-Mutation APIs return the changed item so the frontend can update local cache
-without reloading the whole board:
-
-- `POST /api/boards/todos`
-- `POST /api/boards/todos/{todo_id}:start`
-- `POST /api/boards/todos/{todo_id}:request-changes`
-- `POST /api/boards/todos/{todo_id}:archive`
-- `POST /api/boards/todos/{todo_id}:restore`
-- `POST /api/boards/todos/{todo_id}:link-pr`
-
-## Persistence
-
-`board_todo_items` stores the item state and source references. Each row has an
-`item_revision`. `updated_at` is the Agent Teams row update time, while
-`source_updated_at` is the external source update time used for board sorting.
-`board_todo_workspace_state` stores the current workspace revision and the
-GitHub issue sync cursor.
-
-Every write that changes an item increments the workspace revision and writes
-that value into the item row. Delta queries return rows with
-`item_revision > after_revision`. In active view, archived rows are returned as
-`removed_todo_ids` so the frontend can remove them from the main board.
-
-The GitHub issue cursor is per workspace/repository. A repository change resets
-incremental behavior by ignoring the old cursor.
-
-## Sync Behavior
-
-Sync resolves the workspace Git remote to `owner/repo`, then obtains a GitHub
-token from enabled trigger accounts or the shared GitHub token.
-
-Full sync fetches all open issues and treats that open issue number set as the
-authoritative active TODO set. Incremental sync fetches all issues changed since
-the stored cursor so recent close/reopen events can be reconciled. Pull request
-refresh uses the same cursor during incremental sync and only full sync scans
-all PRs. After a successful sync, the cursor is advanced to the sync time.
-
-GitHub `/issues` responses that contain a `pull_request` object are ignored as
-TODO sources. Closed issues are not imported as new TODO items. If an existing
-active issue item is later observed as closed, sync moves it to `done` only when
-its linked PR is merged; otherwise it is soft-archived with status reason
-`GitHub issue closed`. Pull requests are still listed so linked PR merge state
-can be reconciled for review items.
-
-The frontend uses a versioned localStorage cache. A cache-version bump forces a
-new cold start. The first board load for each workspace in a browser session
-shows cache immediately and may perform a sync in the background only when the
-workspace has not auto-synced in the last hour. Manual `Sync GitHub` is always a
-deliberate full reconciliation so stale closed issues are removed from the active
-board. If a full reconciliation does not see a previously active GitHub issue in
-the open issue set, that item is archived as
-`GitHub issue no longer open`.
-
-If GitHub later reports the same issue as open again, sync restores only items
-that were archived by GitHub closed/non-open reconciliation back to `todo`.
-Items manually archived by a user remain archived until the user explicitly
-restores them.
-
-## Frontend Cache And Progressive Loading
-
-The frontend cache is keyed by `workspace_id + include_archived`. Each cached
-board stores the latest revision. On mount or workspace switch:
-
-- Cached data renders immediately.
-- A delta request refreshes in the background.
-- Without cache, the page shows column skeletons.
-- When full data arrives, cards are rendered in batches to create visible
-  progress instead of a single long blocking update.
-
-Column headers, counts, search, and sort controls do not scroll with the card
-list. Only the cards inside each column have vertical scrolling.
-
-Mutation results are merged into active and archived caches immediately. A
-background delta refresh follows to reconcile any lifecycle updates. Archived
-items are never reactivated by sync unless they were auto-archived because a
-GitHub issue was closed or no longer open and GitHub later reports that issue as
-open again.
-
-Progressive loading animates only cards that first enter the DOM. Cached boards
-render without entrance animation, and non-data interactions such as opening
-details or source links do not re-render the columns. This avoids the impression
-that the whole board is refreshing for every click.
-
-## Failure Modes
-
-If workspace Git remote resolution fails, the board still loads local/manual
-items and returns diagnostics.
-
-If GitHub token resolution or sync fails, cached/local data remains usable and
-diagnostics are displayed. GitHub sync diagnostics must always include a
-non-empty message; API failures include the status code when available. Archived
-items are never reactivated by sync.
-
-If a delta is requested without a usable cache, the frontend falls back to the
-full board endpoint.
-
-## Test Strategy
-
-Backend unit tests cover workspace independence, revision/delta behavior,
-archive/remove semantics, restore, incremental GitHub cursor use, issue-only
-sync, closed issue filtering, review PR linking, merged PR completion, session
-delete recovery, and historical PR TODO archival.
-
-Frontend checks cover cache-first rendering, delta merge, progressive loading,
-workspace/view switch cancellation, per-column search/sort, detail pagination,
-restore from archive, and responsive layout.
+- Board column state 由 Agent Teams 拥有，外部系统只提供 source record 和 completion evidence。
+- TODO source 必须可配置；GitHub 自动探测只能作为默认建议，不能是唯一入口。
+- TODO source 目标 identity 使用 `source_id + source_key`；`source_provider/source_type/source_key` 旧三元组只用于迁移兼容和展示。
+- TODO board 的持久化归属由 `board_workspace_id` 决定；普通 workspace 的 `view_workspace_id` 与 `board_workspace_id` 相同，`git_worktree` fork workspace 只作为 view/execution workspace，共享最终 root workspace 的同一套 TODO board。
+- AGENTS handoff 必须由用户确认最终 prompt 后触发，后端不再隐式拼装不可见提示词。
+- AI 发放也必须走同一条 handoff preview/final prompt/start 管线，不能绕过模板、runtime target、execution workspace 或并发限制。
+- 状态机必须以 session/run 生命周期为一等输入，避免卡片状态和实际执行状态分裂。
+- linked PR merged 只自动完成已经处于 `review` 的 item；`todo` 或 `in_progress` item 只记录 evidence。
+- 排队 handoff 必须保存完整 final prompt snapshot/ref，摘要不能作为后续 run 创建输入。
+- `in_progress` 表示“已发放或处理中”；卡片展示从 queue ticket、attempt phase、run runtime status、review policy/state 和 diagnostics 等事实派生，不新增一套 Hermes 式公共子标签体系。
+- TODO 来源是线性的；AI 或人工可以创建新的 TODO，但新 TODO 与原 TODO 不形成调度依赖。
+- Boards 模块只拥有 TODO board 和 tracker/source 集成，不拥有 run-local todo 工具状态，也不绕过 sessions/runs 的生命周期边界。

--- a/docs/modules/boards/workspace-todo-board-execution-runtime-design.md
+++ b/docs/modules/boards/workspace-todo-board-execution-runtime-design.md
@@ -1,0 +1,629 @@
+# Workspace TODO Board Execution Runtime Design
+
+## 背景
+
+TODO Board 的 Start 不应只被理解为“创建一个 run”。随着 AI 发放、AI review、fork git worktree 隔离和外部 agent runtime 引入，TODO 从 `todo` 进入 `in_progress` 需要先完成一组执行编排决策：
+
+1. 谁发放任务：用户确认、AI 建议后用户确认，还是 AI 自动发放。
+2. 在哪里执行：当前 workspace，还是独立 fork git worktree。
+3. 由哪个 runtime 执行：Agent Teams 本地 role、绑定外部 agent 的 role，还是 orchestration preset。
+4. 是否允许排队：并发上限满时是否进入 `in_progress` 并创建 queue ticket。
+5. 如何 review：人 review、AI 预 review 后人确认，还是 AI review 通过后自动 done。
+
+当前项目已经有独立的 agent runtime 体系。设计上 TODO Board 不直接调用 ACP、A2A、CLI 或本地 provider，而是通过现有 sessions/runs 和 role/runtime 配置执行：
+
+- `RoleDefinition.bound_agent_id = null`：该 role 使用 Agent Teams 本地 provider/runtime。
+- `RoleDefinition.bound_agent_id = "<agent>"`：该 role 通过已配置的 external agent runtime 执行，底层协议可以是 `acp`、`a2a` 或 `cli`。
+- `RunRuntimeRepository` 统一记录 run runtime 状态：`queued`、`running`、`paused`、`stopping`、`stopped`、`completed`、`failed`。
+
+因此 Boards 模块只保存 runtime target 选择、queue ticket、attempt history 和 execution references，不新增另一套 agent runtime 调度器。
+
+## 设计原则
+
+- TODO Board 不直接实现 ACP/A2A/CLI 调度，只选择 runtime target 并调用 sessions/runs。
+- 并发、queue 和 source scope 以解析后的 `board_workspace_id/source_workspace_id` 为准；`view_workspace_id` 只是用户当前页面上下文，fork view 不拆出独立并发池。
+- `in_progress` 表示“已发放或处理中”，不再等同于“run 已创建”。
+- 卡片细节从 queue ticket、attempt phase、run runtime status、review state 和 diagnostics 派生，不新增 Hermes 式公共子标签体系。
+- 并发限制使用 Workspace+Runtime 双口径，避免同一 workspace 被过多任务同时改动，也避免单个外部 runtime 被过度占用。
+- AI 发放必须走和用户发放相同的 preview/render/final prompt/start 管线。
+- AI review 是 review 阶段的一种执行动作，不改变 Board status owner；最终 `done` 仍由 board lifecycle transition 写入。
+
+## Runtime Target
+
+`RuntimeTarget` 是 TODO Board 面向用户和 AI 的执行选择模型。它不是低层 provider 配置，也不是直接的 external agent config。
+
+| Kind | 含义 | 映射到现有项目 |
+| --- | --- | --- |
+| `local_role` | 使用 Agent Teams 本地 runtime 的 role | `RoleDefinition.bound_agent_id = null` |
+| `external_role` | 使用外部 agent runtime 的 role | `RoleDefinition.bound_agent_id` 指向 `agents.json` 中的 agent |
+| `orchestration_preset` | 使用 orchestration preset 执行 | `SessionMode.ORCHESTRATION` + `orchestration_preset_id` |
+
+### Runtime Target 字段
+
+目标模型：
+
+| 字段 | 说明 |
+| --- | --- |
+| `runtime_target_id` | 稳定 target id，例如 `role:main_agent`、`role:codex_external`、`preset:feature_work` |
+| `runtime_target_kind` | `local_role`、`external_role`、`orchestration_preset` |
+| `display_name` | UI 展示名 |
+| `role_id` | role target 时使用 |
+| `orchestration_preset_id` | orchestration target 时使用 |
+| `bound_agent_id` | external role 时展示和诊断使用 |
+| `external_protocol` | `acp`、`a2a`、`cli`，仅 external role 有值 |
+| `external_transport` | `stdio`、`streamable_http`、`custom`，仅 external role 有值 |
+| `capabilities` | 是否支持代码修改、是否支持长任务、是否建议隔离执行等 |
+| `enabled` | 当前是否可选 |
+| `diagnostics` | 不可用原因，例如 role 不存在、外部 agent 未配置、secret 缺失 |
+
+### Runtime Target 来源
+
+`RuntimeTargetService` 从现有配置生成可选项：
+
+- role registry：读取 primary roles、normal mode roles 和用户可见 roles。
+- external agent config：通过 role 的 `bound_agent_id` 展示 runtime 协议和 transport。
+- orchestration settings：读取可用 orchestration preset。
+- workspace/source 配置：过滤 allowed targets，并给出默认 target。
+
+Boards 模块不读取外部 runtime secret，也不直接启动外部 agent process。
+
+## Handoff Initiator 和 Start Policy
+
+任务发放有两个维度：谁提出、是否需要人确认。
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `handoff_initiator` | `human` | 用户点击 Start 或 Request Changes |
+| `handoff_initiator` | `ai_suggested` | AI 建议发放，等待用户确认 |
+| `handoff_initiator` | `ai_auto` | AI 根据策略自动发放 |
+| `start_policy` | `human_required` | 必须用户确认 final prompt 后启动 |
+| `start_policy` | `ai_suggest_then_confirm` | AI 生成建议和 prompt，用户确认后启动 |
+| `start_policy` | `ai_auto_start` | AI 可自动确认 final prompt 并进入 queue/start |
+
+AI 发放规则：
+
+- AI 只能选择 source/workspace policy 允许的 runtime target。
+- AI 自动发放仍必须生成可审计的 `final_prompt`。
+- AI 自动发放不能跳过 execution policy、concurrency policy 或 fork workspace 策略。
+- 如果并发已满，AI 自动发放默认 `queue_if_full = true`，进入 `in_progress` 并创建 queue ticket。
+- 如果 preview/render 失败，AI 不得直接拼接临时 prompt 启动，应记录 diagnostics 并保持 item 在 `todo`。
+
+## Execution Facts and Attempt Phase
+
+Board status 仍只有 `todo`、`in_progress`、`review`、`done`、`archived`。Boards 不定义对外公共的 `queued`、`preparing_workspace`、`running`、`paused`、`ai_reviewing` 子状态。细节展示由以下事实派生：
+
+| 事实 | Board status | 含义 | 是否占 active slot |
+| --- | --- | --- | --- |
+| active queue ticket exists | `in_progress` | 已发放但等待并发 slot | 否 |
+| attempt claimed slot, no run yet | `in_progress` | 正在 fork 或解析 execution workspace，或正在创建 session/run | 是 |
+| `RunRuntimeStatus=queued/running/paused/stopping` | `in_progress` | run 已创建，展示来自 run runtime | 是 |
+| AI review queue ticket exists | `review` | AI review 已请求但等待 reviewer runtime slot | 否 |
+| AI review attempt claimed slot or review run active | `review` | AI review 已获得 reviewer slot，或 review run 处于 `queued/running/paused/stopping` | 占 reviewer slot |
+| unresolved diagnostics exists | any non-archived status | 有需要关注的失败或警告 | 否 |
+
+实现阶段可以在 `BoardTodoAttempt` 上保存内部 `attempt_phase`，例如 `waiting_for_slot`、`preparing_workspace`、`starting_run`、`waiting_for_review_runtime`。这些值只用于恢复、诊断和 UI 文案派生，不是新的 board 状态，也不是 source adapter 需要理解的状态。
+
+`waiting_for_review_runtime` 和普通 queue ticket 一样只是等待事实，不占 reviewer runtime active slot；只有 claim 成功后的 AI review attempt 或已创建的 review run 才计入 reviewer runtime active 数。
+
+## 并发策略
+
+### 限制口径
+
+首版采用 Workspace+Runtime 双口径：
+
+| Scope | 默认值 | 说明 |
+| --- | --- | --- |
+| `max_active_per_source_workspace` | `2` | 同一个 `board_workspace_id/source_workspace_id` 同时 active 的 TODO 数；fork view workspace 不单独计算 |
+| `max_active_per_runtime_target` | `1` | 同一个 runtime concurrency key 同时 active 的 TODO 数 |
+
+Runtime concurrency key 不是永远等于 UI 选择的 `runtime_target_id`：
+
+- `local_role` 使用 Agent Teams 本地 provider/runtime key，通常可由 role id 加 workspace provider 配置派生。
+- `external_role` 必须使用底层 `RoleDefinition.bound_agent_id` 或外部 runtime identity 作为 concurrency key；两个 role 绑定到同一个 external agent 时共享同一个 slot 池。
+- `orchestration_preset` 使用 preset id 作为 orchestration-level key，并在内部为每个实际 role/runtime target 再检查对应的 runtime key。
+
+配置优先级：
+
+1. runtime target override。
+2. source override。
+3. workspace override。
+4. global default。
+
+低层覆盖高层。没有配置时使用上面的保守默认值。
+
+### Active Slot 计算
+
+占用 active slot 的事实：
+
+- attempt 已 claim slot，正在准备 execution workspace。
+- attempt 已 claim slot，正在创建 session/run。
+- `RunRuntimeStatus = queued`
+- `RunRuntimeStatus = running`
+- `RunRuntimeStatus = paused`
+- `RunRuntimeStatus = stopping`
+
+不占用 active slot 的事实：
+
+- 仅有 active queue ticket，尚未 claim slot。
+- `review` 且没有 AI review run。
+- `done`
+- `todo`
+- `archived` 且没有 non-terminal executor run
+- terminal failed/stopped/missing 且已经完成 reconcile。
+
+如果 item 已 archived 但仍有 executor run 处于 `queued/running/paused/stopping`，该 run 继续占用 workspace/runtime active slot，直到 stop/cancel 后进入 terminal 并完成 reconcile。
+
+AI review 使用 reviewer runtime target 的并发 slot，不继续占用 executor runtime target slot。这样执行完成的任务不会因为等待 AI review 阻塞后续实现任务。
+
+### Queue Ticket
+
+当 Start、Request Changes 或 AI Review 被确认，但对应并发口径已满：
+
+1. Start/Request Changes 让 board item 进入 `in_progress`；AI Review 让 item 保持 `review` 并设置 review queue state。
+2. 创建 `BoardTodoAttempt`。
+3. 在同一事务中先保存完整 final prompt 的持久化 snapshot/ref，再创建 queue ticket 并写入 `queue_ticket_id`。
+4. queue ticket 必须在对外可见前已经持有可用 `prompt_ref` / `handoff_snapshot_ref`；摘要 metadata 只能用于展示和审计，不能作为后续执行输入。
+5. 不创建 session/run，不 fork workspace。
+
+slot 可用后，`queue_kind=start` / `queue_kind=request_changes` 走 executor 分支：
+
+1. `ExecutionQueueService` 选择下一个 ticket。
+2. 重新验证 snapshot 中的 executor runtime target 仍存在、可用、allowed，且其 normalized runtime concurrency key 与用户确认时的语义一致；若 unavailable/rebound，ticket failed，item 恢复原状态并写 diagnostic。
+3. 原子抢占 `board_workspace_id/source_workspace_id` slot 和 normalized runtime concurrency key slot，而不是按 UI `runtime_target_id` 直接计数。
+4. claim queue ticket，写入 `claim_token`、`claim_expires_at`、`claimed_by`。
+5. 通过 prompt snapshot/ref 读取完整 final prompt。
+6. 根据 `execution_policy` 创建或复用 execution workspace；如果 fork 已创建，必须立即把 `execution_workspace_id` 持久化到 ticket/attempt。
+7. 写入 run creation idempotency key 或 pre-bind reservation，再创建 session/run；重试时先按该 key 查找已有 run。
+8. run 创建并绑定成功后，原子标记 ticket 为 `completed`，清理 item 上的 `queue_ticket_id`，再由 `RunRuntimeStatus` 驱动卡片展示。
+
+`queue_kind=ai_review` 走 reviewer-only 分支：
+
+1. `ExecutionQueueService` 只抢占 reviewer runtime concurrency key，不抢占 `board_workspace_id/source_workspace_id` executor slot。
+2. claim AI review ticket，读取 review prompt snapshot 和既有 execution context。
+3. 不创建或 fork execution workspace；AI review 使用已完成 executor attempt 的 workspace/session/run summary 作为 review context。
+4. 创建 review run 后，标记 AI review ticket `completed`，清理 review queue 引用，后续由 `review_run_id` 和 review decision 驱动。
+
+如果 fork 或 run 创建失败：
+
+- item 恢复到该 queue ticket 创建前的原 board status：Start 回到 `todo`，Request Changes 回到 `review`。
+- Request Changes 失败恢复到 `review` 时，必须重新绑定或可查询到上一轮 completed executor attempt 的 session/run context；如果 item 当前引用已清空，则 card detail 和下一次 request changes 从 attempt history 中读取 prior review context。
+- 清理 queue ticket 和 active slot。
+- attempt 标记为 failed。
+- 保留 `last_status_reason`、event 和 diagnostics。
+- 不创建半绑定 session/run。
+
+### Handoff Prompt Snapshot
+
+排队 handoff 必须保存完整 final prompt snapshot，因为 queue ticket 创建时还没有 run/message history 可依赖。目标可以新增 `board_todo_handoff_prompts` 表，或使用等价的 prompt snapshot 存储，但至少需要以下字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `prompt_ref` | prompt snapshot id，供 attempt 和 queue ticket 引用 |
+| `todo_id` | 关联 TODO |
+| `attempt_id` | 关联 start、request changes 或 AI review attempt |
+| `template_source` | source/workspace/global/fallback 或 AI suggested source |
+| `final_prompt_snapshot` | 用户或 AI policy 最终确认的完整 prompt |
+| `created_at` | snapshot 创建时间 |
+
+run 创建成功后，完整 prompt 仍会进入 session/run message history。Board 侧 prompt snapshot 用于 queue 恢复、审计和失败诊断；可以在后续清理策略中压缩或保留摘要，但不能在 run 创建前只保存摘要。
+
+### Queue Lease 和恢复
+
+Queue ticket 需要 lease/claim 语义，避免 queue worker 或服务进程崩溃后永久占用 slot。
+
+目标字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `queue_ticket_id` | ticket id |
+| `todo_id` | 关联 TODO |
+| `attempt_id` | 关联 attempt |
+| `queue_kind` | `start`、`request_changes`、`ai_review` |
+| `board_workspace_id` | queue 所属 root board workspace |
+| `source_workspace_id` | source workspace |
+| `view_workspace_id` | 创建 ticket 时的当前页面 workspace，用于审计和 UI 说明 |
+| `execution_workspace_id` | 已准备好的 execution workspace；pending ticket 可为空 |
+| `prompt_ref` | final prompt snapshot id；Start、Request Changes、AI Review queue worker 必须从这里读取执行 prompt |
+| `handoff_snapshot_ref` | runtime/execution/review choices snapshot id，可与 `prompt_ref` 合并实现 |
+| `execution_policy` | confirmed execution policy，至少支持 `fork_git_worktree`、`current_workspace` |
+| `fork_name` | 用户确认的 fork 名称；只在 `fork_git_worktree` 时使用 |
+| `start_ref` | 用户确认的 fork 起点；只在 `fork_git_worktree` 时使用 |
+| `runtime_target_id` | executor 或 reviewer runtime target |
+| `queued_at` | 入队时间 |
+| `claim_token` | 抢占 token |
+| `claim_expires_at` | claim lease 过期时间 |
+| `claimed_by` | queue worker 或 service instance |
+| `status` | `pending`、`claimed`、`completed`、`failed`、`cancelled` |
+| `failure_count` | queue/start 失败次数 |
+
+恢复规则：
+
+- `pending` ticket 不占 active slot。
+- `claimed` ticket 在 `claim_expires_at` 前占 active slot。
+- `claimed` ticket 过期且尚未创建 run 时，释放 slot 并回到 `pending`，写 `queue_ticket_stale` diagnostic。
+- 如果过期前已经创建 `execution_workspace_id` 但尚未创建 run，恢复流程必须复用 ticket 上持久化的 execution workspace，或显式取消 ticket 并交给 workspace 删除流程清理该 fork；不得静默再创建第二个 fork。
+- 如果 session/run 创建调用可能已经成功但 ticket 还未绑定，恢复流程必须用 run creation idempotency key 查找并绑定已有 run；找不到时才允许重试创建。
+- 已创建 run 的 ticket 由 run runtime lifecycle 接管，不再靠 queue lease 判断执行状态。
+- session deleted、run missing 或 fork failed 必须释放 slot 并更新 attempt/event/diagnostic。
+
+### Max Runtime 和连续失败
+
+TODO execution policy 可以包含 `max_runtime_seconds`，用于限制自动发放或长任务占用 runtime slot 的时间。
+
+规则：
+
+- 超时检测不直接 kill 外部 runtime；它通过现有 run/session 控制路径请求停止。
+- 停止后 attempt 标记为 failed 或 timed out，slot 释放。
+- item 根据状态机回到 `todo` 或停在 `review` 等待人工处理。
+- 连续 start/runtime failure 达到阈值后，不新增 `blocked` board 状态，只写 `continuous_start_failure` diagnostic，并阻止 AI auto start 继续重试，直到用户清理诊断或手动重新发放。
+
+### Queue Ordering
+
+首版排序规则：
+
+1. 用户手动确认优先于 AI 自动发放。
+2. 同一优先级按 `queued_at` FIFO。
+3. 同一 source workspace 内不得因为 runtime target 不同而绕过 workspace 上限。
+4. 同一 runtime target 内不得因为 source workspace 不同而绕过 runtime 上限。
+
+后续可以增加 priority、deadline 或 source-specific ordering，但 v1 不需要。
+
+## Execution Workspace 关系
+
+Execution workspace 策略继承 handoff 设计：
+
+| Policy | 说明 |
+| --- | --- |
+| `fork_git_worktree` | 获得 active slot 后调用 workspace fork 能力创建 `git_worktree` workspace |
+| `current_workspace` | 直接在当前 `view_workspace_id` 中创建 session/run；普通 root view 通常等于 source workspace，fork view 下必须是用户显式选择并确认风险后的当前 fork workspace |
+
+`git_worktree` fork workspace 是 execution workspace 或 view workspace，不拥有独立 TODO board。Queue worker 在创建或复用 execution workspace 前必须使用 ticket 上的 `board_workspace_id` 和 `source_workspace_id` 读取 board/source context，不能因为 ticket 来自 fork view 就读取 fork-local source、cursor 或 board item。
+
+因此，`current_workspace` 只影响 execution context，不改变 board/source context。即使 run 创建在 fork view workspace 中，item、source config、cursor、queue scope 仍归属解析后的 `board_workspace_id/source_workspace_id`。
+
+重要顺序：
+
+```text
+confirm handoff
+-> enter in_progress with queue ticket when no slot
+-> acquire slot
+-> prepare execution workspace
+-> create session/run
+-> run runtime lifecycle
+```
+
+这意味着排队中的 TODO 不提前 fork worktree，避免大量 queued item 占用磁盘和分支资源。
+
+Board item 目标字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `board_workspace_id` | TODO board 归属 workspace；fork view 解析到 root workspace |
+| `source_workspace_id` | TODO 所属原 workspace |
+| `view_workspace_id` | 当前操作发起 workspace；主要写入 attempt/event metadata |
+| `execution_workspace_id` | AGENTS 实际执行 workspace；仅有 queue ticket 时可为空 |
+| `execution_branch_name` | fork branch |
+| `execution_policy` | `fork_git_worktree` 或 `current_workspace` |
+| `forked_from_workspace_id` | fork 来源 workspace |
+
+## AI Review
+
+Review 阶段支持人和 AI 组合。
+
+| review_policy | 行为 |
+| --- | --- |
+| `human_required` | 执行 run completed 后进入 `review`，等待用户确认或 request changes |
+| `ai_pre_review` | 进入 `review` 后自动创建 AI review run；AI 输出结论和摘要，但最终仍由人确认 |
+| `ai_auto_done` | AI review 通过后可自动 `review -> done` |
+
+### Review State
+
+| review_state | 含义 |
+| --- | --- |
+| `not_requested` | 未启用 AI review |
+| `waiting_for_slot` | AI review 等待 reviewer runtime slot |
+| `running` | AI review run 正在执行 |
+| `approved` | AI review 通过 |
+| `changes_requested` | AI 建议修改 |
+| `needs_human` | AI 不确定或策略要求人最终确认 |
+| `failed` | AI review 失败 |
+
+AI review run 与 executor run 分开记录：
+
+- `run_id` 或 `executor_run_id`：执行 TODO 的 run；迁移期可继续使用 `run_id` 作为 executor run 字段名。
+- `review_run_id`：AI review 的 run。
+- `runtime_target_id`：executor runtime target。
+- `review_runtime_target_id`：reviewer runtime target。
+
+Lifecycle bridge 必须按 attempt type 分派 run terminal event。executor run completed/failed/stopped/missing 才能驱动主 board status；AI review run terminal 只能更新 review state/decision，并在 `ai_auto_done` approved 时通过 lifecycle 请求 `review -> done`。
+
+### Review Decision
+
+AI review 输出必须被归一化为结构化 decision：
+
+| decision | Board 行为 |
+| --- | --- |
+| `approved` + `human_required` | 停在 `review`，展示 AI 摘要 |
+| `approved` + `ai_pre_review` | 停在 `review`，展示 AI 摘要，等待用户最终确认 |
+| `approved` + `ai_auto_done` | `review -> done` |
+| `changes_requested` | 停在 `review`，展示建议，用户可一键进入 request changes |
+| `needs_human` | 停在 `review` |
+| `failed` | 停在 `review`，记录 diagnostics |
+
+AI review 不应自动触发 request changes。即使 AI 认为需要修改，也应先停在 `review`，除非未来单独设计 AI 自动返工策略。
+
+## API 方向
+
+具体 wire shape 在实现阶段写入 core API 文档。这里定义 Boards 模块设计语义。
+
+### Preview Start
+
+```text
+POST /api/boards/todos/{todo_id}:preview-start
+```
+
+Request 目标字段：
+
+```json
+{
+  "view_workspace_id": "workspace-current-view",
+  "template_override": null,
+  "execution_policy": null,
+  "runtime_target_id": null,
+  "review_policy": null,
+  "review_runtime_target_id": null,
+  "queue_if_full": true
+}
+```
+
+Preview request 中的 `view_workspace_id` 表示当前 TODO 页面所在 workspace；fork view 下必须用它渲染 fork warning、workspace variables 和 `current_workspace` execution context，不能只从 `todo_id` 推导 root board workspace。`queue_if_full` 是 Start editor 当前候选值。后端必须基于该值计算 `queue_preview`，避免预览显示会排队而最终 Start 因 `queue_if_full=false` 返回 conflict。
+
+Response 目标字段：
+
+```json
+{
+  "todo_id": "btodo_123",
+  "board_workspace_id": "root_workspace",
+  "view_workspace_id": "fork_workspace",
+  "is_fork_view": true,
+  "prompt": "rendered prompt",
+  "recommended_execution_policy": "fork_git_worktree",
+  "recommended_runtime_target": {
+    "runtime_target_id": "role:main_agent",
+    "runtime_target_kind": "local_role",
+    "display_name": "Main Agent"
+  },
+  "runtime_options": [],
+  "review_policy": "human_required",
+  "review_runtime_options": [],
+  "concurrency_snapshot": {
+    "source_workspace": {
+      "workspace_id": "root_workspace",
+      "limit": 2,
+      "active": 1,
+      "available": 1
+    },
+    "runtime_target": {
+      "limit": 1,
+      "active": 1,
+      "available": 0
+    }
+  },
+  "queue_preview": {
+    "would_queue": true,
+    "reason": "runtime target concurrency limit reached"
+  },
+  "diagnostics": []
+}
+```
+
+### Start
+
+```text
+POST /api/boards/todos/{todo_id}:start
+```
+
+Request 目标字段：
+
+```json
+{
+  "final_prompt": "user or AI confirmed prompt",
+  "idempotency_key": "start-btodo-123-attempt-1",
+  "view_workspace_id": "workspace-current-view",
+  "execution_workspace_id": null,
+  "execution_policy": "fork_git_worktree",
+  "runtime_target_id": "role:main_agent",
+  "queue_if_full": true,
+  "start_policy": "human_required",
+  "handoff_initiator": "human",
+  "review_policy": "ai_pre_review",
+  "review_runtime_target_id": "role:reviewer",
+  "fork_name": "workspace-btodo-123",
+  "start_ref": null,
+  "yolo": true
+}
+```
+
+Rules：
+
+- `final_prompt` 必须非空。
+- `idempotency_key` 用于去重 confirmed Start 请求；所有 initiator 都必须提交稳定 key，避免 retry 创建重复 fork/session/run。
+- `runtime_target_id` 必须在 allowed runtime targets 中。
+- `review_policy=ai_pre_review` 或 `ai_auto_done` 时，`review_runtime_target_id` 必须存在且在 allowed reviewer runtime targets 中；否则 Start 请求应被拒绝，或用户/AI 必须显式降级为 `human_required`。
+- `view_workspace_id` 必须随 confirmed Start 提交，表示用户或 AI 发放发生时所在页面 workspace；它用于 audit，也用于解析 `execution_policy=current_workspace`。
+- `execution_workspace_id` 在 `fork_git_worktree` 时通常为空并由后端 fork 后写入；在 `current_workspace` 时可以由前端提交为当前 `view_workspace_id`，后端必须校验二者一致，不能从 `todo_id` 推导 root `board_workspace_id` 作为执行 workspace。
+- `queue_if_full = true` 时，并发满则进入 `in_progress` 并创建 queue ticket。
+- `queue_if_full = false` 时，并发满返回 conflict，item 保持 `todo`。
+- AI auto start 必须提交 `handoff_initiator = ai_auto`、`start_policy = ai_auto_start` 和稳定 `idempotency_key`；重复请求返回已有 attempt、queue ticket 或 run 引用。
+- `fork_git_worktree` 只在 slot 获取后执行。
+
+### Request Changes
+
+Request changes 与 Start 共享 runtime/concurrency 语义：
+
+- 默认复用原 `execution_workspace_id`。
+- 如果 request changes 从该 TODO 的 execution fork 页面发起，`view_workspace_id` 可以作为复用 execution workspace 的快捷提示；最终仍以 item 上的 `execution_workspace_id` 为准。
+- 默认复用 executor `runtime_target_id`。
+- 无论复用还是显式更换 executor runtime target，都必须在 confirmed Request Changes 时重新检查 allowed targets、runtime availability 和并发上限。
+- 并发满且 `queue_if_full = true` 时，item 进入 `in_progress` 并创建 request changes queue ticket。
+- legacy review item 如果缺少 `execution_workspace_id` 但有旧 `session_id`，迁移期只能从旧 session workspace 或旧 completed attempt workspace 推导 execution workspace；不能使用当前 `view_workspace_id`。无法证明原执行 workspace 时返回 conflict；目标数据必须写入明确 execution workspace 引用。
+
+### AI Review
+
+目标内部 API 或 service method：
+
+```text
+POST /api/boards/todos/{todo_id}:start-ai-review
+```
+
+首版可以不暴露给普通前端按钮，而由 lifecycle 在 run completed 后根据 `review_policy` 触发。
+
+Rules：
+
+- 只允许从 `review` 触发。
+- 必须存在有效 completed executor attempt、session/run summary 和 execution workspace context；缺失时保持 `review`，写 `review_context_missing` diagnostic，不创建 reviewer run。
+- 必须使用稳定 idempotency key，建议由 `todo_id + completed_executor_attempt_id + review_policy + reviewer_runtime_target_id` 派生；重复 lifecycle replay 返回已有 review attempt、queue ticket 或 review run。
+- 触发前必须确认没有 active `ai_review` attempt 或 pending/claimed AI review ticket；已有 reviewer attempt 时只更新 diagnostics/event，不创建重复 run。
+- 触发时必须重新验证 `review_runtime_target_id` 仍存在、可用且在 allowed reviewer runtime targets 中；若 role/agent 被删除、禁用或 capability drift，item 保持 `review`，写 `review_runtime_unavailable` diagnostic，或显式降级为 `human_required`。
+- reviewer runtime target 独立计入 runtime 并发。
+- review run 完成后归一化 decision。
+- `ai_auto_done` 只有在 decision 为 `approved` 时才能进入 `done`。
+
+## 状态流转补充
+
+```mermaid
+stateDiagram-v2
+    [*] --> todo
+
+    todo --> in_progress: handoff confirmed or AI auto start
+    in_progress --> in_progress: queue ticket waits for slot
+    in_progress --> in_progress: attempt claimed slot and workspace/run starting
+    in_progress --> review: executor run completed
+    in_progress --> todo: executor run failed/stopped/missing or start failed
+
+    review --> review: AI review attempt active
+    review --> review: AI approved but human final required
+    review --> done: AI approved with ai_auto_done
+    review --> done: human marks done or PR merged
+    review --> in_progress: request changes confirmed or queued
+
+    done --> archived
+    archived --> todo: restore
+```
+
+## 持久化方向
+
+目标持久化可以拆成三类：
+
+1. Board item 上的当前引用：
+   - `runtime_target_id`
+   - `runtime_target_kind`
+   - `review_policy`
+   - `review_state`
+   - `review_run_id`
+   - `current_attempt_id`
+   - `active_attempt_id`
+   - `queue_ticket_id`
+2. Queue ticket 表：
+   - `queue_ticket_id`
+   - `todo_id`
+   - `board_workspace_id`
+   - `source_workspace_id`
+   - `view_workspace_id`
+   - `execution_workspace_id`
+   - `prompt_ref`
+   - `handoff_snapshot_ref`
+   - `execution_policy`
+   - `fork_name`
+   - `start_ref`
+   - `runtime_target_id`
+   - `review_runtime_target_id`
+   - `queue_kind`，例如 `start`、`request_changes`、`ai_review`
+   - `queued_at`
+   - `priority`
+   - `prompt_ref`，引用完整 final prompt snapshot
+   - `handoff_snapshot_ref`，引用用户确认后的 execution/runtime/review 选择；queue worker 必须从该 snapshot 读取 fork 策略、fork 名称和起点
+   - `claim_token`
+   - `claim_expires_at`
+   - `claimed_by`
+   - `failure_count`
+   - `status`
+   - `diagnostics`
+3. Handoff prompt snapshot 表或等价存储：
+   - `prompt_ref`
+   - `todo_id`
+   - `attempt_id`
+   - `template_source`
+   - `final_prompt_snapshot`
+   - `created_at`
+4. Runtime policy 配置：
+   - workspace-level concurrency defaults。
+   - source-level overrides，以 `board_workspace_id/source_workspace_id/source_id` 为作用域。
+   - runtime target overrides。
+   - allowed runtime targets。
+
+如果实现阶段新增 schema，必须同步更新 `docs/core/database-schema.md`。
+
+## 前端表现
+
+主看板仍保持四个主列：`todo`、`in_progress`、`review`、`done`。
+
+卡片展示从事实派生：
+
+- queue ticket：等待哪个 slot、queued time、queue kind。
+- attempt：当前 attempt 类型、是否已 claim slot、是否已有 execution workspace。
+- run runtime：`queued`、`running`、`paused`、`stopping`、`completed`、`failed`。
+- review：review policy、review attempt、AI decision。
+- diagnostics：未清理 warning/error/critical。
+
+Start prompt editor 需要展示：
+
+- board scope：root board workspace、当前 view workspace，以及是否为 fork view。
+- runtime target selector。
+- execution policy selector。
+- concurrency preview。
+- `queue_if_full` 控件。
+- review policy selector。
+- reviewer runtime target selector。
+
+AI suggested start 应展示为一个待确认建议：用户可以打开同一个 Start prompt editor，看到 AI 选择的 prompt、runtime、execution policy 和 review policy，并可修改后确认。
+
+## 测试矩阵
+
+| 场景 | 期望 |
+| --- | --- |
+| local role target | preview 可选择，start 创建 normal session/run |
+| external role target | preview 展示 bound agent protocol/transport，start 仍通过 sessions/runs |
+| orchestration preset target | start 创建 orchestration session/run |
+| runtime target 不可用 | preview 返回 diagnostics，start 拒绝 |
+| board/source workspace active 达到 2 | 按 `board_workspace_id/source_workspace_id` 统计，新 handoff 进入 `in_progress` 并创建 queue ticket |
+| runtime target active 达到 1 | 新 handoff 进入 `in_progress` 并创建 queue ticket |
+| Start with `queue_if_full=false` | 并发满时返回 conflict，item 保持 `todo` |
+| Request Changes with `queue_if_full=false` | 并发满时返回 conflict，item 保持原 `review` 状态 |
+| queue ticket 获得 slot | claim ticket，准备 workspace，创建 session/run，后续由 run runtime 驱动 |
+| queue ticket 获得 slot | 必须先读取完整 prompt snapshot，再创建 session/run |
+| fork 失败 | item 回到 `todo`，不创建 run，不占 slot |
+| queue claim 过期 | 释放 slot，ticket 恢复或失败，写 diagnostic |
+| max runtime exceeded | 请求停止 run；slot 保持占用直到 runtime 进入 stopped/failed terminal 并完成 reconcile，然后写 attempt failure |
+| 连续 start failure 达阈值 | 写 diagnostic，阻止 AI auto retry，不新增 board 状态 |
+| run completed + human_required | `in_progress -> review` |
+| run completed + ai_pre_review | 创建 AI review attempt；AI 通过后仍停 `review` |
+| run completed + ai_auto_done | AI approved 后 `review -> done` |
+| AI review changes_requested | 停 `review`，显示建议，不自动返工 |
+| AI review run terminal | 只更新 review state/decision，不执行 executor run 状态映射 |
+| linked PR merged while in_progress | 只记录 evidence，保持 `in_progress` |
+| request changes slot 满 | `review -> in_progress`，创建 request changes queue ticket |
+| fork view start | 并发统计使用 root board/source workspace，不按 fork view workspace 分裂 |
+| fork view queued ticket | ticket 保存 `board_workspace_id`、`view_workspace_id` 和后续 `execution_workspace_id` |
+| request changes from execution fork | 复用 item 已绑定 execution workspace |
+| legacy review item without execution workspace | request changes fallback 到 `current_workspace` |
+| session deleted while queued | 清理 ticket，回到 `todo` |
+| session deleted while done | 保持 `done`，清理 session/run refs |
+
+## 实现阶段注意事项
+
+- Queue ticket 和 slot 获取必须有原子性，避免两个 worker 同时启动超过上限的 TODO。
+- `run_runtime` 是 run 状态 source of truth；Boards 只做映射和引用清理。
+- external agent runtime 的 secret、transport 解析仍归 `agent_runtimes` 和 role/provider 层。
+- AI auto start 和 AI auto done 都必须产生可审计 metadata：initiator、policy、runtime target、template source、decision summary。
+- 文档中的 API 和 schema 是目标设计，实现时若落地公共接口必须同步 core API/schema 文档。

--- a/docs/modules/boards/workspace-todo-board-module-layout.md
+++ b/docs/modules/boards/workspace-todo-board-module-layout.md
@@ -1,0 +1,786 @@
+# Workspace TODO Board Module Layout Design
+
+## 背景
+
+当前 `src/relay_teams/boards/` 同时包含两套思路：
+
+1. 真实运行中的 Workspace TODO Board：
+   - `todo_models.py`
+   - `todo_repository.py`
+   - `todo_service.py`
+   - `/api/boards/todos*`
+
+2. 早期通用 task board/tracker adapter 原型：
+   - `adapter.py`
+   - `dispatcher.py`
+   - `github_adapter.py`
+   - `linear_adapter.py`
+   - `internal_adapter.py`
+   - `/api/boards/{board_id}/tasks` 等空实现或占位实现
+
+这导致目录表达不清：
+
+- `todo_service.py` 聚合了 source sync、GitHub remote 探测、GitHub API 调用、state reconciliation、session/run handoff、prompt 拼接等多个职责。
+- 旧 `TaskBoardAdapter` 具备 move/assign/comment 等双向 tracker 语义，但 Workspace TODO Board 的目标是 Agent Teams 拥有状态、外部 tracker 提供 evidence。
+- router 中同时暴露真实 TODO API 和旧 board task API，读者难以判断哪个是主线。
+
+目标是迁移旧 adapter 中可复用的读取和归一化思路，但不保留旧双向 tracker board 语义。旧 `TaskBoardAdapter`、`/api/boards/{board_id}/tasks`、`/api/boards/state-map` 和 move/assign/state-map API 规划删除，不继续让两套抽象平行扩展。
+
+## 目标目录结构
+
+```text
+src/relay_teams/boards/
+  __init__.py
+  api_models.py
+  todo/
+    __init__.py
+    board_scope_service.py
+    models.py
+    repository.py
+    service.py
+    lifecycle.py
+    attempt_models.py
+    attempt_repository.py
+    attempt_service.py
+    comment_models.py
+    comment_repository.py
+    event_models.py
+    event_repository.py
+    diagnostic_models.py
+    diagnostic_service.py
+    handoff_models.py
+    handoff_service.py
+    execution_models.py
+    execution_queue_repository.py
+    execution_queue_service.py
+    runtime_target_models.py
+    runtime_target_service.py
+    review_models.py
+    review_service.py
+    worker_context_service.py
+    source_models.py
+    source_repository.py
+    source_service.py
+  sources/
+    __init__.py
+    base.py
+    github.py
+    manual.py
+    linear.py
+  state/
+    __init__.py
+    transitions.py
+    session_bridge.py
+    run_bridge.py
+```
+
+## 模块职责
+
+### `boards/api_models.py`
+
+放置 router-facing request/response models，避免 router 内定义大量 Pydantic model。
+
+职责：
+
+- API request/response schema。
+- 将 domain model 转换为 API response 的薄适配。
+- 不访问 repository。
+- 不包含业务决策。
+
+### `boards/todo/models.py`
+
+TODO Board domain model。
+
+职责：
+
+- `BoardTodoItem`
+- `BoardTodoScope`
+- `BoardTodoStatus`
+- source provider/type enum。
+- 目标 source identity：`source_id` + `source_key`，以 `(board_workspace_id/source_workspace_id, source_id, source_key)` 去重。
+- legacy source provider/type/key 字段的兼容和展示边界。
+- status counts。
+- board/delta response 的 domain shape。
+- 当前 attempt 引用、idempotency key 和 diagnostic count。
+
+### `boards/todo/board_scope_service.py`
+
+TODO board scope resolution 服务。
+
+职责：
+
+- 接收 router 传入的当前页面 `view_workspace_id`。
+- 从 workspace profile 读取 `file_scope.backend` 和 `file_scope.forked_from_workspace_id`。
+- 普通 project workspace 返回自身作为 `board_workspace_id`。
+- `git_worktree` workspace 沿 `forked_from_workspace_id` 追溯最终 root workspace，返回 `BoardTodoScope`。
+- 处理 cycle guard、root workspace missing、权限不足和脏 fork metadata diagnostics。
+- 为 source、handoff、queue、lifecycle、repository 查询提供统一 board scope。
+
+不负责：
+
+- 创建或删除 workspace fork。
+- 修改 board item 状态。
+- 读取 GitHub remote 或 source config。
+
+不负责：
+
+- GitHub API shape。
+- router request parsing。
+- template rendering。
+- attempt history、comments、events 或 diagnostics 的完整持久化。
+
+### `boards/todo/repository.py`
+
+TODO item persistence。
+
+职责：
+
+- `board_todo_items` CRUD。
+- revision/delta 查询。
+- archive/restore 所需基础读写。
+- 按 source/session/run/link PR 查询。
+- item 上 current/active attempt 和 diagnostic count 的轻量引用维护。
+
+不负责：
+
+- 调 GitHub。
+- 创建 run。
+- 渲染 prompt。
+- 判断 run status 映射。
+
+### `boards/todo/attempt_models.py`
+
+TODO attempt domain models。
+
+职责：
+
+- `BoardTodoAttempt`
+- attempt type：`start`、`request_changes`、`ai_review`。
+- attempt status：`pending`、`active`、`succeeded`、`failed`、`cancelled`。
+- 内部 attempt phase，例如等待 slot、准备 workspace、创建 run。
+- structured completion metadata model。
+- `prompt_ref` 引用完整 final prompt snapshot，而不是只保存摘要。
+
+不负责：
+
+- board status transition。
+- 直接创建 run。
+
+### `boards/todo/attempt_repository.py`
+
+Attempt history persistence。
+
+职责：
+
+- 保存 start、request changes、AI review attempt。
+- 按 TODO 查询 attempt history。
+- 绑定 session/run/runtime/execution workspace。
+- 保存 summary、metadata 和 error。
+
+### `boards/todo/attempt_service.py`
+
+Attempt application service。
+
+职责：
+
+- 创建 attempt。
+- 更新 attempt status 和 metadata。
+- 为 handoff preview 和 worker context 汇总 prior attempts。
+- 将 run terminal/review decision 映射到 attempt result。
+
+不负责：
+
+- 决定 board status。
+- 渲染 prompt。
+
+### `boards/todo/comment_models.py`
+
+Board-level comment domain models。
+
+职责：
+
+- `BoardTodoComment`
+- comment source：`human`、`agent`、`ai_review`、`source_sync`、`system`。
+- comment 与 attempt/run/session 的可选引用。
+
+### `boards/todo/comment_repository.py`
+
+Comment persistence。
+
+职责：
+
+- 按 TODO 写入和查询 comments。
+- 提供 card detail 和 worker context 所需摘要。
+
+### `boards/todo/event_models.py`
+
+Append-only event domain models。
+
+职责：
+
+- `BoardTodoEvent`
+- event type enum，例如 `created`、`imported`、`prompt_previewed`、`queued_for_start`、`workspace_forked`、`run_started`、`run_completed`、`review_completed`、`done`、`archived`。
+- actor 和 payload model。
+
+### `boards/todo/event_repository.py`
+
+Event persistence。
+
+职责：
+
+- 追加事件。
+- 按 TODO 查询 timeline。
+- 支持 board delta 或 card detail 的最近 events 摘要。
+
+### `boards/todo/diagnostic_models.py`
+
+Diagnostic domain models。
+
+职责：
+
+- `BoardTodoDiagnostic`
+- severity：`info`、`warning`、`error`、`critical`。
+- diagnostic kind，例如 source sync failed、template render failed、runtime unavailable、workspace fork failed、queue stale、run missing、AI review failed。
+- suggested action model。
+
+### `boards/todo/diagnostic_service.py`
+
+Diagnostic application service。
+
+职责：
+
+- 创建、清理和查询 diagnostics。
+- 根据 source sync、handoff、queue、run/session lifecycle 和 AI review 结果写入诊断。
+- 维护 item 上 `diagnostic_count` projection。
+
+不负责：
+
+- 用 diagnostics 替代 board status。
+
+### `boards/todo/service.py`
+
+TODO Board application service。
+
+职责：
+
+- 编排 repository、source service、handoff service、lifecycle service。
+- 提供 router 使用的高层方法：list board、sync board、create manual TODO、start、request changes、archive、restore、link PR。
+- 在触碰任何 board persistence 前调用 `board_scope_service`，把 `workspace_id` 参数解析为 `view_workspace_id` 和 `board_workspace_id`。
+- 保持事务/失败恢复边界。
+
+目标是让此文件变薄，不再直接包含所有 GitHub sync 和 prompt 拼接细节。
+
+### `boards/todo/lifecycle.py`
+
+Board 状态机和生命周期策略。
+
+职责：
+
+- 执行 `todo -> in_progress`、`in_progress -> review` 等 transition。
+- 校验 transition guard。
+- 生成 `last_status_reason`。
+- 处理 run completed/failed/stopped/missing。
+- 处理 session deleted。
+- 处理 linked PR merged evidence；只自动执行 `review -> done`，`todo`/`in_progress` 仅记录 evidence。
+- 区分 executor `run_id` 与 AI `review_run_id`，避免 review run terminal 误触发 executor 状态映射。
+
+可以与 `state/transitions.py` 配合：`state/transitions.py` 定义纯 transition table，`todo/lifecycle.py` 执行 repository 更新。
+
+### `boards/todo/handoff_models.py`
+
+Handoff domain models。
+
+职责：
+
+- template scope。
+- template kind。
+- preview request/response。
+- final handoff request。
+- template variables model。
+- prompt snapshot/ref model，保存排队 handoff 所需的完整 final prompt。
+- runtime target、execution policy、review policy 的 request/response 引用。
+
+### `boards/todo/handoff_service.py`
+
+Handoff prompt rendering 和模板选择。
+
+职责：
+
+- 根据 todo item/source/workspace 选择模板。
+- 渲染 preview prompt。
+- 处理 source/workspace/global/fallback 优先级。
+- 输出 diagnostics。
+- 输出 attempt context、prior attempts 摘要和 unresolved diagnostics 摘要。
+- 在 Start、request changes 和 AI auto start 确认后保存完整 final prompt snapshot/ref，供 queue ticket 和 attempt 引用。
+
+不负责：
+
+- 创建 run。
+- 修改 board status。
+- 分配并发 slot。
+- 直接调用 external agent runtime。
+
+### `boards/todo/execution_models.py`
+
+执行编排 domain models。
+
+职责：
+
+- `ExecutionPolicy`：`fork_git_worktree`、`current_workspace`。
+- queue kind：`start`、`request_changes`、`ai_review`。
+- concurrency snapshot 和 queue preview models。
+- queue ticket claim/lease models。
+- 内部 attempt phase 引用；不作为 board 公共状态。
+
+### `boards/todo/execution_queue_repository.py`
+
+Execution queue persistence。
+
+职责：
+
+- 保存 queue ticket。
+- 保存或引用完整 final prompt snapshot/ref；queue worker 创建 run 时必须能读取完整 prompt。
+- 根据 `board_workspace_id/source_workspace_id`、runtime target 和 queue kind 查询 pending ticket。
+- 原子更新 ticket status。
+- 保存 `claim_token`、`claim_expires_at`、`claimed_by` 和 `failure_count`。
+- 保存 diagnostics。
+
+不负责：
+
+- fork workspace。
+- 创建 session/run。
+- 选择 runtime target。
+
+### `boards/todo/execution_queue_service.py`
+
+并发 slot 和 queue 编排。
+
+职责：
+
+- 按 Workspace+Runtime 双口径检查 active slot。
+- v1 默认 `max_active_per_source_workspace = 2`，统计口径是 `board_workspace_id/source_workspace_id`，不是 fork view workspace。
+- v1 默认 `max_active_per_runtime_target = 1`。
+- `queue_kind=start` 和 `queue_kind=request_changes` 同时检查 workspace/source active slot 与 executor runtime slot。
+- `queue_kind=ai_review` 只检查 reviewer runtime slot，不占用 source workspace execution slot，也不阻塞实现类 TODO 的 workspace 并发额度。
+- 并发满且允许 queue 时创建 queue ticket。
+- slot 可用时抢占 ticket，驱动 workspace preparation 和 run creation。
+- run terminal、start failure、session deleted 时释放 slot。
+- claim lease 过期时恢复或失败 ticket，并写 diagnostic/event。
+- 支持 `max_runtime_seconds` 和连续 start/runtime failure diagnostics。
+
+不负责：
+
+- 渲染 prompt。
+- 直接执行 runtime。
+- 调外部 tracker。
+
+### `boards/todo/runtime_target_models.py`
+
+Runtime target domain models。
+
+职责：
+
+- `RuntimeTargetKind`：`local_role`、`external_role`、`orchestration_preset`。
+- runtime target option、capability、diagnostic models。
+- allowed runtime target policy。
+
+### `boards/todo/runtime_target_service.py`
+
+Runtime target 解析服务。
+
+职责：
+
+- 从 role registry 生成 local role 和 external role target。
+- 从 orchestration settings 生成 orchestration preset target。
+- 根据 workspace/source policy 过滤 allowed targets。
+- 生成 preview 默认 runtime target 和 diagnostics。
+
+不负责：
+
+- 读取 external runtime secrets。
+- 启动 ACP/A2A/CLI runtime。
+- 创建 run。
+
+### `boards/todo/review_models.py`
+
+Review domain models。
+
+职责：
+
+- `ReviewPolicy`：`human_required`、`ai_pre_review`、`ai_auto_done`。
+- AI review 状态和 decision model。
+- AI review decision 和 summary models。
+
+### `boards/todo/review_service.py`
+
+AI review 编排。
+
+职责：
+
+- 根据 review policy 决定是否启动 AI review。
+- 渲染 AI review prompt/template。
+- 选择 reviewer runtime target。
+- 创建 review run 或进入 review queue。
+- 将 AI review 输出归一化为 decision。
+- 在 `ai_auto_done` 且 approved 时请求 lifecycle 执行 `review -> done`。
+- 创建和更新 `ai_review` attempt。
+
+不负责：
+
+- 自动触发 request changes。
+- 绕过 lifecycle 直接写 done。
+
+### `boards/todo/worker_context_service.py`
+
+TODO-bound worker context 服务。
+
+职责：
+
+- 为 TODO-bound session/run 生成 worker context。
+- 汇总 TODO、root board source context、execution workspace、prior attempts、comments、events 和 diagnostics。
+- 定义 TODO-bound tool 可见性边界。
+- 校验工具调用只能操作当前 session/run 绑定的 TODO。
+
+不负责：
+
+- 暴露全局 board 管理工具。
+- 让 worker 直接将 TODO 标记为 `done`。
+
+### `boards/todo/source_models.py`
+
+Source config 和 normalized record/evidence model。
+
+职责：
+
+- `BoardTodoSource`
+- `BoardTodoSourceKind`
+- `BoardTodoSourceState`
+- `SourceRecord`
+- `SourceEvidence`
+- provider-specific config Pydantic models。
+
+### `boards/todo/source_repository.py`
+
+Source config/state persistence。
+
+职责：
+
+- source 配置 CRUD。
+- per-source cursor。
+- sync diagnostics。
+- enabled source 查询。
+
+### `boards/todo/source_service.py`
+
+Source sync orchestration。
+
+职责：
+
+- 根据 `board_workspace_id/source` 调用 adapter。
+- 将 adapter 输出交给 board item repository/lifecycle。
+- 支持 full/incremental/preview sync。
+- 多 source 错误隔离。
+- 管理 per-source cursor。
+
+不负责：
+
+- 外部 provider 细节。
+- run/session lifecycle。
+
+### `boards/sources/base.py`
+
+Source adapter protocol/base class。
+
+职责：
+
+- 定义 adapter 接口。
+- 定义 sync result。
+- 定义 capability flags，例如是否支持 comments/artifacts。
+
+### `boards/sources/github.py`
+
+GitHub Issues source adapter。
+
+职责：
+
+- GitHub repo config validation。
+- workspace remote auto-detect suggestion。
+- GitHub issue/PR/timeline API 调用。
+- 输出 `SourceRecord` 和 `SourceEvidence`。
+- 使用现有 proxy-aware `net.clients` 和 GitHub client 能力。
+
+不负责：
+
+- 直接写 `BoardTodoItem`。
+- 直接设置 board status。
+
+### `boards/sources/manual.py`
+
+Manual source adapter。
+
+职责：
+
+- 提供 manual source metadata。
+- manual source 没有外部 sync。
+- 统一 source display 和 handoff context。
+
+### `boards/sources/linear.py`
+
+Linear source adapter，迁移旧 `linear_adapter.py` 思路。
+
+职责：
+
+- Linear issue list normalization。
+- 输出 source records。
+- 可选 comment/artifact capability。
+
+v1 可以只保留设计和空 adapter，不必立即暴露 UI。
+
+### `boards/state/transitions.py`
+
+纯状态机定义。
+
+职责：
+
+- transition table。
+- event enum。
+- guard 结果。
+- 纯函数：给定当前状态和事件，返回目标状态或 conflict。
+
+### `boards/state/session_bridge.py`
+
+Session lifecycle bridge。
+
+职责：
+
+- sessions 模块删除 session 时调用的窄接口。
+- 将 session deleted 转为 board lifecycle event。
+
+### `boards/state/run_bridge.py`
+
+Run lifecycle bridge。
+
+职责：
+
+- runs 模块 run terminal 时调用的窄接口。
+- 将 run completed/failed/stopped/missing 转为 board lifecycle event。
+
+## 依赖方向
+
+```text
+interfaces/server/routers
+  -> boards/api_models
+  -> boards/todo/service
+  -> boards/todo/{board_scope_service,repository,lifecycle,attempt_service,comment_repository,event_repository,diagnostic_service,handoff_service,source_service,execution_queue_service,runtime_target_service,review_service,worker_context_service}
+  -> boards/sources/*
+  -> sessions/runs service protocols
+```
+
+规则：
+
+- routers 不访问 repository。
+- routers 传入的 `workspace_id` 只表示 `view_workspace_id`；domain service 统一通过 board scope service 解析 `board_workspace_id`。
+- source adapters 不访问 board item repository。
+- lifecycle 不调用外部 provider。
+- handoff service 不创建 run。
+- execution queue 不渲染 prompt，不直接执行 runtime。
+- attempt service 不决定 board status。
+- diagnostics 不替代 board status。
+- runtime target service 不读取外部 runtime secrets。
+- review service 通过 sessions/runs 创建 review run，不直接调用 provider。
+- source service 不写 message history。
+- sessions/runs 通过 bridge/protocol 通知 boards，避免反向深耦合。
+
+## 旧文件迁移策略
+
+| 当前文件 | 目标位置 | 说明 |
+| --- | --- | --- |
+| `todo_models.py` | `todo/models.py` | 拆出 API request models 到 `api_models.py` |
+| `todo_repository.py` | `todo/repository.py` | 保留 item persistence，新增 source id 后迁移 |
+| `todo_service.py` | `todo/service.py` + 多个子服务 | 拆出 GitHub sync、handoff、lifecycle |
+| start/request changes queue 逻辑 | `todo/execution_queue_service.py` | 新增并发和 queue 编排 |
+| start/request changes/review history | `todo/attempt_service.py` | 新增 attempt history |
+| card comments | `todo/comment_repository.py` | 新增 board-level comment thread |
+| card events | `todo/event_repository.py` | 新增 append-only audit log |
+| diagnostics | `todo/diagnostic_service.py` | 新增可恢复诊断 |
+| TODO-bound worker context | `todo/worker_context_service.py` | 新增 AGENTS 执行上下文边界 |
+| role/external runtime option 解析 | `todo/runtime_target_service.py` | 新增 runtime target 解析 |
+| AI review 逻辑 | `todo/review_service.py` | 新增 review policy 和 decision 映射 |
+| `adapter.py` | 删除，迁移可复用类型到 `sources/base.py` + `todo/source_models.py` | `TaskBoardAdapter` 不作为新公开接口 |
+| `github_adapter.py` | `sources/github.py` | 只迁移 issue/PR 读取和 records/evidence 输出 |
+| `linear_adapter.py` | `sources/linear.py` | 只迁移 issue list normalization |
+| `internal_adapter.py` | 后续删除或独立 source adapter | internal projection 不作为 v1 主线 |
+| `dispatcher.py` | 删除 | 旧 polling/worker outcome loop 不作为新 TODO Board 核心 |
+| `controlled_tools.py` | 迁移到 `todo/worker_context_service.py` 暴露的 TODO-bound tools，或随旧 adapter 一起删除 | 旧 `TaskBoardAdapter.move_task/add_artifact` 工具不作为新公开写入路径 |
+| router 内 BoardTask models | 删除 | 旧空 API 规划删除，不作为 legacy 长期保留 |
+
+## 旧 API 处理
+
+当前 router 中有两类 API：
+
+真实主线：
+
+```text
+/api/boards/todos*
+```
+
+旧占位：
+
+```text
+/api/boards
+/api/boards/{board_id}/tasks
+/api/boards/{board_id}/sync
+/api/boards/{board_id}/tasks/{task_id}/state
+/api/boards/state-map
+```
+
+目标：
+
+- 新 TODO Board 能力继续围绕 `/api/boards/todos*` 和新的 todo source/handoff endpoints。
+- 旧 `/api/boards/{board_id}/tasks` 不作为 Workspace TODO Board 扩展入口，并规划删除。
+- 旧 `/api/boards/state-map` 属于 task-board adapter 兼容，不是 TODO Board 状态机，并规划删除。
+- 前端和新 API 不得依赖旧 BoardTask/TaskBoardStateMap 实现新 TODO 看板。
+
+## Migration Phases
+
+### Phase 1: 文档和模型设计
+
+- 拆分文档。
+- 定义 source、handoff、state machine、目录结构。
+- 不改业务代码。
+
+### Phase 2: Source 配置持久化和 source_id 双轨
+
+- 新增 board scope service，让所有 TODO Board API 先把 `view_workspace_id` 解析为 `board_workspace_id`。
+- 新增 source config/state models 和 repository。
+- 新增 `source_id` 并把目标去重键定义为 `(board_workspace_id/source_workspace_id, source_id, source_key)`。
+- 迁移期保留 `source_provider/source_type/source_key` 旧字段用于展示、读旧数据和兼容现有 rows，但文档和新写入逻辑以 `source_id` 为准。
+- GitHub source 显式配置。
+- workspace source settings API。
+- fork workspace source settings 读写 root board sources，不创建 fork-local source/cursor。
+- 保留旧自动 remote 作为迁移 fallback。
+
+### Phase 3: GitHub sync 迁移
+
+- 将 `BoardTodoService._sync_github` 拆到 `sources/github.py` 和 `source_service.py`。
+- cursor 改为 per-source。
+- workspace-level sync 遍历 enabled sources。
+
+### Phase 4: Handoff 迁移
+
+- 新增 template models/service。
+- 新增 preview endpoints。
+- 前端 Start/Request changes 改为 prompt editor。
+- 后端 Start 使用 final prompt。
+- preview/start 增加 runtime target、execution policy、review policy 和 concurrency preview。
+
+### Phase 5: Execution Queue 和 Runtime Target
+
+- 新增 runtime target models/service。
+- 新增 handoff prompt snapshot/ref 存储，queue ticket 和 attempt 通过 `prompt_ref` 找回完整 final prompt。
+- 新增 execution queue repository/service。
+- 实现 Workspace+Runtime 双口径并发限制。
+- `in_progress` 通过 queue ticket、attempt phase 和 run runtime 派生展示。
+- queue ticket 获得 slot 后再 fork workspace 和创建 session/run。
+
+### Phase 6: Attempts、Comments、Events 和 Diagnostics
+
+- 新增 attempt models/repository/service。
+- 新增 comment repository。
+- 新增 event repository。
+- 新增 diagnostic models/service。
+- Handoff、queue、review 和 lifecycle 写入 attempt/event/diagnostic。
+- Card detail 展示 attempt history、comments、events 和 diagnostics。
+
+### Phase 7: Lifecycle 和 Review 拆分
+
+- run/session bridge 迁移到 `state/` 或 `todo/lifecycle.py`。
+- reconcile 逻辑集中。
+- 补齐 run status 映射测试。
+- 新增 review models/service。
+- 支持 `human_required`、`ai_pre_review`、`ai_auto_done`。
+- AI review 创建 `ai_review` attempt。
+
+### Phase 8: TODO-bound Worker Context
+
+- 新增 worker context service。
+- 定义 TODO-bound tool 暴露边界。
+- 支持 `board_todo_show`、`board_todo_comment`、`board_todo_create`、`board_todo_report_progress` 的目标语义。
+- `board_todo_create` 创建线性 TODO，不创建依赖关系。
+
+### Phase 9: Legacy adapter 和 API 删除
+
+- 迁移旧 adapters 中可复用的 provider 读取和 normalization 代码。
+- 删除旧 `TaskBoardAdapter` 双向 tracker state 语义。
+- 删除旧空 API：`/api/boards/{board_id}/tasks`、`/api/boards/{board_id}/sync`、`/api/boards/{board_id}/tasks/{task_id}/state`、`/api/boards/state-map`。
+- 更新 `docs/core/project-layout.md` 和模块边界文档。
+
+## 测试布局
+
+目标测试目录：
+
+```text
+tests/unit_tests/boards/
+  todo/
+    test_board_scope_service.py
+    test_models.py
+    test_repository.py
+    test_lifecycle.py
+    test_attempt_service.py
+    test_comment_repository.py
+    test_event_repository.py
+    test_diagnostic_service.py
+    test_handoff_service.py
+    test_execution_queue_service.py
+    test_runtime_target_service.py
+    test_review_service.py
+    test_source_service.py
+    test_worker_context_service.py
+  sources/
+    test_github_source.py
+    test_manual_source.py
+    test_linear_source.py
+  state/
+    test_transitions.py
+  test_api_models.py
+```
+
+集成测试：
+
+```text
+tests/integration_tests/api/test_board_todo_sources.py
+tests/integration_tests/api/test_board_todo_scope.py
+tests/integration_tests/api/test_board_todo_handoff.py
+tests/integration_tests/api/test_board_todo_execution_queue.py
+tests/integration_tests/api/test_board_todo_review.py
+tests/integration_tests/api/test_board_todo_collaboration.py
+tests/integration_tests/api/test_board_todo_lifecycle.py
+```
+
+前端测试：
+
+```text
+tests/unit_tests/frontend/test_board_todo_source_settings_ui.py
+tests/unit_tests/frontend/test_board_todo_handoff_ui.py
+tests/unit_tests/frontend/test_board_todo_execution_labels_ui.py
+tests/unit_tests/frontend/test_board_todo_review_ui.py
+tests/unit_tests/frontend/test_board_todo_detail_timeline_ui.py
+```
+
+## 验收标准
+
+- 新目录结构能让读者从文件名判断职责。
+- `todo_service.py` 不再是 source sync、prompt rendering、state machine、run creation 的混合大文件。
+- 旧 `TaskBoardAdapter` 概念被迁移可复用读取逻辑后删除，避免与 TODO Board 状态机冲突。
+- Router 保持薄层，只做 request/response 和 HTTP error mapping。
+- Runtime target 覆盖本地 role、外部 agent role 和 orchestration preset，但 Boards 不直接执行 external runtime。
+- 并发上限由 execution queue 统一控制，AI auto start 不能绕过。
+- AI review 通过 lifecycle 进入 done，不直接写 board status。
+- linked PR merged 只自动推进 linked `review` item；`todo`/`in_progress` item 只记录 evidence。
+- queue ticket 和 attempt 必须引用完整 prompt snapshot/ref。
+- Root workspace 和 fork workspace 通过 `board_scope_service` 解析到同一个 `board_workspace_id`，共享 TODO items、sources、cursors、templates、revision 和 delta。
+- Fork workspace 不创建独立 source/cursor/item；source settings、sync、manual create、archive/restore 都操作 root board，并在 event/attempt 中记录发起 workspace。
+- TODO 是线性列表，不引入 dependency graph 或 dependency service。
+- 卡片细节从 queue ticket、attempt、run runtime、review state 和 diagnostics 派生，不引入 Hermes 式公共状态标签体系。
+- Attempt/comment/event/diagnostic history 能解释 Start、Request Changes、AI Review 和失败恢复过程。
+- 新增 API/DB 时，core API/schema 文档同步更新。

--- a/docs/modules/boards/workspace-todo-board-overview.md
+++ b/docs/modules/boards/workspace-todo-board-overview.md
@@ -1,0 +1,373 @@
+# Workspace TODO Board Overview
+
+## 背景
+
+Workspace TODO Board 是 Agent Teams 内部拥有的 workspace 工作项看板。它面向用户的核心价值不是复制 GitHub、Linear 或其他外部 tracker 的完整看板，而是把“可以交给 AGENTS 执行的工作项”集中到一个统一流程里：
+
+1. 从一个或多个 source 导入候选 TODO。
+2. 在 Agent Teams 中持久化 board item 和 board 状态。
+3. 由用户选择一个 TODO，编辑交付 prompt 后交给 AGENTS。
+4. 绑定 dedicated session/run，跟踪执行状态。
+5. 执行完成后进入 review，用户验收或通过 PR merged evidence 完成。
+
+现有实现已经有 `/api/boards/todos*`、`BoardTodoService`、`BoardTodoRepository` 和前端 TODO 看板，但当前设计仍偏 v1：
+
+- GitHub source 从 workspace git remote 自动探测，用户不能显式配置。
+- Start 操作直接调用后端，后端用内置 `_build_start_prompt()` 拼接提示词。
+- `src/relay_teams/boards/` 内同时存在真实 TODO board 实现和旧 `TaskBoardAdapter`/dispatcher 抽象，边界不够清楚；旧 task-board adapter API 后续应规划删除，而不是继续作为 TODO Board 扩展入口。
+
+本设计把 TODO Board 重新定义为一个清晰的 boards domain 子系统，并拆分 source、state lifecycle、handoff 和 persistence 职责。
+
+## 目标
+
+- 支持 workspace 级 TODO source 配置。v1 source 包括 `manual` 和 `github_issues`，未来可扩展 Linear、Jira、internal task、custom API 等。
+- 明确 board 状态只由 Agent Teams 拥有，外部系统不直接决定 TODO card 所在列。
+- 明确 board 状态与 session/run runtime 状态之间的映射，避免 run 已失败但 card 仍停在 `in_progress`。
+- 支持 AGENTS handoff prompt 由用户编辑后再触发，同时支持可配置模板。
+- 支持 AI 发放、AI review 和 AI 自动放行到 `done`，但这些自动化必须受模板、runtime target、execution workspace 和并发策略约束。
+- 支持不同 TODO 绑定不同 runtime target，包括本地 role、绑定外部 agent runtime 的 role，以及 orchestration preset。
+- 支持 attempt/run history、comments/events、diagnostics、idempotency 和 TODO-bound worker context，使 TODO card 自身具备可审计协作上下文。
+- 支持 root workspace 与由它 fork 出来的 `git_worktree` execution workspace 共享同一套 TODO board；fork workspace 的 TODO 页面是 root board 的视图，不创建独立 board 数据。
+- 重建 Boards 模块目录结构，把旧通用 board adapter 中可复用的读取/归一化思路迁移到新的 source adapter；旧 `/api/boards/{board_id}/tasks`、`/api/boards/state-map` 和双向 tracker state 语义规划删除。
+- 保持现有 `/api/boards/todos*` 能力可平滑迁移，避免一次性破坏前端和已有测试。
+
+## 非目标
+
+- 不把 GitHub Projects、Linear board column 或 Jira workflow 作为 Agent Teams board 状态的 source of truth。
+- 不在 Boards 模块内重新实现 session/run 调度。
+- 不让 interface/router 直接访问 repository。
+- 不把 run-local `todo_read`/`todo_write` 工具状态合并进 Workspace TODO Board；二者是不同层级的 TODO。
+- 不在 v1 中完整实现所有未来 source，只定义扩展接口和边界。
+- 不设计 TODO 之间的 parent/child dependency graph；TODO 来源和调度流程都是线性的。
+- 不照搬 Hermes Kanban 的 `triage`、`ready`、`blocked` 等状态体系。等待、运行、暂停、AI review 等展示必须从 Agent Teams 自己的 queue ticket、run runtime status、review state 和 diagnostics 派生。
+- 不让 fork 出来的 `git_worktree` workspace 拥有独立 `board_todo_sources`、`board_todo_source_state`、`board_todo_items` 或独立 revision；它们共享 root board。
+
+## 核心概念
+
+### Board Item
+
+`BoardTodoItem` 是 Agent Teams 持久化的 TODO card。它包含：
+
+- Agent Teams 自有字段：`todo_id`、`board_workspace_id`、`source_workspace_id`、`status`、`title`、`body`、`session_id`、`run_id`、`review_run_id`、`item_revision`、`created_at`、`updated_at`。
+- source 引用字段：`source_id`、`source_key`、`source_url`、`source_updated_at`、source-specific reference。`workspace_id` 可在迁移期继续表示 source workspace；`source_provider`/`source_type`/`source_key` 是 legacy 兼容和展示字段，不再作为目标 identity。
+- completion evidence 字段：linked PR、merged status、source completion evidence 等。
+- lifecycle 诊断字段：`last_status_reason`、`archived_at`、`last_synced_at`。
+
+Board item 的 `status` 是 Agent Teams 自己的状态，不等于 GitHub issue state、Linear issue state 或 run runtime status。
+
+### Board Workspace Scope
+
+TODO 页面需要区分“用户当前打开的 workspace”和“TODO board 真正归属的 workspace”：
+
+| 字段 | 说明 |
+| --- | --- |
+| `view_workspace_id` | 用户当前打开的 workspace，可能是 root project workspace，也可能是 fork 出来的 `git_worktree` execution workspace |
+| `board_workspace_id` | TODO board 的持久化归属 workspace；普通 workspace 等于 `view_workspace_id`，fork workspace 解析为最终 root workspace |
+| `source_workspace_id` | TODO source 所属 workspace；当前设计下通常等于 `board_workspace_id` |
+| `execution_workspace_id` | AGENTS 实际执行 workspace，可以是从 root/source workspace fork 出来的独立 worktree |
+
+所有 board list、delta、source settings、sync、manual create、archive、restore、Start 和 Request Changes 请求即使仍以 `workspace_id` 作为当前页面参数，进入 domain/service 层后也必须先解析：
+
+```text
+resolve_board_workspace_id(view_workspace_id)
+```
+
+解析规则：
+
+1. 读取 `view_workspace_id` 对应 workspace profile。
+2. 如果 `file_scope.backend != git_worktree`，返回自身。
+3. 如果是 `git_worktree` fork，必须存在有效 `file_scope.forked_from_workspace_id`，并沿该字段继续追溯，直到最终 root workspace。
+4. 解析过程必须有 cycle guard；遇到缺失 parent、cycle、root 缺失或无权限时，不创建 fork-local board，不 fallback 到 `view_workspace_id`，而是返回 diagnostics。
+
+这意味着：
+
+- Root workspace 与所有 fork workspace 的 TODO 页面显示同一组 board items、sources、cursors、templates 和 revision。
+- Fork workspace 中创建 manual TODO 或 AI-created TODO 时，item 仍写入 root board；event/attempt metadata 记录 `initiated_from_workspace_id = view_workspace_id`。
+- Fork workspace 中打开 source settings 时展示 root board sources；如果允许编辑，实际修改 root board source config，并在 UI 中标明这些配置 shared with root workspace。
+- 从 fork workspace 页面触发 sync 时，同步 root board sources 和 root cursors，不把 fork workspace 的 git remote 作为 source identity。
+- TODO board cache、revision 和 delta subscription 以 `board_workspace_id` 为主 key；`view_workspace_id` 只作为页面上下文和 execution workspace shortcut。
+
+### Attempt、Comment、Event 和 Diagnostic
+
+TODO item 是逻辑任务，attempt 是一次执行或 review 尝试。Start、request changes 和 AI review 都会形成 attempt history。Board 侧还保存 comment thread、append-only event log 和 diagnostics，避免用户必须打开 session 历史才能理解卡片发生过什么。
+
+详细设计见 [协作审计、Attempt 和诊断设计](workspace-todo-board-collaboration-design.md)。
+
+### Source
+
+Source 是某个 board workspace 内的 TODO 数据来源配置。每个 root board workspace 可以有多个 source；fork workspace 只继承和操作 root board 的 source 配置。
+
+v1 source：
+
+- `manual`：用户在 Agent Teams 内创建的本地 TODO。
+- `github_issues`：一个显式或自动探测得到的 GitHub repository 的 issue source。
+
+source 负责提供 source record 和 evidence，不拥有 card column：
+
+- open GitHub issue 可以导入或更新 TODO item。
+- closed GitHub issue 可以作为 archive/done reconciliation 的 evidence。
+- GitHub PR merged 可以作为 `review -> done` 的 evidence。
+
+### Handoff
+
+Handoff 是用户把 TODO 交给 AGENTS 的动作。它不是单纯的 `start_todo` RPC，而是一个显式用户确认流程：
+
+1. 用户点击 card 上的 Start。
+2. 前端请求后端渲染默认 handoff prompt。
+3. 用户在弹窗中编辑最终 prompt。
+4. 用户确认后，前端提交 final prompt。
+5. 后端创建或复用 session/run，并把 item 移到 `in_progress`。
+
+AI 也可以发放 TODO，但 AI 发放不等于绕过 handoff。AI suggested start 生成可编辑建议，由用户确认；AI auto start 则按策略自动提交 final prompt，但仍必须经过同一套模板渲染、runtime target 校验、execution workspace 策略和并发限制。
+
+### Runtime Target
+
+Runtime target 是 TODO 交付时选择的执行后端抽象。TODO Board 不直接调用 provider 或 external agent runtime，而是选择现有 sessions/runs 能理解的执行入口：
+
+- `local_role`：未绑定 `bound_agent_id` 的 Agent Teams role，走本地 provider/runtime。
+- `external_role`：绑定了 `bound_agent_id` 的 role，底层可以走 `acp`、`a2a` 或 `cli` agent runtime。
+- `orchestration_preset`：通过 `SessionMode.ORCHESTRATION` 使用 orchestration preset。
+
+详细设计见 [执行 Runtime、AI 发放和并发设计](workspace-todo-board-execution-runtime-design.md)。
+
+### Execution Facts
+
+`in_progress` 列表示 TODO 已经发放或正在处理，不再只表示 run 已经创建。更细的展示不由 Boards 再定义一套公共子状态，而是从事实派生：
+
+- 是否存在 active queue ticket。
+- queue kind 和 queued time。
+- active attempt phase。
+- 是否已有 execution workspace。
+- 当前 `RunRuntimeStatus`。
+- review policy、review state 和 AI review decision。
+- 是否存在未清理 diagnostics。
+
+例如并发上限满时，TODO 可以进入 `in_progress`，但卡片展示应表达“存在 start queue ticket，等待 runtime slot”，而不是把 `queued` 变成新的 board domain 状态。
+
+### Lifecycle Bridge
+
+Lifecycle Bridge 是 Boards 和 Sessions/Runs 之间的窄边界：
+
+- run completed 通知 board item 进入 `review`；如果该 item 已经存有可信 linked PR merged evidence，则可直接进入 `done`。
+- run failed/stopped/missing 通知 board item 回到 `todo`。
+- session deleted 通知 board 清理 stale session/run 引用。
+- PR merged 通知 linked `review` item 进入 `done`；如果 item 仍在 `todo` 或 `in_progress`，只记录 completion evidence，不抢占 run lifecycle。
+
+Boards 不直接执行 run，也不决定 run recovery；它只消费 sessions/runs 暴露的生命周期事件。
+
+## 系统边界
+
+### 与 Connectors 的关系
+
+Connectors 负责账号、凭据、可用性和健康状态。Boards 使用 connector 或 trigger account 提供的凭据访问外部 source，但不把 connector overview 当成 board 配置。
+
+示例：
+
+- GitHub connector 显示账号是否可用。
+- TODO Board source 配置声明使用哪个 GitHub account/token source 访问 `owner/repo`。
+
+### 与 Sessions/Runs 的关系
+
+Sessions/Runs 负责执行生命周期。Board item 只保存绑定引用：
+
+- `session_id`：从 TODO 启动后创建或复用的 dedicated session。
+- `run_id`：当前正在处理或最近一次处理该 TODO 的 run。
+
+Board 不直接写 message history，不直接调用 agent execution loop，也不绕过 `RunService`。
+
+### 与 Agents 的关系
+
+AGENTS 接收用户或 AI 策略确认后的 handoff prompt。模板渲染和编辑发生在 handoff 层，Agent runtime 只看到最终 user prompt。
+
+这保证：
+
+- 用户能理解和修改交付内容。
+- 不同 source 可以有不同上下文格式。
+- 后端不会偷偷追加用户不可见的核心任务描述。
+- AI auto start 也有可审计的 final prompt、runtime target 和 execution policy。
+
+### 与 Agent Runtimes 的关系
+
+Agent runtime 是 role/provider/session-run 层的能力，不属于 Boards 模块。Boards 只记录 runtime target 选择：
+
+- role 没有 `bound_agent_id` 时，执行走 Agent Teams 本地 runtime。
+- role 有 `bound_agent_id` 时，执行走配置的 external agent runtime。
+- external runtime 的协议和 transport 由 `agent_runtimes` 模块处理。
+- run 的实际状态由 `run_runtime` 归一化后回传给 board lifecycle。
+
+### 与 External Trackers 的关系
+
+外部 tracker 是 evidence provider，不是 board state owner。
+
+| 外部事件 | Agent Teams 行为 |
+| --- | --- |
+| GitHub issue opened/updated | upsert source record 到 TODO item |
+| GitHub issue closed without merged PR | 自动 archive 或保持 done，取决于 evidence |
+| GitHub issue reopened | 只恢复由 source reconciliation 自动 archive 的 item |
+| GitHub PR linked | 记录 linked PR evidence |
+| GitHub PR merged | linked `review` item 可进入 `done`；`todo`/`in_progress` item 只记录 evidence |
+| Manual archive | 不被外部 sync 自动恢复 |
+
+## 端到端流程
+
+```mermaid
+flowchart TD
+    A["Workspace TODO page opens with view_workspace_id"] --> A1["Resolve board_workspace_id"]
+    A1 --> B["Load cached board state by board_workspace_id"]
+    B --> C["Fetch board delta by board_workspace_id"]
+    C --> D["User opens source settings"]
+    D --> E["Configure manual/github_issues sources"]
+    E --> F["Sync enabled sources"]
+    F --> G["Source adapters normalize records"]
+    G --> H["Board service upserts BoardTodoItem"]
+    H --> I["Kanban columns render Agent Teams status"]
+    I --> J["User clicks Start"]
+    J --> K["Render handoff prompt from template"]
+    K --> L["User edits final prompt"]
+    L --> M["Confirm handoff"]
+    M --> M1{"Concurrency slot available?"}
+    M1 -->|no| M2["Board status: in_progress, active queue ticket"]
+    M2 --> M1
+    M1 -->|yes| N["Prepare execution workspace and create session/run"]
+    N --> O["Board status: in_progress, bound run runtime drives display"]
+    O --> P{"Bound run terminal?"}
+    P -->|completed| Q["Board status: review"]
+    P -->|failed/stopped/missing| R["Board status: todo"]
+    Q --> Q1{"Review policy"}
+    Q1 -->|human_required| S{"Completion evidence or user decision?"}
+    Q1 -->|ai_pre_review| Q2["AI review, then human final decision"]
+    Q1 -->|ai_auto_done| Q3["AI review can approve done"]
+    Q2 --> S
+    Q3 -->|approved| T["Board status: done"]
+    Q3 -->|changes or uncertain| S
+    S -->|linked PR merged or user marks done| T
+    S -->|request changes| U["Render request-changes prompt"]
+    U --> L
+```
+
+## 用户体验
+
+### 主看板
+
+主看板保持四个工作列：
+
+- `todo`
+- `in_progress`
+- `review`
+- `done`
+
+`archived` 仍是独立视图，不参与主流程列。
+
+每张 card 显示：
+
+- title、body 摘要。
+- source provider/type/source label。
+- repository 或 source scope。
+- board workspace、当前 view workspace 和 execution workspace。
+- source 更新时间和 board 更新时间。
+- bound session/run。
+- linked PR 或 completion evidence。
+- status reason。
+- queue/run/review 派生展示，例如等待 slot、run paused、AI review pending。
+- runtime target 和 execution workspace。
+- review state，例如 `AI reviewing`、`AI approved`、`AI requested changes`。
+- attempt count、未清理 diagnostic 数量和最近 event 摘要。
+
+### 右上角设置入口
+
+TODO 列表右上角新增设置按钮，打开 source settings 面板。设置面板至少包含：
+
+- source 列表。
+- 新增 GitHub issue source。
+- 启用/禁用 source。
+- 显式 `owner/repo` 配置。
+- 自动探测建议。
+- 同步状态、最近 sync 时间、diagnostics。
+- source 级 handoff template 入口。
+
+这个入口属于 TODO Board 页面，而不是全局 connector 页面。Connector 页面仍只负责账号和健康状态。若用户当前在 fork workspace 的 TODO 页面中打开设置，面板展示 root board 的 sources，并清楚标注这些设置与 root workspace 共享。
+
+### Start Prompt Editor
+
+点击 Start 后不立即创建 run，而是打开 prompt editor：
+
+- 预填后端渲染的 prompt。
+- 显示模板来源：source/workspace/global/fallback。
+- 显示并允许选择 runtime target。
+- 显示 execution workspace 策略和 fork 预览。
+- 显示并发预览；如果会排队，明确显示 queue ticket 将被创建以及预计等待的 slot 口径。
+- 显示 review policy 和 reviewer runtime target。
+- 用户可以编辑。
+- 确认后进入 start pipeline：如果并发 slot 可用才准备 execution workspace 并创建 session/run；如果会排队，则只创建 queue ticket 和 prompt snapshot，不提前 fork workspace 或创建 run。
+
+Request changes 也打开类似编辑器，但默认模板包含 `feedback`。
+
+## API 方向
+
+现有 `/api/boards/todos*` 保持作为 board item 和 sync 入口。目标设计新增或调整以下能力：
+
+- scope resolution：
+  - request 中的 `workspace_id` 表示当前页面 `view_workspace_id`。
+  - response 返回 `board_workspace_id`、`view_workspace_id`、`is_fork_view`、`forked_from_workspace_id`、`source_workspace_id` 和 `execution_workspace_id`。
+  - service 层在触碰 board persistence 前统一解析 `board_workspace_id`。
+- source 配置：
+  - list/create/update/delete workspace sources。
+  - test/preview GitHub auto-detect result。
+  - per-source sync。
+- handoff：
+  - preview rendered start prompt。
+  - preview rendered request-changes prompt。
+  - start with final prompt。
+  - request changes with final prompt and feedback metadata。
+- execution/runtime：
+  - list runtime target options。
+  - preview concurrency and queue outcome。
+  - start queued handoff when active slots are unavailable。
+  - start AI review according to review policy。
+- collaboration/audit：
+  - list/create comments。
+  - list attempt history。
+  - list events。
+  - list/clear diagnostics。
+  - nudge queue reconciliation。
+- lifecycle：
+  - internal service methods consume run/session/PR lifecycle events。
+
+具体 wire shape 在实现阶段进入 `docs/core/api-design.md`。
+
+## 持久化方向
+
+当前 `board_todo_workspace_state.github_issue_sync_cursor` 是 per workspace/repository 的 GitHub issue cursor。目标设计改为以 `board_workspace_id` 为作用域的 per source cursor：
+
+- `board_todo_sources`：root board workspace source 配置。
+- `board_todo_source_state`：每个 source 的 cursor、sync status、diagnostics。
+- `board_todo_items`：继续保存 board item，增加 `board_workspace_id`、source id/reference 的稳定字段。
+- `board_todo_handoff_templates` 或配置型 JSON：保存 workspace/source 模板覆盖。
+- `board_todo_handoff_prompts` 或等价 prompt snapshot：保存排队和 attempt 所需的完整 `final_prompt` snapshot/ref。
+- execution queue：保存 queued handoff ticket、runtime target、queue kind、diagnostics 和 prompt snapshot reference。
+- runtime policy：保存 workspace/source/runtime target 并发配置和 allowed runtime targets。
+- review metadata：保存 AI review run、review policy、review state 和 review decision。
+- `board_todo_attempts`：保存 start、request changes 和 AI review attempt history。
+- `board_todo_comments`：保存 card-level comment thread。
+- `board_todo_events`：保存 append-only audit log。
+- `board_todo_diagnostics`：保存可恢复 diagnostics。
+
+具体 schema 在实现阶段进入 `docs/core/database-schema.md`。
+
+## 后续实现验收
+
+- 用户可以在 TODO 页面右上角配置 GitHub repo，而不是只能依赖 git remote。
+- Root workspace 和它 fork 出来的 `git_worktree` workspace TODO 页面显示同一组 TODO items、同一 revision 和同一 source settings。
+- Fork workspace source settings 展示 root board sources；从 fork 页面编辑 source 或触发 sync 时修改/同步 root board，不创建 fork-local source、cursor 或 item。
+- Fork workspace 中手动创建或 AI 创建 TODO 时，item 归属 root board，event 记录 `initiated_from_workspace_id`。
+- Root board 更新时，root 页面和所有 fork 页面收到同一个 board delta/invalidation。
+- 多个 source 可以同时启用，sync cursor 不互相覆盖。
+- TODO item 目标去重键使用 `(board_workspace_id/source_workspace_id, source_id, source_key)`；legacy provider/type/key 只用于迁移兼容和展示。
+- Start 和 request changes 都必须经过用户可编辑 prompt。
+- 排队的 Start、request changes 和 AI review 必须能通过 prompt snapshot 找回完整 final prompt，摘要不能作为执行输入。
+- AI auto start 和 AI review 必须可审计，且不能绕过并发限制。
+- Start、request changes 和 AI review 都能形成 attempt history，并在 card detail 中展示。
+- Comments、events、diagnostics 能解释 TODO 的协作过程和失败原因。
+- Runtime target 可以覆盖本地 role、外部 agent role 和 orchestration preset。
+- run/session 生命周期能可靠驱动 card 状态变化。
+- 旧 adapter/dispatcher 体系不再作为新 API 扩展方向；可复用逻辑迁移后，旧 `/api/boards/{board_id}/tasks`、`state-map` 和 `TaskBoardAdapter` 规划删除。

--- a/docs/modules/boards/workspace-todo-board-source-design.md
+++ b/docs/modules/boards/workspace-todo-board-source-design.md
@@ -1,0 +1,347 @@
+# Workspace TODO Board Source Design
+
+## 设计目标
+
+TODO Board source 设计解决三个问题：
+
+1. 当前 GitHub issue source 只能从 workspace git remote 自动探测，用户不能配置。
+2. 当前 cursor 和 repository state 偏 GitHub-only，不适合未来多 source。
+3. `TaskBoardAdapter`、`GitHubAdapter`、`LinearAdapter`、`InternalBoardAdapter` 与真实 TODO Board 实现并存，但语义没有统一，且旧双向 tracker board API 不应继续作为 TODO Board 主线。
+
+目标模型是：root board workspace 拥有一组可配置 source，source adapter 只负责同步和 evidence normalization，Agent Teams board service 负责 item persistence、状态机和 handoff。由 root workspace fork 出来的 `git_worktree` workspace 不拥有独立 TODO source，它的 TODO 页面共享 root board 的 source 配置和 cursor。旧 adapter 中可复用的读取和归一化逻辑可以迁移，旧 move/assign/state-map 语义规划删除。
+
+## Source 类型
+
+v1 支持两种 source：
+
+| Source kind | Provider | 说明 |
+| --- | --- | --- |
+| `manual` | `local` | 用户在 Agent Teams 内创建 TODO，不需要外部 sync |
+| `github_issues` | `github` | 从一个 GitHub repository 的 issues 导入 TODO，PR 只作为 evidence |
+
+预留扩展：
+
+| Source kind | Provider | 说明 |
+| --- | --- | --- |
+| `linear_issues` | `linear` | 从 Linear team/project/view 导入 issue |
+| `jira_issues` | `jira` | 从 Jira JQL/filter 导入 issue |
+| `internal_tasks` | `internal` | 从 Agent Teams task repository 投影候选工作项 |
+| `custom_http` | `custom` | 用户配置 HTTP source，由 adapter 归一化为 source record |
+
+## Source 配置入口
+
+TODO 页面右上角新增设置按钮，打开 source settings 面板。
+
+设置面板属于解析后的 `board_workspace_id`：
+
+- 请求参数中的 `workspace_id` 表示当前页面 `view_workspace_id`。
+- 后端先执行 `resolve_board_workspace_id(view_workspace_id)`。
+- 普通 workspace 只展示自身 board sources。
+- `git_worktree` fork workspace 展示 root board sources；如果允许编辑，实际修改 root board source config。
+- 新建 source 默认绑定 `board_workspace_id`，而不是 fork workspace。
+- 切换 workspace 时 settings 面板按解析后的 `board_workspace_id` 加载对应配置。
+- Connector 健康状态可以显示为辅助信息，但不是配置入口。
+
+Fork workspace UI 必须清楚提示 source settings shared with root workspace，避免用户以为自己正在修改 fork-local board。
+
+### Settings 面板内容
+
+Source 列表显示：
+
+- source display name。
+- source kind/provider。
+- enabled/disabled 状态。
+- source scope，例如 `owner/repo`。
+- 最近同步时间。
+- 最近同步结果和 diagnostics。
+- source 级 handoff template 是否覆盖。
+- 手动 Sync 按钮。
+
+GitHub source 编辑表单包含：
+
+- `display_name`：用户可读名称。
+- `enabled`：是否参与自动/手动 sync。
+- `repository_full_name`：显式 `owner/repo`。
+- `auto_detect_from_workspace`：允许用 workspace git remote 生成默认建议。
+- `credential_ref`：凭据来源，初期可复用已有 GitHub trigger account 或 shared GitHub token。
+- `sync_open_issues`：v1 固定为 true。
+- `sync_pr_evidence`：v1 固定为 true。
+
+## GitHub 自动探测
+
+自动探测不再是唯一行为，而是配置体验中的默认建议。
+
+流程：
+
+1. 用户打开 source settings。
+2. 后端读取 `board_workspace_id` 对应 root/source workspace 的 git remotes。
+3. 如果找到 GitHub remote，返回 suggested repository，例如 `owner/repo`。
+4. 新建 GitHub source 表单预填该 repository。
+5. 用户可以接受、修改或禁用自动探测。
+
+自动探测失败时：
+
+- 不阻止用户手动输入 `owner/repo`。
+- settings 面板显示诊断，例如 `Workspace has no GitHub remote`。
+- board 仍可加载 manual TODO 和其他 enabled source。
+
+如果用户在 fork workspace 页面打开设置或点击检测，自动探测仍以 root/source workspace 为准。fork workspace 的 git remote 不能作为 source identity；最多只能作为 UI 诊断中的辅助信息，不能驱动 fork-local source 创建。
+
+## Source Identity
+
+每个 source 必须有稳定 id，例如 `bsrc_{uuid}`。不要再把 source identity 隐含在 `(workspace_id, source_provider, source_key)` 中。
+
+建议字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `source_id` | 稳定 source id |
+| `workspace_id` | 绑定 board workspace；目标语义可命名为 `board_workspace_id` |
+| `kind` | `manual`、`github_issues` 等 |
+| `provider` | `local`、`github`、`linear` 等 |
+| `display_name` | 用户可读名称 |
+| `enabled` | 是否启用 |
+| `config` | provider-specific Pydantic model 序列化结果 |
+| `created_at` / `updated_at` | 本地配置时间 |
+
+`BoardTodoItem` 目标 identity 应保留：
+
+- `source_id`
+- `source_key`
+
+并可在迁移期保留 `source_provider`、`source_type` 等 legacy/display 字段。目标实现不能再把这些 legacy 字段作为跨 source identity。
+
+其中 `source_key` 是 source 内部稳定 key，例如：
+
+- manual：`manual:{todo_id}`
+- GitHub issue record：`issue:{issue_number}`
+- Linear issue：`issue:{linear_issue_id}`
+
+跨 source 唯一性应由 `(board_workspace_id/source_workspace_id, source_id, source_key)` 保证，而不是把所有 GitHub repo 都压到同一个 workspace cursor。`workspace_id` 在迁移期可继续表示 source workspace；目标文档应优先使用 `board_workspace_id` 表达 board 归属、使用 `source_workspace_id` 表达 TODO 所属原 workspace。
+
+命名层级固定为：
+
+- `source.kind = github_issues`：workspace source 配置类型，表示一个 GitHub repository 的 issue source。
+- `SourceRecord.source_type = github_issue`：adapter 输出的 normalized record 类型。
+- `github_pull_request`：只允许作为 legacy cleanup/evidence 语境出现；PR 在新设计中不是 TODO source/card。
+
+## Source State 和 Cursor
+
+当前 `board_todo_workspace_state.github_issue_sync_cursor` 需要演进为 per-source cursor。
+
+建议 source state：
+
+| 字段 | 说明 |
+| --- | --- |
+| `source_id` | source id |
+| `workspace_id` | board workspace id；目标语义可命名为 `board_workspace_id` |
+| `revision` | 可选，source config/state revision |
+| `sync_cursor` | adapter 私有 cursor，JSON 或 typed string |
+| `last_sync_started_at` | 最近 sync 开始时间 |
+| `last_sync_finished_at` | 最近 sync 完成时间 |
+| `last_sync_status` | `idle`、`running`、`succeeded`、`failed` |
+| `last_diagnostics` | 最近诊断信息 |
+
+GitHub cursor v1：
+
+- full sync：先为当前 source/repo 下所有带 linked GitHub PR refs 的 board item 刷新 linked PR / merged evidence，包括 GitHub issue-backed 和 manual TODO；再拉取 open issues 作为 active open issue set，最后对 missing/non-open records 做 reconcile。
+- incremental sync：按 `updated_since` 拉取 changed issues 和 changed PRs。
+- cursor 成功后推进到 sync start time 减 1 秒，保留当前实现的容错思想。
+
+多 source 时，每个 source 独立推进 cursor。一个 source 失败不能阻止其他 source 同步。
+
+### Fork Workspace Source Inheritance
+
+Fork workspace 是 execution workspace 或 view workspace，不是独立 TODO source workspace。
+
+规则：
+
+- Fork workspace 不创建独立 `board_todo_sources`。
+- Fork workspace 不创建独立 `board_todo_source_state` 或 cursor。
+- Fork workspace 不因为打开 TODO 页面或点击 Sync 而创建独立 `board_todo_items`。
+- Source settings 在 fork workspace 中展示 root board sources；编辑 source、启用/禁用 source、修改 GitHub `owner/repo`、修改 source template 都写入 root board workspace。
+- 从 fork 页面触发 sync 时，sync root board sources 和 root cursors。
+- GitHub repo/source config 只属于 root board workspace；自动探测只作为 root source 配置建议。
+- Manual source 也归属 root board workspace；在 fork 页面创建 manual TODO 时，TODO 写入 root board，event 记录 `initiated_from_workspace_id = fork_workspace_id`。
+
+如果 root workspace 已删除、缺失或解析出现 cycle，source settings 和 sync 返回 diagnostics，例如 `board_scope_missing_root`，不得悄悄创建 fork-local source。
+
+## Source Adapter 抽象
+
+旧 `TaskBoardAdapter` 同时包含 `list_tasks`、`move_task`、`assign_task`、`add_comment`、`add_artifact`，更像外部 tracker 的双向 board 操作接口。新的 TODO Board 不应该让 adapter 拥有 board column state，因此只能迁移其读取和归一化思路；旧 `TaskBoardAdapter` 类型、`/api/boards/{board_id}/tasks` 和 `state-map` API 规划删除，不再改造成新的公开扩展点。
+
+目标接口语义：
+
+```text
+BoardTodoSourceAdapter
+  describe_config()
+  validate_config(config)
+  resolve_default_config(workspace)
+  sync(config, state, mode) -> SourceSyncResult
+  fetch_completion_evidence(item_refs) -> EvidenceResult
+```
+
+Source adapter 输出 normalized records，而不是直接写 board item：
+
+```text
+SourceRecord
+  source_key
+  source_type
+  title
+  body
+  source_url
+  source_updated_at
+  external_status
+  references
+  raw_summary
+```
+
+```text
+SourceEvidence
+  source_key
+  evidence_type
+  linked_url
+  linked_number
+  completed
+  completed_at
+  reason
+```
+
+Board service 消费 adapter 输出：
+
+- 根据 source record upsert `BoardTodoItem`。
+- 根据 evidence 触发状态机事件。
+- 根据 sync mode reconcile missing/closed external records。
+- 写 revision/delta。
+
+## GitHub Source 行为
+
+### 导入规则
+
+- GitHub `/issues` 中带 `pull_request` 对象的记录不是 TODO item。
+- open issue 导入或更新为 TODO item。
+- closed issue 不作为新 TODO 导入。
+- 已存在 active item 被观察为 closed：
+  - 如果 linked PR merged 且 item 已在 `review`，进入 `done`。
+  - 如果 linked PR merged 但 item 仍在 `todo` 或 `in_progress`，只记录 evidence，等待 run lifecycle 或用户动作决定状态。
+  - 如果 item 已在 `done`，保持 `done`，只补充 closed evidence，不自动 archive。
+  - 否则自动 archive，并记录 source reason；archive 前必须取消 pending/claimed queue ticket、释放 queue slot，并 supersede active AI review attempt。若已有 active executor run，Boards 应请求 stop/cancel，且在 run 进入 terminal 前继续计入 workspace/runtime active slot；item 标为 archived 后忽略该 run 后续对 board status 的自动推进，只保留 event/diagnostic。
+
+### PR Evidence
+
+PR 不单独成为 TODO card。PR 的作用：
+
+- 通过 issue timeline 或用户手动 link 关联到 issue/manual TODO。
+- merged PR 可以把 linked `review` item 推进到 `done`。
+- 对 linked `todo` 或 `in_progress` item，merged PR 只记录 completion evidence，不抢占 board/run lifecycle。
+
+### Reopen 行为
+
+GitHub issue reopened 时：
+
+- 只恢复由 source reconciliation 自动 archive 的 item。
+- 用户手动 archive 的 item 不自动恢复。
+- 恢复目标状态为 `todo`，不恢复 archive 前状态，避免绕过 session/run 状态机。
+
+### Explicit Repo 优先级
+
+GitHub source repository 解析优先级：
+
+1. source config 中显式 `repository_full_name`。
+2. 新建配置时的 auto-detect suggestion。
+3. 无配置时不再默默 sync；只显示 diagnostics。
+
+现有“自动从 remote 推导并立即 sync”的行为应作为迁移 fallback，而不是长期目标。
+
+## Manual Source 行为
+
+Manual TODO 不是外部 source sync 的结果，但仍应建模为 source：
+
+- 每个 workspace 默认有一个 system-managed `manual` source。
+- 用户创建 manual TODO 时，source 为该 manual source。
+- manual source 没有 cursor。
+- manual TODO 不会被外部 sync 自动 archive 或 restore。
+
+这样 manual 和 external item 在 UI、revision、handoff 中使用同一套 board item 模型。
+
+## Linear/Internal Adapter 整合
+
+旧 `LinearAdapter`、`InternalBoardAdapter` 可迁移为 `sources/linear.py` 和 `sources/internal.py` 的基础，但必须改变语义：
+
+- `list_tasks` 转为 `sync` 输出 `SourceRecord`。
+- `move_task` 不作为 board status 更新主路径。
+- `add_comment`/`add_artifact` 可保留为 optional evidence delivery capability，但不属于 v1 必需能力。
+- `TaskBoardStateMap` 不再映射到 TODO Board column；旧兼容 API 删除前只能视为 legacy，不作为新设计依赖。
+
+旧 dispatcher 的 polling/worker outcome loop 不作为新 TODO Board 的调度核心。新设计由 source sync service 和 lifecycle bridge 分别负责外部同步与 run/session 状态消费；旧 dispatcher 相关 API 后续删除。
+
+## Source Sync 模式
+
+| 模式 | 用途 | 行为 |
+| --- | --- | --- |
+| `full` | 用户手动全量同步、首次同步 | 先刷新所有 linked PR / merged evidence，再拉取 source active set，最后 reconcile missing/non-open records |
+| `incremental` | 背景刷新、页面 delta | 使用 per-source cursor 拉取 changed records |
+| `preview` | 配置验证 | 不写 item，只返回可同步数量、诊断和示例记录 |
+
+同步失败：
+
+- source state 记录失败 diagnostics。
+- board 仍返回已有本地数据。
+- 失败 source 不推进 cursor。
+- 多 source sync 时继续执行其他 source。
+
+## API 方向
+
+目标 API 仅作为设计方向，具体 schema 在实现阶段写入 core API 文档。
+
+```text
+GET    /api/boards/todo-sources?workspace_id=...
+POST   /api/boards/todo-sources
+PATCH  /api/boards/todo-sources/{source_id}
+DELETE /api/boards/todo-sources/{source_id}
+POST   /api/boards/todo-sources:detect
+POST   /api/boards/todo-sources/{source_id}:sync
+POST   /api/boards/todo-sources/{source_id}:preview-sync
+```
+
+API request 中的 `workspace_id` 是当前页面 `view_workspace_id`。Response 应返回 `board_workspace_id`、`view_workspace_id`、`is_fork_view` 和 `forked_from_workspace_id`，让前端缓存和设置面板以 root board 为主 key。
+
+Source 删除语义：
+
+- `DELETE /api/boards/todo-sources/{source_id}` 只允许删除没有 item、template、cursor、diagnostic 引用的 source。
+- 如果 source 已经导入过 TODO 或仍有 active/done/archived item，首版 UI 应提供 disable/archive source 语义，而不是物理删除；`PATCH enabled=false` 保留 `source_id`、cursor、diagnostics 和 item/source context。
+- 用户需要停止同步时使用 disable；已有 TODO 保持线性 board item，不因 source disabled 自动删除。
+- 后续若支持强制删除，必须先把 item 转成 `source_provider=manual` 或写入 tombstone source record，避免 preview/sync/diagnostic 出现 dangling `source_id`。
+
+现有：
+
+```text
+POST /api/boards/todos:sync
+POST /api/boards/todos:sync-changes
+```
+
+可以作为 workspace-level sync，内部遍历 enabled sources。手动 sync 默认 `full`，背景 sync 默认 `incremental`。
+
+## 测试矩阵
+
+| 场景 | 期望 |
+| --- | --- |
+| 显式 GitHub repo | sync 使用配置 repo，不读取 git remote 作为最终值 |
+| 自动探测成功 | 新建 source 表单预填 `owner/repo` |
+| 自动探测失败 | 用户仍可手动配置 GitHub repo |
+| 多 GitHub source | 每个 source cursor 独立推进 |
+| source disabled | 不参与自动和 workspace-level sync |
+| delete unused source | 删除 source config 和空 cursor/diagnostic 引用 |
+| delete source with imported items | 拒绝物理删除，引导使用 `enabled=false` |
+| GitHub token 缺失 | 返回 source diagnostics，不影响 manual TODO |
+| issue open | upsert TODO item |
+| issue closed without merged PR and item in `todo`/`in_progress`/`review` | 自动 archive |
+| issue closed without merged PR and item in `done` | 保持 `done`，只记录 closed evidence |
+| issue closed with merged PR and item in `review` | 进入 `done` |
+| issue closed with merged PR and item in `todo`/`in_progress` | 只记录 PR merged evidence，不抢占 run lifecycle |
+| issue reopened | 只恢复 source 自动 archive 的 item |
+| manual archived | 不被 source sync 自动恢复 |
+| fork workspace 打开 source settings | 展示 root board sources，并标明 shared with root workspace |
+| fork workspace 编辑 GitHub repo | 修改 root board source config，不创建 fork-local source |
+| fork workspace 触发 sync | 使用 root board sources/cursors，不读取 fork remote 作为 source identity |
+| root workspace 缺失 | 返回 diagnostics，不创建 fork-local board/source |

--- a/docs/modules/boards/workspace-todo-board-state-machine.md
+++ b/docs/modules/boards/workspace-todo-board-state-machine.md
@@ -1,0 +1,333 @@
+# Workspace TODO Board State Machine
+
+## 设计目标
+
+TODO Board 状态机要解决两个一致性问题：
+
+- Board card 所在列必须反映 Agent Teams 对该 TODO 的处理状态，而不是外部 tracker 的状态。
+- Board card 必须与绑定 session/run 生命周期保持一致，不能出现 run 已失败、删除或完成但 card 长期停在错误列。
+
+本设计把状态变化归纳为事件驱动：用户操作、run lifecycle、session lifecycle、source evidence 和 sync reconciliation 都转换为明确的 board transition。
+
+## Board 状态
+
+| 状态 | 含义 | 是否主看板显示 |
+| --- | --- | --- |
+| `todo` | 可启动，当前没有 active bound run | 是 |
+| `in_progress` | 已发放给 AGENTS 或进入执行队列；可能尚未创建 run，也可能绑定当前 run 正在执行或等待恢复 | 是 |
+| `review` | bound run 已完成，等待用户验收、AI review 或 completion evidence | 是 |
+| `done` | 已完成，通常由用户确认或 linked PR merged 证明 | 是 |
+| `archived` | 软删除或 source reconciliation 移出主看板 | 否，独立 archive 视图 |
+
+状态 owner：
+
+- `status` 由 Agent Teams board domain 拥有。
+- GitHub issue state、Linear issue state、run runtime status 都不是 board status。
+- 外部状态只能作为 transition evidence。
+
+状态机执行前必须先完成 board scope resolution。请求参数中的 `workspace_id` 表示当前页面 `view_workspace_id`；transition、revision、source reconciliation 和 archive/restore 都作用在解析后的 `board_workspace_id` 上。`git_worktree` fork workspace 不拥有独立状态机实例；它展示和操作 root board 的同一批 item。由 fork view 触发的 transition 只在 event/attempt metadata 中记录 `initiated_from_workspace_id`。
+
+## Run Runtime 映射
+
+Board item 通过 executor `run_id` 绑定当前处理 run。AI review 使用独立 `review_run_id`，不能复用 executor `run_id`。Lifecycle bridge 必须先根据 `active_attempt_id` 和 attempt type 判断 run 事件属于 executor attempt 还是 AI review attempt：
+
+- executor run terminal 驱动 `in_progress -> review` 或 `in_progress -> todo`。
+- AI review run terminal 只更新 `review_state`、`review_decision` 和 `review_run_id` 相关 attempt；只有 `ai_auto_done` 且 decision 为 approved 时，才通过 lifecycle 执行 `review -> done`。
+
+executor run runtime status 映射如下：
+
+| RunRuntimeStatus | Board 解释 | Board 目标状态 |
+| --- | --- | --- |
+| `queued` | 已提交，尚未开始执行 | `in_progress` |
+| `running` | 正在执行 | `in_progress` |
+| `stopping` | 正在停止，尚未到终态 | `in_progress` |
+| `paused` | 等待人工输入、审批或恢复 | `in_progress` |
+| `completed` | 本次执行完成，进入验收 | `review` |
+| `failed` | 本次执行失败，需要重新启动 | `todo` |
+| `stopped` | 用户或系统停止，需要重新启动 | `todo` |
+| missing run | stale 引用，不能继续显示执行中 | `todo` |
+
+注意：
+
+- `paused` 不应回到 `todo`，因为它仍是可恢复或等待中的 active run。
+- `stopping` 不应提前回到 `todo`，避免用户并发启动第二个 run。
+- `completed` 只进入 `review`，不直接进入 `done`，除非同时存在完成证据。
+
+## 派生执行事实
+
+`in_progress` 是主列状态，表示 TODO 已被发放或正在处理。Boards 不再定义一套对外公共的 `queued`、`preparing`、`running`、`paused`、`ai_reviewing` 子标签体系。卡片上的细节展示从以下事实派生：
+
+| 事实 | Board status | 说明 |
+| --- | --- | --- |
+| active queue ticket exists | `in_progress` | handoff 已确认，但 source workspace 或 runtime target 并发 slot 暂不可用；此时允许 `session_id/run_id` 为空，必须能通过 prompt snapshot/ref 找回完整 final prompt |
+| active attempt has not created run | `in_progress` | 已获得 slot，正在准备 execution workspace 或创建 session/run；这是内部 attempt phase，不是公共 board 状态 |
+| bound run runtime is `queued/running/paused/stopping` | `in_progress` | 展示直接来自 `RunRuntimeStatus` |
+| AI review attempt active | `review` | executor run 已完成，AI review run 正在执行或等待 reviewer runtime slot |
+| unresolved diagnostics exists | any non-archived status | 表示需要关注的错误或警告，不改变 board status |
+
+实现阶段可以在 attempt 或 queue ticket 上保存内部 phase，例如 `waiting_for_slot`、`preparing_workspace`、`starting_run`。这些 phase 用于恢复和诊断，不作为新的 board column 或跨模块公共状态体系。
+
+## Session 关系
+
+Board item 可以绑定 `session_id`：
+
+- Start 创建 dedicated session，并写入 metadata，例如 `board_todo_id`。
+- Request changes 在同一个 session 中创建新 run。
+- Session 删除时必须清理 board 引用。
+
+Session 删除规则：
+
+| 当前 board 状态 | 行为 |
+| --- | --- |
+| `archived` + no active executor/reviewer refs | 不处理，保持 archived |
+| `archived` + deleted bound executor/reviewer session | 保持 archived，清理匹配 refs，释放或 reconcile slot，记录 event/diagnostic |
+| `done` + deleted executor session | 保持 done，清理 `session_id/run_id`，记录 reason |
+| `done` + deleted AI review session | 保持 done，清理匹配的 `review_run_id`，记录 reason |
+| `todo` | 清理 `session_id/run_id`，保持 todo |
+| `in_progress` | 回到 todo，清理 `session_id/run_id`，取消 pending/claimed queue ticket |
+| `review` + deleted executor session | 回到 todo，清理 `session_id/run_id`，取消/supersede active AI review attempt |
+| `review` + deleted AI review session | 保持 review，清理 `review_run_id`，将 AI review attempt 标记 failed |
+
+设计理由：
+
+- 已完成 item 不应因 session 删除而失去完成状态。
+- 未完成 item 不能继续引用已删除 session。
+- `review` 回到 `todo` 只适用于 executor session 被删除的情况，因为用户无法继续检查执行上下文。
+- AI review session/run 只影响 reviewer attempt，不拥有 executor lifecycle；删除后 item 保持 `review`，等待人工确认、重新 AI review 或 request changes。
+
+## 状态流转表
+
+| From | Event | Guard | To | Side effects |
+| --- | --- | --- | --- | --- |
+| `todo` | user confirms handoff | final prompt 非空且 slot available | `in_progress` | save prompt snapshot, acquire slot, prepare execution workspace, then create session/run and bind ids |
+| `todo` | user/AI confirms handoff but concurrency full | `queue_if_full=true` | `in_progress` | create queue ticket and start attempt |
+| `todo` | AI auto start | allowed source/workspace policy | `in_progress` | same as confirmed handoff; may queue |
+| `todo` | user archive | none | `archived` | set `archived_at`, reason |
+| `in_progress` | queue ticket acquired slot | active queue ticket exists | `in_progress` | claim ticket, prepare workspace, create session/run, then mark ticket completed and clear `queue_ticket_id` atomically |
+| `in_progress` | workspace/run start failed | before run bound | saved prior status (`todo` for Start, `review` for Request Changes) | clear queue/slot refs, reason, record diagnostic |
+| `in_progress` | run completed | bound `run_id` matches and linked PR merged evidence already stored | `done` | consume stored completion evidence, keep attempt summary |
+| `in_progress` | run completed | bound `run_id` matches | `review` | keep session/run, reason |
+| `in_progress` | run failed/stopped | bound executor `run_id` matches | `todo` | move failed session/run refs into attempt history, clear current `session_id/run_id`; next Start creates a new dedicated session |
+| `in_progress` | run missing | stale `run_id` | `todo` | clear `session_id/run_id`, reason |
+| `todo` | linked PR merged | linked PR evidence | `todo` | record evidence only; do not mark done |
+| `in_progress` | linked PR merged | linked PR evidence | `in_progress` | record evidence only; do not interrupt executor lifecycle |
+| `in_progress` | user archive | none | `archived` | cancel pending/claimed queue ticket if present; request stop/cancel for active executor run, move current refs into attempt history or detach from item row, hide from main view |
+| `review` | request changes confirmed | final prompt 非空且有有效 `session_id` 和 reusable `execution_workspace_id` | `in_progress` | cancel/supersede active AI review attempt if present, archive prior `review_state/review_decision/review_run_id` with old attempt, reset current review metadata, move previous executor run into attempt history, create new run in bound session |
+| `review` | request changes confirmed | 缺少有效 review execution context | `review` | return conflict/diagnostic，不创建 disconnected session |
+| `review` | request changes confirmed but concurrency full | `queue_if_full=true` 且有有效 review execution context | `in_progress` | cancel/supersede active AI review attempt if present, archive prior `review_state/review_decision/review_run_id` with old attempt, reset current review metadata, move previous executor run into attempt history, clear current executor `run_id`, create queue ticket, reuse execution workspace |
+| `review` | AI review started | review policy enabled and valid completed executor context exists | `review` | create or queue review run, set review state |
+| `review` | AI review started | missing completed executor context | `review` | write `review_context_missing` diagnostic, do not create reviewer run |
+| `review` | AI review queue ticket acquired reviewer slot | active AI review queue ticket exists | `review` | claim ticket, read review prompt snapshot, create review run, mark ticket completed and clear review queue ref atomically |
+| `review` | AI review approved | `review_policy=ai_auto_done` | `done` | save AI decision |
+| `review` | AI review approved | `review_policy=ai_pre_review` | `review` | save summary, wait human |
+| `review` | AI review changes requested | none | `review` | save feedback, offer request changes |
+| `review` | linked PR merged | evidence trusted | `done` | set linked PR evidence, cancel/supersede active AI review attempt |
+| `review` | user marks done | user confirmation | `done` | cancel/supersede active AI review attempt, reason `Completed by user` |
+| `review` | user archive | none | `archived` | cancel/supersede active AI review attempt, set `archived_at`, reason |
+| `done` | user archive | none | `archived` | set `archived_at`, reason |
+| `archived` | user restore | manual action | `todo` | clear `archived_at`; clear stale `session_id/run_id/review_run_id/queue_ticket_id` after moving refs into attempt history; do not restore previous status |
+| `archived` | source reopened | auto-archived by source | `todo` | clear `archived_at`; clear stale `session_id/run_id/review_run_id/queue_ticket_id` after moving refs into attempt history; reason |
+| `archived` | source reopened | manually archived | `archived` | no-op |
+
+## Mermaid 状态图
+
+```mermaid
+stateDiagram-v2
+    [*] --> todo: manual create or source import
+
+    todo --> in_progress: user or AI confirms handoff
+    todo --> archived: user archive
+
+    in_progress --> in_progress: active queue ticket waits for slot
+    in_progress --> in_progress: slot acquired, workspace/run starting as attempt phase
+    in_progress --> done: bound run completed with stored PR evidence
+    in_progress --> review: bound run completed without completion evidence
+    in_progress --> todo: bound run failed/stopped/missing
+    in_progress --> todo: Start workspace/run start failed
+    in_progress --> review: Request Changes workspace/run start failed
+    in_progress --> archived: user archive
+
+    review --> in_progress: request changes confirmed
+    review --> review: AI review queue ticket claimed
+    review --> review: AI review attempt active
+    review --> review: AI approved but human required
+    review --> done: AI approved with ai_auto_done
+    review --> done: linked PR merged
+    review --> done: user marks done
+    review --> archived: user archive
+
+    done --> archived: user archive
+
+    archived --> todo: user restore
+    archived --> todo: source reopened after source-auto archive
+```
+
+## Source Evidence 事件
+
+Source sync 不能直接写任意 board 状态；它只能产生标准事件。
+
+`source-driven archive cleanup` 与人工 archive 的执行清理一致：取消 pending/claimed queue ticket 并释放 queue slot，supersede active AI review attempt。若 executor run 已经存在，Boards 应请求 stop/cancel；在 run 进入 terminal 前，workspace/runtime active slot 继续计数，archived item 忽略该 run 后续对 board status 的自动推进，只记录 event/diagnostic。
+
+| Source evidence | 适用 item | Board 行为 |
+| --- | --- | --- |
+| source record open/updated | source-auto archived item | upsert content，restore to `todo` |
+| source record open/updated | existing or new non-source-archived item | upsert content，保持现有 board status |
+| source record closed | `done` GitHub issue item | record closed evidence only, keep `done` |
+| source record closed | active GitHub issue item | 若无 merged PR evidence，则按 source-driven archive cleanup 后 archive |
+| source record missing in full sync | active GitHub issue item | 若无 merged PR evidence，则按 source-driven archive cleanup 后 archive |
+| source record reopened | source-auto archived item | restore to `todo` |
+| linked PR discovered | non-archived GitHub/manual item | 写 linked PR fields，不一定完成 |
+| linked PR merged | linked `review` item | move to `done` |
+| linked PR merged | linked `todo` or `in_progress` item | record evidence only, keep current status |
+
+### GitHub issue closed
+
+GitHub issue closed 有两种含义：
+
+- 用户关闭 issue 但没有 merged PR：非 `done` 的 active board item 自动 archive；已经 `done` 的 item 保持 `done`。
+- issue 被 PR 关闭且 PR merged：作为完成证据；只有 item 已在 `review` 时进入 `done`，`todo`/`in_progress` 只记录 evidence。
+
+因此 closed issue 不能简单等同于 done。
+
+PR merged 也不能简单等同于所有 linked item 完成。它只自动完成已经进入 `review` 的 TODO。若 TODO 仍在 `todo` 或 `in_progress`，PR merged evidence 应保存到 item/attempt/event 中，等待 executor run terminal、用户确认或后续 review policy 决定是否进入 `done`。
+
+### GitHub issue reopened
+
+Reopened 只能恢复由 source 自动 archive 的行：
+
+- `last_status_reason` 是 `GitHub issue closed` 或 `GitHub issue no longer open` 等 source reconciliation reason。
+- 用户手动 archive 的行不恢复。
+
+恢复后状态固定为 `todo`，不恢复旧状态，避免绕过 run/session 状态机。
+
+## Archive 语义
+
+`archived` 是软删除，不是完成状态。
+
+Archive 来源：
+
+- 用户手动 archive。
+- source full sync 发现 item 不再 open。
+- source incremental sync 观察到 item closed。
+- cleanup 归档不应出现在 TODO board 中的历史 PR item。
+
+Restore 语义：
+
+- 用户 restore 总是回到 `todo`。
+- source reopened restore 也回到 `todo`。
+- restore 不恢复 archive 前状态。
+- restore 不重建已删除 session/run。
+
+## Request Changes 语义
+
+`request changes` 只允许从 `review` 发起：
+
+1. 用户输入 feedback。
+2. 后端渲染 request-changes prompt。
+3. 用户编辑并确认 final prompt。
+4. 复用 execution workspace 和 executor runtime target，除非用户显式更换 runtime target。
+5. 若并发 slot 可用，在 bound session 中创建新 run。
+6. 若并发 slot 不可用且允许 queue，item 回到 `in_progress`，写入 request changes queue ticket。
+7. run 创建成功后，executor `run_id` 更新为新 run。
+
+Request Changes 发放前必须取消或 supersede 该 TODO 上仍 active 的 AI review queue ticket / review run，避免旧 reviewer 对上一轮 executor attempt 的结论覆盖返工中的 item。上一轮已完成的 `review_state`、`review_decision`、`review_run_id` 归档到 prior attempt metadata，当前 review metadata 清空。进入 queue 时，上一轮已完成 executor run 从 item 当前引用移入 attempt history，item 的 current executor `run_id` 为空，直到新 run 创建成功后再绑定。
+
+Legacy 迁移规则：
+
+- 如果已有 `review` item 来自旧实现，缺少 `execution_workspace_id` 但仍有 `session_id`，request changes 只能从旧 session workspace 或旧 completed attempt workspace 推导 execution workspace；不能使用当前页面 `view_workspace_id`。无法证明原执行 workspace 时返回 conflict。
+- 新目标数据仍应保存明确的 `execution_workspace_id`；legacy fallback 只用于避免旧 review item 无法返工。
+
+如果 item 没有 bound session：
+
+- v1 可以返回 conflict，要求用户重新 Start。
+- 不应隐式创建新 session 继续 request changes，否则 review 上下文会断裂。
+
+## Concurrency 和 Reservation
+
+Start 和 request changes 都需要 reservation：
+
+- `todo -> in_progress` reservation 防止双击 Start 创建两个 run。
+- `review -> in_progress` reservation 防止并发 request changes。
+- 如果创建 session/run 失败，状态恢复到原状态并记录失败 reason。
+
+Reservation 状态可以继续复用当前实现中“先写 `in_progress` 且 `run_id=None`”的思路，但目标设计中需要区分 transient reservation 和稳定的 queue ticket：
+
+- transient reservation：短时间内部状态，用于防止重复启动。
+- queue ticket：用户可见事实，有 `queue_ticket_id`，表示等待并发 slot；它不是新的 board 状态。
+
+queue ticket 必须引用完整 handoff prompt snapshot。只保存 prompt 摘要不足以让 queue worker 在稍后可靠创建 run。
+
+并发限制采用 Workspace+Runtime 双口径：
+
+| Scope | v1 默认值 | 说明 |
+| --- | --- | --- |
+| source workspace active limit | `2` | 同一 source workspace 同时 active 的 TODO 数 |
+| runtime concurrency key active limit | `1` | 同一 normalized runtime concurrency key 同时 active 的 TODO 数；external role 使用 bound external agent/runtime identity |
+
+占用 active slot 的事实包括：attempt 已获得 slot 且正在准备 execution workspace、attempt 正在创建 session/run、bound run runtime 为 `queued/running/paused/stopping`。仅有 queue ticket 且尚未 claim slot 时不占 active slot。
+
+## Review Policy 语义
+
+Review 阶段可以由人、AI 或二者组合完成：
+
+| review_policy | 行为 |
+| --- | --- |
+| `human_required` | run completed 后进入 `review`，等待用户确认或 request changes |
+| `ai_pre_review` | 自动启动 AI review，AI 结论展示给人，最终仍由人确认 |
+| `ai_auto_done` | AI review 通过后可直接 `review -> done` |
+
+AI review decision 映射：
+
+| decision | 行为 |
+| --- | --- |
+| `approved` + `ai_auto_done` | `review -> done` |
+| `approved` + `ai_pre_review` | 保持 `review`，展示 AI 摘要 |
+| `approved` + `human_required` | 保持 `review`，展示 AI 摘要 |
+| `changes_requested` | 保持 `review`，用户可发起 request changes |
+| `needs_human` | 保持 `review` |
+| `failed` | 保持 `review`，记录 diagnostics |
+
+AI review 不自动触发 request changes；自动返工需要后续单独设计。
+
+## Reconcile 时机
+
+Board lifecycle reconciliation 发生在：
+
+- board list/delta 前的轻量 reconcile。
+- run terminal event 回调。
+- session delete 回调。
+- source sync 完成后。
+- 后端启动恢复时的必要 cleanup。
+
+Reconcile 不应做外部网络调用，外部网络调用属于 source sync adapter。
+
+## 测试矩阵
+
+| 场景 | 期望 |
+| --- | --- |
+| Start 成功 | `todo -> in_progress`，写 session/run |
+| Start 并发满且允许 queue | `todo -> in_progress`，写 queue ticket |
+| Start 并发满且不允许 queue | 返回 conflict，保持 `todo` |
+| queue ticket 获得 slot | claim ticket，准备 execution workspace，创建 session/run，后续由 `RunRuntimeStatus` 驱动展示 |
+| Start 创建 run 失败 | 回到 `todo`，reason `Start failed` |
+| run completed | `in_progress -> review` |
+| run failed | `in_progress -> todo`，清理当前 run |
+| run stopped | `in_progress -> todo`，清理当前 run |
+| run queued/running/paused/stopping | 保持 `in_progress` |
+| run missing | 回到 `todo`，清理 stale refs |
+| request changes 成功 | `review -> in_progress`，新 run id |
+| request changes 并发满 | `review -> in_progress`，写 request changes queue ticket |
+| AI pre review 通过 | 保持 `review`，等待人确认 |
+| AI auto done 通过 | `review -> done` |
+| AI review changes requested | 保持 `review`，展示建议 |
+| linked PR merged | linked `review` item -> `done`；linked `todo`/`in_progress` item 只记录 evidence |
+| linked PR merged while in_progress | 保持 `in_progress`，executor run terminal 仍是状态主输入 |
+| AI review run completed | 只更新 review attempt/decision，不触发 executor run 映射 |
+| session deleted with done item | 保持 `done`，清 refs |
+| session deleted with review item and executor session | 回到 `todo`，清 executor refs，supersede active AI review |
+| session deleted with review item and AI review session | 保持 `review`，清 `review_run_id`，AI review attempt failed |
+| legacy review item without execution workspace | request changes 使用 `current_workspace` fallback |
+| manual archive then GitHub reopened | 仍保持 `archived` |
+| source-auto archive then GitHub reopened | 恢复到 `todo` |
+| fork workspace archive/restore | 作用于 root board item，event 记录 fork view workspace |
+| root workspace 缺失或 scope cycle | 不创建 fork-local board，返回 diagnostics |


### PR DESCRIPTION
## Summary

- Split and expand Workspace TODO Board design docs into overview, source, state machine, handoff, execution runtime, collaboration, and module layout documents.
- Clarify configurable GitHub sources, linear TODO flow, attempt/comment/event/diagnostic models, AI start/review, runtime targets, queue reliability, and fork worktree execution isolation.
- Add board scope resolution so forked git_worktree workspaces share the root workspace TODO board via board_workspace_id/view_workspace_id semantics.

Fixes #813

## Validation

- uv run --extra dev pre-commit run --files docs/modules/boards/workspace-todo-board-design.md docs/modules/boards/workspace-todo-board-agent-handoff.md docs/modules/boards/workspace-todo-board-collaboration-design.md docs/modules/boards/workspace-todo-board-execution-runtime-design.md docs/modules/boards/workspace-todo-board-module-layout.md docs/modules/boards/workspace-todo-board-overview.md docs/modules/boards/workspace-todo-board-source-design.md docs/modules/boards/workspace-todo-board-state-machine.md