### PR TITLE
feat: constrain Windows batch line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Shell scripts must keep LF endings — CRLF breaks #!/bin/sh in Linux containers.
 *.sh text eol=lf
 docker/* text eol=lf
+
+# Windows batch files must keep CRLF endings.
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/tests/unit_tests/frontend/test_system_status_ui.py
+++ b/tests/unit_tests/frontend/test_system_status_ui.py
@@ -1427,13 +1427,16 @@ function installGlobals(elements) {{
             return element;
         }},
     }};
-    globalThis.navigator = {{
-        clipboard: {{
-            async writeText(value) {{
-                globalThis.__clipboardWrites.push(String(value));
+    Object.defineProperty(globalThis, 'navigator', {{
+        configurable: true,
+        value: {{
+            clipboard: {{
+                async writeText(value) {{
+                    globalThis.__clipboardWrites.push(String(value));
+                }},
             }},
         }},
-    }};
+    }});
     globalThis.__fetchConfigStatusCalls = 0;
     globalThis.__reloadMcpCalls = 0;
     globalThis.__reloadSkillsCalls = 0;


### PR DESCRIPTION
## Summary
- Add .gitattributes rules that keep Windows batch files (*.bat and *.cmd) normalized to CRLF.
- Update the frontend system status unit-test harness to install the mock navigator via Object.defineProperty so it works with Node versions where global navigator is readonly.

Fixes #821

## Tests
- git check-attr text eol -- setup.bat docs/example.cmd
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests
- uv run --extra dev bandit -r src --configfile pyproject.toml --severity-level medium --confidence-level medium
- uv run --extra dev xenon --max-absolute F --max-modules C --max-average B --exclude src/relay_teams/builtin/skills/pptx-craft/scripts/svg_to_pptx src/relay_teams src/relay_teams_evals