### PR TITLE
Fix board workspace after memory view

### DIFF
--- a/frontend/dist/js/components/projectView.js
+++ b/frontend/dist/js/components/projectView.js
@@ -101,6 +101,7 @@ import { showConfirmDialog, showFormDialog, showToast } from '../utils/feedback.
 import { logWarn, sysLog } from '../utils/logger.js';
 
 let currentWorkspace = null;
+let lastKnownWorkspaceId = '';
 let currentAutomationProject = null;
 let currentProjectViewMode = 'workspace';
 let currentFeatureViewId = '';
@@ -2733,7 +2734,16 @@ function renderFeatureEmptyState(title, copy, action = '') {
     `;
 }
 
+function rememberLastKnownWorkspaceId(workspaceId = state.currentWorkspaceId) {
+    const safeWorkspaceId = String(workspaceId || '').trim();
+    if (!safeWorkspaceId || safeWorkspaceId.startsWith('feature:')) {
+        return;
+    }
+    lastKnownWorkspaceId = safeWorkspaceId;
+}
+
 function openFeatureShell(featureId) {
+    rememberLastKnownWorkspaceId();
     cacheProjectViewState();
     resetFeatureSurface();
     currentProjectViewMode = 'feature';
@@ -4091,6 +4101,7 @@ export async function openWorkspaceProjectView(workspace) {
         return;
     }
 
+    rememberLastKnownWorkspaceId(workspaceId);
     abortCurrentFeatureRequest();
     currentFeatureRequestToken += 1;
     cacheProjectViewState();
@@ -4329,6 +4340,7 @@ function resolveBoardsFeaturePreferredWorkspaceId() {
     return String(
         state.pendingNewSessionWorkspaceId
         || state.currentWorkspaceId
+        || lastKnownWorkspaceId
         || '',
     ).trim();
 }
@@ -4414,6 +4426,7 @@ export function prepareExternalFeatureView(featureId) {
     if (!safeFeatureId) {
         return;
     }
+    rememberLastKnownWorkspaceId();
     abortCurrentFeatureRequest();
     currentFeatureRequestToken += 1;
     resetFeatureSurface();

--- a/tests/unit_tests/frontend/test_project_view_ui.py
+++ b/tests/unit_tests/frontend/test_project_view_ui.py
@@ -5167,9 +5167,11 @@ import {
     openBoardsFeatureView,
 } from "./projectView.mjs";
 import { openMemoryFeatureView } from "./memoryView.mjs";
+import { state } from "./mockState.mjs";
 import { els, flushTasks } from "./mockDom.mjs";
 
 initializeProjectView();
+state.currentWorkspaceId = "alpha-project";
 await openMemoryFeatureView();
 await flushTasks();
 await flushTasks();
@@ -5203,7 +5205,9 @@ console.log(JSON.stringify({ afterMemory, afterBoards }));
     assert after_boards["toolbarHidden"] is True
     assert "board-todo-root" in str(after_boards["contentHtml"])
     assert "memory-toolbar-controls" not in str(after_boards["toolbarHtml"])
-    assert len(cast(list[object], after_boards["mountCalls"])) == 1
+    assert cast(list[dict[str, object]], after_boards["mountCalls"]) == [
+        {"preferredWorkspaceId": "alpha-project"}
+    ]
 
 
 def test_board_todo_full_sync_bypasses_stale_delta_cache() -> None:


### PR DESCRIPTION
## Summary
- Preserve the last valid workspace before global feature views clear currentWorkspaceId.
- Use that workspace as the board feature fallback after navigating through Memory.
- Cover the Memory -> Boards transition so the board mounts with the expected workspace.

Fixes #816

## Tests
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_project_view_ui.py
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude