### PR TITLE
Fix ask_question flow through IM gateways

### DIFF
--- a/src/relay_teams/gateway/discord/service.py
+++ b/src/relay_teams/gateway/discord/service.py
@@ -14,7 +14,7 @@ from threading import Lock
 from typing import Protocol
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, JsonValue
 
 from relay_teams.agents.orchestration.settings_service import (
     OrchestrationSettingsService,
@@ -44,6 +44,13 @@ from relay_teams.gateway.discord.secret_store import (
 from relay_teams.gateway.gateway_models import GatewayChannelType, GatewaySessionRecord
 from relay_teams.gateway.gateway_session_service import GatewaySessionService
 from relay_teams.gateway.im.command_service import ImSessionCommandResult
+from relay_teams.gateway.user_questions import (
+    UserQuestionAnswerStatus,
+    answer_pending_user_question_status_async,
+    format_user_question_request,
+    is_user_question_requested_async,
+    parse_user_question_event,
+)
 from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressBusyPolicy,
     GatewaySessionIngressRequest,
@@ -55,6 +62,9 @@ from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import (
     IntentInput,
     RuntimePromptConversationContext,
+)
+from relay_teams.sessions.runs.user_question_models import (
+    UserQuestionAnswerSubmission,
 )
 from relay_teams.sessions.runs.terminal_payload import (
     extract_terminal_error,
@@ -86,13 +96,33 @@ class _RunEventSource(Protocol):
     async def ensure_run_started_async(self, run_id: str) -> None:
         raise NotImplementedError  # pragma: no cover
 
-    def stream_run_events(self, run_id: str) -> AsyncIterator["_RunEventRecord"]:
+    def stream_run_events(
+        self,
+        run_id: str,
+        after_event_id: int = 0,
+    ) -> AsyncIterator["_RunEventRecord"]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
         raise NotImplementedError  # pragma: no cover
 
 
 class _RunEventRecord(Protocol):
     event_type: RunEventType
     payload_json: str
+    event_id: int | None
 
 
 class _ImSessionCommandService(Protocol):
@@ -364,16 +394,69 @@ class DiscordGatewayService:
         if account.status != DiscordAccountStatus.ENABLED:
             return
         text = self._accepted_text(account=account, message=message)
+        pending_answer_only = False
+        if text is None:
+            text = self._unmentioned_question_answer_text(
+                account=account,
+                message=message,
+            )
+            pending_answer_only = text is not None
         if text is None:
             return
         now = datetime.now(tz=timezone.utc)
+        if pending_answer_only:
+            gateway_session = await asyncio.to_thread(
+                self._find_gateway_session,
+                account,
+                message,
+            )
+            if gateway_session is None:
+                return
+        else:
+            gateway_session = await asyncio.to_thread(
+                self._resolve_gateway_session,
+                account,
+                message,
+                now,
+            )
         self._set_status(account.account_id, last_inbound_at=now, last_event_at=now)
-        gateway_session = await asyncio.to_thread(
-            self._resolve_gateway_session,
-            account,
-            message,
-            now,
-        )
+        if await self._has_inbound_message_record(
+            account_id=account.account_id,
+            message=message,
+        ):
+            return
+        active_run_id = await self._active_run_id(gateway_session.internal_session_id)
+        if active_run_id is not None:
+            answer_status = await self._try_answer_user_question(
+                run_id=active_run_id,
+                text=text,
+            )
+            if answer_status != UserQuestionAnswerStatus.NOT_PENDING:
+                if not await self._record_answer_message_consumed(
+                    account_id=account.account_id,
+                    message=message,
+                    gateway_session=gateway_session,
+                    text=text,
+                ):
+                    return
+                if answer_status == UserQuestionAnswerStatus.ANSWERED:
+                    answer_text = "Answer received. Continuing."
+                    event_name = "discord.user_question.answer"
+                else:
+                    answer_text = "Reply with one non-empty line for each question."
+                    event_name = "discord.user_question.invalid_answer"
+                await self._send_intermediate_text(
+                    account_id=account.account_id,
+                    gateway_session_id=gateway_session.gateway_session_id,
+                    channel_id=self._reply_channel_id(message),
+                    reply_to_message_id=message.message_id,
+                    text=answer_text,
+                    event_name=event_name,
+                    failure_message="Failed to send Discord user question answer acknowledgement",
+                )
+                return
+        if pending_answer_only:
+            return
         command_result = await asyncio.to_thread(
             self._im_session_command_service.handle_discord_command,
             session_id=gateway_session.internal_session_id,
@@ -432,6 +515,53 @@ class DiscordGatewayService:
             failure_message="Failed to send Discord receipt",
         )
 
+    async def _has_inbound_message_record(
+        self,
+        *,
+        account_id: str,
+        message: DiscordInboundMessage,
+    ) -> bool:
+        try:
+            _ = await self._inbound_queue_repo.get_by_message_key(
+                account_id=account_id,
+                channel_id=self._reply_channel_id(message),
+                message_key=f"mid:{message.message_id}",
+            )
+        except KeyError:
+            return False
+        return True
+
+    async def _record_answer_message_consumed(
+        self,
+        *,
+        account_id: str,
+        message: DiscordInboundMessage,
+        gateway_session: GatewaySessionRecord,
+        text: str,
+    ) -> bool:
+        now = datetime.now(tz=timezone.utc)
+        _record, created = await self._inbound_queue_repo.create_or_get(
+            DiscordInboundQueueRecord(
+                inbound_queue_id=f"dq_{uuid4().hex[:16]}",
+                account_id=account_id,
+                message_key=f"mid:{message.message_id}",
+                gateway_session_id=gateway_session.gateway_session_id,
+                session_id=gateway_session.internal_session_id,
+                peer_user_id=message.author_id,
+                channel_id=self._reply_channel_id(message),
+                guild_id=message.guild_id,
+                thread_id=message.thread_id,
+                reply_to_message_id=message.message_id,
+                text=text,
+                status=DiscordInboundQueueStatus.COMPLETED,
+                run_id=None,
+                created_at=now,
+                updated_at=now,
+                completed_at=now,
+            )
+        )
+        return created
+
     def _resolve_gateway_session(
         self,
         account: DiscordAccountRecord,
@@ -471,6 +601,19 @@ class DiscordGatewayService:
                 "reply_to_message_id": message.message_id,
                 "last_inbound_at": now.isoformat(),
             },
+        )
+
+    def _find_gateway_session(
+        self,
+        account: DiscordAccountRecord,
+        message: DiscordInboundMessage,
+    ) -> GatewaySessionRecord | None:
+        return self._gateway_session_service.get_by_external_session(
+            channel_type=GatewayChannelType.DISCORD,
+            external_session_id=self._external_session_id(
+                account_id=account.account_id,
+                message=message,
+            ),
         )
 
     async def _drain_inbound_queue(self) -> None:
@@ -708,41 +851,86 @@ class DiscordGatewayService:
         reply_to_message_id: str | None,
     ) -> None:
         try:
-            async for event in self._run_service.stream_run_events(run_id):
-                if event.event_type == RunEventType.RUN_PAUSED:
-                    text = self._paused_text(event)
+            after_event_id = 0
+            while True:
+                skipped_question_pause = False
+                skip_next_pause_after_user_question = False
+                async for event in self._run_service.stream_run_events(
+                    run_id,
+                    after_event_id=after_event_id,
+                ):
+                    if event.event_type == RunEventType.USER_QUESTION_REQUESTED:
+                        parsed = parse_user_question_event(event.payload_json)
+                        if parsed is None:
+                            continue
+                        question_id, questions = parsed
+                        is_requested = await is_user_question_requested_async(
+                            run_service=self._run_service,
+                            run_id=run_id,
+                            question_id=question_id,
+                        )
+                        if not is_requested:
+                            skip_next_pause_after_user_question = True
+                            continue
+                        text = format_user_question_request(
+                            question_id=question_id,
+                            questions=questions,
+                        )
+                        await self._im_tool_service.send_text_to_discord_channel(
+                            account_id=account_id,
+                            channel_id=channel_id,
+                            text=text,
+                            reply_to_message_id=reply_to_message_id,
+                        )
+                        self._record_pause_notice(
+                            account_id=account_id,
+                            occurred_at=datetime.now(tz=timezone.utc),
+                        )
+                        skip_next_pause_after_user_question = True
+                        continue
+                    if event.event_type == RunEventType.RUN_PAUSED:
+                        if skip_next_pause_after_user_question:
+                            if event.event_id is not None:
+                                after_event_id = event.event_id
+                            else:
+                                after_event_id = -1
+                            skipped_question_pause = True
+                            break
+                        text = self._paused_text(event)
+                        await self._im_tool_service.send_text_to_discord_channel(
+                            account_id=account_id,
+                            channel_id=channel_id,
+                            text=text,
+                            reply_to_message_id=reply_to_message_id,
+                        )
+                        self._record_pause_notice(
+                            account_id=account_id,
+                            occurred_at=datetime.now(tz=timezone.utc),
+                        )
+                        continue
+                    if event.event_type not in _TERMINAL_EVENT_TYPES:
+                        continue
+                    text = self._terminal_text(event)
                     await self._im_tool_service.send_text_to_discord_channel(
                         account_id=account_id,
                         channel_id=channel_id,
                         text=text,
                         reply_to_message_id=reply_to_message_id,
                     )
-                    self._record_pause_notice(
+                    self._record_reply_success(
                         account_id=account_id,
+                        gateway_session_id=gateway_session_id,
+                        run_id=run_id,
+                        channel_id=channel_id,
+                        reply_to_message_id=reply_to_message_id,
                         occurred_at=datetime.now(tz=timezone.utc),
                     )
+                    return
+                if skipped_question_pause:
                     continue
-                if event.event_type not in _TERMINAL_EVENT_TYPES:
-                    continue
-                text = self._terminal_text(event)
-                await self._im_tool_service.send_text_to_discord_channel(
-                    account_id=account_id,
-                    channel_id=channel_id,
-                    text=text,
-                    reply_to_message_id=reply_to_message_id,
+                raise RuntimeError(
+                    f"Discord reply watcher ended before a stop event for {run_id}."
                 )
-                self._record_reply_success(
-                    account_id=account_id,
-                    gateway_session_id=gateway_session_id,
-                    run_id=run_id,
-                    channel_id=channel_id,
-                    reply_to_message_id=reply_to_message_id,
-                    occurred_at=datetime.now(tz=timezone.utc),
-                )
-                return
-            raise RuntimeError(
-                f"Discord reply watcher ended before a stop event for {run_id}."
-            )
         except Exception as exc:
             await self._record_reply_failure(
                 account_id=account_id,
@@ -1034,6 +1222,29 @@ class DiscordGatewayService:
             return "Received. Processing now."
         return f"Received. Queued behind {queue_depth} message(s) in this session."
 
+    async def _try_answer_user_question(
+        self,
+        *,
+        run_id: str,
+        text: str,
+    ) -> UserQuestionAnswerStatus:
+        try:
+            return await answer_pending_user_question_status_async(
+                run_service=self._run_service,
+                run_id=run_id,
+                text=text,
+            )
+        except (KeyError, RuntimeError, ValueError, AttributeError) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="discord.user_question.answer_failed",
+                message="Failed to answer pending Discord user question",
+                payload={"run_id": run_id, "error": str(exc)},
+                exc_info=exc,
+            )
+            return UserQuestionAnswerStatus.NOT_PENDING
+
     async def _queue_depth(self, record: DiscordInboundQueueRecord) -> int:
         ahead_count = await self._inbound_queue_repo.count_non_terminal_ahead(
             record.inbound_queue_id
@@ -1189,6 +1400,21 @@ class DiscordGatewayService:
         ):
             return text
         return None
+
+    @staticmethod
+    def _unmentioned_question_answer_text(
+        *,
+        account: DiscordAccountRecord,
+        message: DiscordInboundMessage,
+    ) -> str | None:
+        if message.author_is_bot:
+            return None
+        if account.bot_user_id is not None and message.author_id == account.bot_user_id:
+            return None
+        if message.is_dm or message.mentions_bot:
+            return None
+        text = message.content.strip()
+        return text or None
 
     @staticmethod
     def _reply_channel_id(message: DiscordInboundMessage) -> str:

--- a/src/relay_teams/gateway/discord/service.py
+++ b/src/relay_teams/gateway/discord/service.py
@@ -100,6 +100,8 @@ class _RunEventSource(Protocol):
         self,
         run_id: str,
         after_event_id: int = 0,
+        *,
+        stop_on_pause: bool = True,
     ) -> AsyncIterator["_RunEventRecord"]:
         raise NotImplementedError  # pragma: no cover
 
@@ -851,86 +853,77 @@ class DiscordGatewayService:
         reply_to_message_id: str | None,
     ) -> None:
         try:
-            after_event_id = 0
-            while True:
-                skipped_question_pause = False
-                skip_next_pause_after_user_question = False
-                async for event in self._run_service.stream_run_events(
-                    run_id,
-                    after_event_id=after_event_id,
-                ):
-                    if event.event_type == RunEventType.USER_QUESTION_REQUESTED:
-                        parsed = parse_user_question_event(event.payload_json)
-                        if parsed is None:
-                            continue
-                        question_id, questions = parsed
-                        is_requested = await is_user_question_requested_async(
-                            run_service=self._run_service,
-                            run_id=run_id,
-                            question_id=question_id,
-                        )
-                        if not is_requested:
-                            skip_next_pause_after_user_question = True
-                            continue
-                        text = format_user_question_request(
-                            question_id=question_id,
-                            questions=questions,
-                        )
-                        await self._im_tool_service.send_text_to_discord_channel(
-                            account_id=account_id,
-                            channel_id=channel_id,
-                            text=text,
-                            reply_to_message_id=reply_to_message_id,
-                        )
-                        self._record_pause_notice(
-                            account_id=account_id,
-                            occurred_at=datetime.now(tz=timezone.utc),
-                        )
+            skip_next_pause_after_user_question = False
+            async for event in self._run_service.stream_run_events(
+                run_id,
+                stop_on_pause=False,
+            ):
+                if event.event_type == RunEventType.USER_QUESTION_REQUESTED:
+                    parsed = parse_user_question_event(event.payload_json)
+                    if parsed is None:
+                        continue
+                    question_id, questions = parsed
+                    is_requested = await is_user_question_requested_async(
+                        run_service=self._run_service,
+                        run_id=run_id,
+                        question_id=question_id,
+                    )
+                    if not is_requested:
                         skip_next_pause_after_user_question = True
                         continue
-                    if event.event_type == RunEventType.RUN_PAUSED:
-                        if skip_next_pause_after_user_question:
-                            if event.event_id is not None:
-                                after_event_id = event.event_id
-                            else:
-                                after_event_id = -1
-                            skipped_question_pause = True
-                            break
-                        text = self._paused_text(event)
-                        await self._im_tool_service.send_text_to_discord_channel(
-                            account_id=account_id,
-                            channel_id=channel_id,
-                            text=text,
-                            reply_to_message_id=reply_to_message_id,
-                        )
-                        self._record_pause_notice(
-                            account_id=account_id,
-                            occurred_at=datetime.now(tz=timezone.utc),
-                        )
-                        continue
-                    if event.event_type not in _TERMINAL_EVENT_TYPES:
-                        continue
-                    text = self._terminal_text(event)
+                    text = format_user_question_request(
+                        question_id=question_id,
+                        questions=questions,
+                    )
                     await self._im_tool_service.send_text_to_discord_channel(
                         account_id=account_id,
                         channel_id=channel_id,
                         text=text,
                         reply_to_message_id=reply_to_message_id,
                     )
-                    self._record_reply_success(
+                    self._record_pause_notice(
                         account_id=account_id,
-                        gateway_session_id=gateway_session_id,
-                        run_id=run_id,
-                        channel_id=channel_id,
-                        reply_to_message_id=reply_to_message_id,
                         occurred_at=datetime.now(tz=timezone.utc),
                     )
-                    return
-                if skipped_question_pause:
+                    skip_next_pause_after_user_question = True
                     continue
-                raise RuntimeError(
-                    f"Discord reply watcher ended before a stop event for {run_id}."
+                if event.event_type == RunEventType.RUN_PAUSED:
+                    if skip_next_pause_after_user_question:
+                        skip_next_pause_after_user_question = False
+                        continue
+                    text = self._paused_text(event)
+                    await self._im_tool_service.send_text_to_discord_channel(
+                        account_id=account_id,
+                        channel_id=channel_id,
+                        text=text,
+                        reply_to_message_id=reply_to_message_id,
+                    )
+                    self._record_pause_notice(
+                        account_id=account_id,
+                        occurred_at=datetime.now(tz=timezone.utc),
+                    )
+                    continue
+                if event.event_type not in _TERMINAL_EVENT_TYPES:
+                    continue
+                text = self._terminal_text(event)
+                await self._im_tool_service.send_text_to_discord_channel(
+                    account_id=account_id,
+                    channel_id=channel_id,
+                    text=text,
+                    reply_to_message_id=reply_to_message_id,
                 )
+                self._record_reply_success(
+                    account_id=account_id,
+                    gateway_session_id=gateway_session_id,
+                    run_id=run_id,
+                    channel_id=channel_id,
+                    reply_to_message_id=reply_to_message_id,
+                    occurred_at=datetime.now(tz=timezone.utc),
+                )
+                return
+            raise RuntimeError(
+                f"Discord reply watcher ended before a stop event for {run_id}."
+            )
         except Exception as exc:
             await self._record_reply_failure(
                 account_id=account_id,

--- a/src/relay_teams/gateway/feishu/inbound_runtime.py
+++ b/src/relay_teams/gateway/feishu/inbound_runtime.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Protocol
 
 from pydantic import JsonValue
@@ -257,6 +258,7 @@ class FeishuInboundRuntime:
         *,
         runtime_config: FeishuTriggerRuntimeConfig,
         message: FeishuNormalizedMessage,
+        message_created_at: datetime | None = None,
     ) -> UserQuestionAnswerStatus:
         binding = await self._external_session_binding_repo.get_binding_async(
             platform=FEISHU_PLATFORM,
@@ -279,6 +281,7 @@ class FeishuInboundRuntime:
                 run_service=self._run_service,
                 session_id=session_id,
                 text=message.trigger_text,
+                message_created_at=message_created_at,
             )
             return status
         run_id = await self._session_ingress_service.active_run_id_async(session_id)
@@ -288,6 +291,7 @@ class FeishuInboundRuntime:
             run_service=self._run_service,
             run_id=run_id,
             text=message.trigger_text,
+            message_created_at=message_created_at,
         )
 
     async def is_user_question_requested_async(

--- a/src/relay_teams/gateway/feishu/inbound_runtime.py
+++ b/src/relay_teams/gateway/feishu/inbound_runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Protocol
 
+from pydantic import JsonValue
+
 from relay_teams.gateway.feishu.models import (
     FEISHU_METADATA_CHAT_ID_KEY,
     FEISHU_METADATA_CHAT_TYPE_KEY,
@@ -22,6 +24,12 @@ from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressRequest,
     GatewaySessionIngressService,
 )
+from relay_teams.gateway.user_questions import (
+    UserQuestionAnswerStatus,
+    answer_pending_user_question_for_session_status_async,
+    answer_pending_user_question_status_async,
+    is_user_question_requested_async,
+)
 from relay_teams.logger import get_logger, log_event
 from relay_teams.media import content_parts_from_text
 from relay_teams.providers.token_usage_repo import SessionTokenUsage
@@ -31,6 +39,9 @@ from relay_teams.sessions.external_session_binding_repository import (
 )
 from relay_teams.sessions.runs.enums import ExecutionMode
 from relay_teams.sessions.runs.run_models import IntentInput
+from relay_teams.sessions.runs.user_question_models import (
+    UserQuestionAnswerSubmission,
+)
 from relay_teams.sessions.session_metadata import (
     SESSION_METADATA_SOURCE_ICON_KEY,
     SESSION_METADATA_SOURCE_KIND_KEY,
@@ -57,35 +68,67 @@ class SessionServiceLike(Protocol):
         session_mode: SessionMode | None = None,
         normal_root_role_id: str | None = None,
         orchestration_preset_id: str | None = None,
-    ) -> SessionRecord: ...
+    ) -> SessionRecord:
+        raise NotImplementedError  # pragma: no cover
 
-    def get_session(self, session_id: str) -> SessionRecord: ...
+    def get_session(self, session_id: str) -> SessionRecord:
+        raise NotImplementedError  # pragma: no cover
 
-    def sync_session_metadata(
-        self, session_id: str, metadata: dict[str, str]
-    ) -> None: ...
+    async def get_session_async(self, session_id: str) -> SessionRecord:
+        raise NotImplementedError  # pragma: no cover
 
-    def get_session_messages(self, session_id: str) -> list[dict[str, object]]: ...
+    def sync_session_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
+        raise NotImplementedError  # pragma: no cover
 
-    def get_token_usage_by_session(self, session_id: str) -> SessionTokenUsage: ...
+    def get_session_messages(self, session_id: str) -> list[dict[str, object]]:
+        raise NotImplementedError  # pragma: no cover
 
-    def clear_session_messages(self, session_id: str) -> int: ...
+    def get_token_usage_by_session(self, session_id: str) -> SessionTokenUsage:
+        raise NotImplementedError  # pragma: no cover
+
+    def clear_session_messages(self, session_id: str) -> int:
+        raise NotImplementedError  # pragma: no cover
 
 
 class RunServiceLike(Protocol):
-    def create_run(self, intent: IntentInput) -> tuple[str, str]: ...
+    def create_run(self, intent: IntentInput) -> tuple[str, str]:
+        raise NotImplementedError  # pragma: no cover
 
-    def create_detached_run(self, intent: IntentInput) -> tuple[str, str]: ...
+    def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
+        raise NotImplementedError  # pragma: no cover
 
     async def create_detached_run_async(self, intent: IntentInput) -> tuple[str, str]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
-    def ensure_run_started(self, run_id: str) -> None: ...
+    def ensure_run_started(self, run_id: str) -> None:
+        raise NotImplementedError  # pragma: no cover
 
     async def ensure_run_started_async(self, run_id: str) -> None:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
-    def stop_run(self, run_id: str) -> None: ...
+    def stop_run(self, run_id: str) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def list_user_questions_by_session_async(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
 
 class FeishuClientLike(Protocol):
@@ -94,7 +137,8 @@ class FeishuClientLike(Protocol):
         *,
         chat_id: str,
         environment: FeishuEnvironment | None = None,
-    ) -> str | None: ...
+    ) -> str | None:
+        raise NotImplementedError  # pragma: no cover
 
     async def resolve_user_name(
         self,
@@ -102,7 +146,8 @@ class FeishuClientLike(Protocol):
         open_id: str,
         chat_id: str | None = None,
         environment: FeishuEnvironment | None = None,
-    ) -> str | None: ...
+    ) -> str | None:
+        raise NotImplementedError  # pragma: no cover
 
 
 class FeishuInboundRuntime:
@@ -206,6 +251,56 @@ class FeishuInboundRuntime:
 
     def stop_run(self, run_id: str) -> None:
         self._run_service.stop_run(run_id)
+
+    async def answer_pending_user_question_async(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        message: FeishuNormalizedMessage,
+    ) -> UserQuestionAnswerStatus:
+        binding = await self._external_session_binding_repo.get_binding_async(
+            platform=FEISHU_PLATFORM,
+            trigger_id=runtime_config.trigger_id,
+            tenant_key=message.tenant_key,
+            external_chat_id=message.chat_id,
+        )
+        if binding is None:
+            return UserQuestionAnswerStatus.NOT_PENDING
+        session_id = binding.session_id
+        try:
+            await self._session_service.get_session_async(session_id)
+        except KeyError:
+            return UserQuestionAnswerStatus.NOT_PENDING
+        if self._session_ingress_service is None:
+            (
+                status,
+                _run_id,
+            ) = await answer_pending_user_question_for_session_status_async(
+                run_service=self._run_service,
+                session_id=session_id,
+                text=message.trigger_text,
+            )
+            return status
+        run_id = await self._session_ingress_service.active_run_id_async(session_id)
+        if run_id is None:
+            return UserQuestionAnswerStatus.NOT_PENDING
+        return await answer_pending_user_question_status_async(
+            run_service=self._run_service,
+            run_id=run_id,
+            text=message.trigger_text,
+        )
+
+    async def is_user_question_requested_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+    ) -> bool:
+        return await is_user_question_requested_async(
+            run_service=self._run_service,
+            run_id=run_id,
+            question_id=question_id,
+        )
 
     def _create_session(
         self,

--- a/src/relay_teams/gateway/feishu/message_pool_service.py
+++ b/src/relay_teams/gateway/feishu/message_pool_service.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable, Coroutine
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 from uuid import uuid4
@@ -268,7 +269,8 @@ class FeishuMessagePoolService:
                 lambda: self._inbound_runtime.answer_pending_user_question_async(
                     runtime_config=runtime_config,
                     message=normalized,
-                )
+                ),
+                loop=self._loop,
             )
         except (GatewaySessionBusyError, RuntimeError, KeyError, ValueError) as exc:
             log_event(
@@ -1151,7 +1153,25 @@ def _run_answer_check(
         [],
         Coroutine[object, object, UserQuestionAnswerStatus],
     ],
+    *,
+    loop: asyncio.AbstractEventLoop | None = None,
 ) -> UserQuestionAnswerStatus:
+    if loop is not None and loop.is_running():
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            future = asyncio.run_coroutine_threadsafe(coroutine_factory(), loop)
+            try:
+                return future.result(timeout=30)
+            except FutureTimeoutError as exc:
+                future.cancel()
+                raise RuntimeError(
+                    "Timed out answering a Feishu user question on the service loop"
+                ) from exc
+        if running_loop is loop:
+            raise RuntimeError(
+                "Cannot synchronously answer a Feishu user question on the service loop"
+            )
     try:
         asyncio.get_running_loop()
     except RuntimeError:

--- a/src/relay_teams/gateway/feishu/message_pool_service.py
+++ b/src/relay_teams/gateway/feishu/message_pool_service.py
@@ -563,19 +563,21 @@ class FeishuMessagePoolService:
                     UserQuestionAnswerStatus.ANSWERED,
                     UserQuestionAnswerStatus.INVALID_REPLY,
                 }:
-                    completed_at = datetime.now(tz=timezone.utc)
-                    self._message_pool_repo.update(
-                        claimed.message_pool_id,
-                        processing_status=FeishuMessageProcessingStatus.COMPLETED,
-                        final_reply_status=FeishuMessageDeliveryStatus.SKIPPED,
-                        final_reply_text=(
-                            "Answer received."
-                            if answer_status == UserQuestionAnswerStatus.ANSWERED
-                            else "Invalid answer ignored."
-                        ),
-                        completed_at=completed_at,
-                        last_error=None,
-                    )
+                    if answer_status == UserQuestionAnswerStatus.INVALID_REPLY:
+                        await self._complete_invalid_user_question_reply(
+                            record=claimed,
+                            runtime_config=runtime_config,
+                        )
+                    else:
+                        completed_at = datetime.now(tz=timezone.utc)
+                        self._message_pool_repo.update(
+                            claimed.message_pool_id,
+                            processing_status=FeishuMessageProcessingStatus.COMPLETED,
+                            final_reply_status=FeishuMessageDeliveryStatus.SKIPPED,
+                            final_reply_text="Answer received.",
+                            completed_at=completed_at,
+                            last_error=None,
+                        )
                     continue
                 session_id, run_id = await self._inbound_runtime.start_run_async(
                     runtime_config=runtime_config,
@@ -596,6 +598,55 @@ class FeishuMessagePoolService:
                 last_error=None,
             )
         return progress
+
+    async def _complete_invalid_user_question_reply(
+        self,
+        *,
+        record: FeishuMessagePoolRecord,
+        runtime_config: FeishuTriggerRuntimeConfig,
+    ) -> None:
+        reply_text = "请按问题数量逐行回答后再发送。"
+        completed_at = datetime.now(tz=timezone.utc)
+        attempts = record.final_reply_attempts + 1
+        try:
+            await self._send_terminal_reply(
+                record=record,
+                text=reply_text,
+                environment=runtime_config.environment,
+            )
+        except RuntimeError as exc:
+            status = (
+                FeishuMessageDeliveryStatus.FAILED
+                if attempts >= _FINAL_REPLY_MAX_ATTEMPTS
+                else FeishuMessageDeliveryStatus.PENDING
+            )
+            processing_status = (
+                FeishuMessageProcessingStatus.DEAD_LETTER
+                if attempts >= _FINAL_REPLY_MAX_ATTEMPTS
+                else FeishuMessageProcessingStatus.RETRYABLE_FAILED
+            )
+            self._message_pool_repo.update(
+                record.message_pool_id,
+                processing_status=processing_status,
+                final_reply_status=status,
+                final_reply_text=reply_text,
+                final_reply_attempts=attempts,
+                next_attempt_at=completed_at + _backoff_for_attempt(attempts),
+                completed_at=completed_at
+                if attempts >= _FINAL_REPLY_MAX_ATTEMPTS
+                else None,
+                last_error=str(exc),
+            )
+            return
+        self._message_pool_repo.update(
+            record.message_pool_id,
+            processing_status=FeishuMessageProcessingStatus.COMPLETED,
+            final_reply_status=FeishuMessageDeliveryStatus.SENT,
+            final_reply_text=reply_text,
+            final_reply_attempts=attempts,
+            completed_at=completed_at,
+            last_error=None,
+        )
 
     async def _finalize_waiting_results(self, *, limit: int = 20) -> bool:
         progress = False

--- a/src/relay_teams/gateway/feishu/message_pool_service.py
+++ b/src/relay_teams/gateway/feishu/message_pool_service.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import json
 import asyncio
+import json
 import logging
+from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 from uuid import uuid4
@@ -25,6 +26,11 @@ from relay_teams.gateway.feishu.models import (
     TriggerProcessingResult,
 )
 from relay_teams.gateway.session_ingress_service import GatewaySessionBusyError
+from relay_teams.gateway.user_questions import (
+    UserQuestionAnswerStatus,
+    format_user_question_event,
+    parse_user_question_event,
+)
 from relay_teams.logger import get_logger, log_event
 from relay_teams.sessions.external_session_binding_repository import (
     ExternalSessionBindingRepository,
@@ -67,7 +73,8 @@ class FeishuRuntimeConfigLookup(Protocol):
     def get_runtime_config_by_trigger_id(
         self,
         trigger_id: str,
-    ) -> FeishuTriggerRuntimeConfig | None: ...
+    ) -> FeishuTriggerRuntimeConfig | None:
+        raise NotImplementedError  # pragma: no cover
 
 
 class FeishuClientLike(Protocol):
@@ -77,7 +84,8 @@ class FeishuClientLike(Protocol):
         message_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> str: ...
+    ) -> str:
+        raise NotImplementedError  # pragma: no cover
 
     async def create_message_reaction(
         self,
@@ -85,7 +93,8 @@ class FeishuClientLike(Protocol):
         message_id: str,
         reaction_type: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> None:
+        raise NotImplementedError  # pragma: no cover
 
     async def send_text_message(
         self,
@@ -93,7 +102,8 @@ class FeishuClientLike(Protocol):
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> str: ...
+    ) -> str:
+        raise NotImplementedError  # pragma: no cover
 
     async def resolve_user_name(
         self,
@@ -101,7 +111,8 @@ class FeishuClientLike(Protocol):
         open_id: str,
         chat_id: str | None = None,
         environment: FeishuEnvironment | None = None,
-    ) -> str | None: ...
+    ) -> str | None:
+        raise NotImplementedError  # pragma: no cover
 
 
 class FeishuMessagePoolService:
@@ -244,6 +255,86 @@ class FeishuMessagePoolService:
             trigger_name=runtime_config.trigger_name,
             event_id=record.event_id,
             duplicate=False,
+        )
+
+    def answer_pending_user_question(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+    ) -> UserQuestionAnswerStatus:
+        try:
+            return _run_answer_check(
+                lambda: self._inbound_runtime.answer_pending_user_question_async(
+                    runtime_config=runtime_config,
+                    message=normalized,
+                )
+            )
+        except (GatewaySessionBusyError, RuntimeError, KeyError, ValueError) as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                event="feishu.message_pool.user_question_answer_failed",
+                message="Failed to answer pending Feishu user question",
+                payload={
+                    "trigger_id": runtime_config.trigger_id,
+                    "chat_id": normalized.chat_id,
+                    "message_id": normalized.message_id,
+                    "error": str(exc),
+                },
+                exc_info=exc,
+            )
+            return UserQuestionAnswerStatus.NOT_PENDING
+
+    def has_message_record(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+    ) -> bool:
+        try:
+            _ = self._message_pool_repo.get_by_message_key(
+                trigger_id=runtime_config.trigger_id,
+                tenant_key=normalized.tenant_key,
+                message_key=_message_key(normalized),
+            )
+        except KeyError:
+            return False
+        return True
+
+    def record_consumed_user_question_answer(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+        reason: str,
+    ) -> None:
+        now = datetime.now(tz=timezone.utc)
+        self._message_pool_repo.create_or_get(
+            FeishuMessagePoolRecord(
+                message_pool_id=f"fmp_{uuid4().hex[:16]}",
+                trigger_id=runtime_config.trigger_id,
+                trigger_name=runtime_config.trigger_name,
+                tenant_key=normalized.tenant_key,
+                chat_id=normalized.chat_id,
+                chat_type=normalized.chat_type,
+                event_id=normalized.event_id,
+                message_key=_message_key(normalized),
+                message_id=normalized.message_id,
+                command_name=reason,
+                sender_name=normalized.sender_name,
+                intent_text=normalized.trigger_text,
+                payload=normalized.payload,
+                metadata=normalized.metadata,
+                processing_status=FeishuMessageProcessingStatus.COMPLETED,
+                reaction_status=FeishuMessageDeliveryStatus.SKIPPED,
+                ack_status=FeishuMessageDeliveryStatus.SKIPPED,
+                final_reply_status=FeishuMessageDeliveryStatus.SKIPPED,
+                next_attempt_at=now,
+                created_at=now,
+                updated_at=now,
+                completed_at=now,
+            )
         )
 
     def get_chat_summary(
@@ -461,6 +552,30 @@ class FeishuMessagePoolService:
                         sender_name=enriched.sender_name,
                         metadata=enriched.metadata,
                     )
+                answer_status = (
+                    await self._inbound_runtime.answer_pending_user_question_async(
+                        runtime_config=runtime_config,
+                        message=enriched,
+                    )
+                )
+                if answer_status in {
+                    UserQuestionAnswerStatus.ANSWERED,
+                    UserQuestionAnswerStatus.INVALID_REPLY,
+                }:
+                    completed_at = datetime.now(tz=timezone.utc)
+                    self._message_pool_repo.update(
+                        claimed.message_pool_id,
+                        processing_status=FeishuMessageProcessingStatus.COMPLETED,
+                        final_reply_status=FeishuMessageDeliveryStatus.SKIPPED,
+                        final_reply_text=(
+                            "Answer received."
+                            if answer_status == UserQuestionAnswerStatus.ANSWERED
+                            else "Invalid answer ignored."
+                        ),
+                        completed_at=completed_at,
+                        last_error=None,
+                    )
+                    continue
                 session_id, run_id = await self._inbound_runtime.start_run_async(
                     runtime_config=runtime_config,
                     message=enriched,
@@ -516,6 +631,10 @@ class FeishuMessagePoolService:
                 if runtime.phase == RunRuntimePhase.AWAITING_RECOVERY:
                     progress = (
                         await self._notify_recovery_pause(record, runtime) or progress
+                    )
+                if runtime.phase == RunRuntimePhase.AWAITING_MANUAL_ACTION:
+                    progress = (
+                        await self._notify_user_question_request(record) or progress
                     )
                 continue
             if runtime.status not in {
@@ -747,6 +866,59 @@ class FeishuMessagePoolService:
         self._pause_notice_keys.add(dedupe_key)
         return True
 
+    async def _notify_user_question_request(
+        self,
+        record: FeishuMessagePoolRecord,
+    ) -> bool:
+        question_event_id: int | None = None
+        text = ""
+        for (
+            event_id,
+            candidate_question_id,
+            candidate_text,
+        ) in await _user_question_events_async(
+            run_id=str(record.run_id or ""),
+            event_log=self._event_log,
+        ):
+            if await self._inbound_runtime.is_user_question_requested_async(
+                run_id=str(record.run_id or ""),
+                question_id=candidate_question_id,
+            ):
+                question_event_id = event_id
+                text = candidate_text
+                break
+        if question_event_id is None or not text:
+            return False
+        dedupe_key = f"{record.run_id}:{question_event_id}"
+        if dedupe_key in self._pause_notice_keys:
+            return False
+        runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
+            record.trigger_id
+        )
+        if runtime_config is None or self._feishu_client is None:
+            return False
+        try:
+            await self._send_terminal_reply(
+                record=record,
+                text=text,
+                environment=runtime_config.environment,
+            )
+        except RuntimeError as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                event="feishu.message_pool.user_question_notice_failed",
+                message="Failed to send Feishu user question notice",
+                payload={
+                    "message_pool_id": record.message_pool_id,
+                    "run_id": record.run_id,
+                    "error": str(exc),
+                },
+            )
+            return False
+        self._pause_notice_keys.add(dedupe_key)
+        return True
+
     async def _send_queue_reply(
         self,
         *,
@@ -922,6 +1094,21 @@ def _message_key(message: FeishuNormalizedMessage) -> str:
     return message.event_id
 
 
+def _run_answer_check(
+    coroutine_factory: Callable[
+        [],
+        Coroutine[object, object, UserQuestionAnswerStatus],
+    ],
+) -> UserQuestionAnswerStatus:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coroutine_factory())
+    raise RuntimeError(
+        "Cannot synchronously answer a Feishu user question inside an active event loop"
+    )
+
+
 def _build_ack_text(queue_depth: int) -> str:
     if queue_depth <= 0:
         return "收到，正在处理。"
@@ -1072,3 +1259,61 @@ def _latest_pause_event(
     except ValueError:
         return None, None
     return None, None
+
+
+def _user_question_events(
+    *,
+    run_id: str,
+    event_log: EventLog,
+) -> tuple[tuple[int, str, str], ...]:
+    events: list[tuple[int, str, str]] = []
+    try:
+        for event in reversed(event_log.list_by_trace_with_ids(run_id)):
+            if (
+                str(event.get("event_type") or "")
+                != RunEventType.USER_QUESTION_REQUESTED.value
+            ):
+                continue
+            event_id = event.get("id")
+            if not isinstance(event_id, int):
+                continue
+            payload_json = str(event.get("payload_json") or "{}")
+            parsed = parse_user_question_event(payload_json)
+            if parsed is None:
+                continue
+            question_id, _questions = parsed
+            text = format_user_question_event(payload_json)
+            if text:
+                events.append((event_id, question_id, text))
+    except ValueError:
+        return ()
+    return tuple(events)
+
+
+async def _user_question_events_async(
+    *,
+    run_id: str,
+    event_log: EventLog,
+) -> tuple[tuple[int, str, str], ...]:
+    events: list[tuple[int, str, str]] = []
+    try:
+        for event in reversed(await event_log.list_by_trace_with_ids_async(run_id)):
+            if (
+                str(event.get("event_type") or "")
+                != RunEventType.USER_QUESTION_REQUESTED.value
+            ):
+                continue
+            event_id = event.get("id")
+            if not isinstance(event_id, int):
+                continue
+            payload_json = str(event.get("payload_json") or "{}")
+            parsed = parse_user_question_event(payload_json)
+            if parsed is None:
+                continue
+            question_id, _questions = parsed
+            text = format_user_question_event(payload_json)
+            if text:
+                events.append((event_id, question_id, text))
+    except ValueError:
+        return ()
+    return tuple(events)

--- a/src/relay_teams/gateway/feishu/message_pool_service.py
+++ b/src/relay_teams/gateway/feishu/message_pool_service.py
@@ -556,6 +556,7 @@ class FeishuMessagePoolService:
                     await self._inbound_runtime.answer_pending_user_question_async(
                         runtime_config=runtime_config,
                         message=enriched,
+                        message_created_at=claimed.created_at,
                     )
                 )
                 if answer_status in {

--- a/src/relay_teams/gateway/feishu/subscription_service.py
+++ b/src/relay_teams/gateway/feishu/subscription_service.py
@@ -437,12 +437,17 @@ class _FeishuWsController:
         self._event_handler = event_handler
         self._client: WsClientLike | None = None
         self._task: asyncio.Task[None] | None = None
+        self._handler_queue: asyncio.Queue[tuple[P2ImMessageReceiveV1, str]] = (
+            asyncio.Queue()
+        )
+        self._handler_task: asyncio.Task[None] | None = None
         self._stop_requested = False
 
     async def start(self) -> None:
         if self._task is not None and not self._task.done():
             return
         self._stop_requested = False
+        self._start_handler_worker()
         self._task = asyncio.create_task(
             self._run(),
             name=f"feishu-sdk-subscription-{self._runtime_config.trigger_id}",
@@ -456,6 +461,7 @@ class _FeishuWsController:
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
+        await self._stop_handler_worker()
         self._task = None
 
     def is_running(self) -> bool:
@@ -527,14 +533,7 @@ class _FeishuWsController:
             json_obj = json_module.json_obj
 
             raw_body = json_obj.marshal(event) or "{}"
-            result = self._event_handler.handle_sdk_event(
-                trigger_id=self._runtime_config.trigger_id,
-                event=event,
-                raw_body=raw_body,
-                headers={},
-                remote_addr=None,
-            )
-            _log_processing_result(result)
+            self._enqueue_sdk_event(event=event, raw_body=raw_body)
 
         dispatcher = (
             event_dispatcher_handler.builder(
@@ -550,6 +549,70 @@ class _FeishuWsController:
             log_level=lark.LogLevel.INFO,
             event_handler=dispatcher,
         )
+
+    def _start_handler_worker(self) -> None:
+        if self._handler_task is not None and not self._handler_task.done():
+            return
+        self._handler_task = asyncio.create_task(
+            self._process_handler_queue(),
+            name=f"feishu-sdk-handler-{self._runtime_config.trigger_id}",
+        )
+
+    async def _stop_handler_worker(self) -> None:
+        handler_task = self._handler_task
+        if handler_task is None:
+            return
+        handler_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await handler_task
+        self._handler_task = None
+
+    def _enqueue_sdk_event(
+        self,
+        *,
+        event: P2ImMessageReceiveV1,
+        raw_body: str,
+    ) -> None:
+        self._start_handler_worker()
+        self._handler_queue.put_nowait((event, raw_body))
+
+    async def _process_handler_queue(self) -> None:
+        while True:
+            event, raw_body = await self._handler_queue.get()
+            try:
+                await asyncio.to_thread(
+                    self._handle_sdk_event_in_worker,
+                    event=event,
+                    raw_body=raw_body,
+                )
+            except Exception as exc:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="feishu.subscription.event_handler_failed",
+                    message="Feishu SDK event handler failed",
+                    payload={
+                        "trigger_id": self._runtime_config.trigger_id,
+                        "error": str(exc),
+                    },
+                )
+            finally:
+                self._handler_queue.task_done()
+
+    def _handle_sdk_event_in_worker(
+        self,
+        *,
+        event: P2ImMessageReceiveV1,
+        raw_body: str,
+    ) -> None:
+        result = self._event_handler.handle_sdk_event(
+            trigger_id=self._runtime_config.trigger_id,
+            event=event,
+            raw_body=raw_body,
+            headers={},
+            remote_addr=None,
+        )
+        _log_processing_result(result)
 
     async def _connect_client(self, client: WsClientLike) -> None:
         ws_client_module = import_lark_ws_client_module()

--- a/src/relay_teams/gateway/feishu/subscription_service.py
+++ b/src/relay_teams/gateway/feishu/subscription_service.py
@@ -566,6 +566,7 @@ class _FeishuWsController:
         try:
             await handler_task
         except asyncio.CancelledError:
+            # Cancellation is the expected shutdown path for the serial handler worker.
             pass
         self._handler_task = None
 

--- a/src/relay_teams/gateway/feishu/subscription_service.py
+++ b/src/relay_teams/gateway/feishu/subscription_service.py
@@ -563,8 +563,10 @@ class _FeishuWsController:
         if handler_task is None:
             return
         handler_task.cancel()
-        with suppress(asyncio.CancelledError):
+        try:
             await handler_task
+        except asyncio.CancelledError:
+            pass
         self._handler_task = None
 
     def _enqueue_sdk_event(

--- a/src/relay_teams/gateway/feishu/trigger_handler.py
+++ b/src/relay_teams/gateway/feishu/trigger_handler.py
@@ -19,6 +19,7 @@ from relay_teams.gateway.feishu.models import (
     FeishuTriggerRuntimeConfig,
     TriggerProcessingResult,
 )
+from relay_teams.gateway.user_questions import UserQuestionAnswerStatus
 from relay_teams.logger import get_logger, log_event
 
 if TYPE_CHECKING:
@@ -43,7 +44,8 @@ class FeishuRuntimeConfigLookup(Protocol):
     def get_runtime_config_by_trigger_id(
         self,
         trigger_id: str,
-    ) -> FeishuTriggerRuntimeConfig | None: ...
+    ) -> FeishuTriggerRuntimeConfig | None:
+        raise NotImplementedError  # pragma: no cover
 
 
 class FeishuMessagePoolServiceLike(Protocol):
@@ -55,7 +57,33 @@ class FeishuMessagePoolServiceLike(Protocol):
         raw_body: str,
         headers: dict[str, str],
         remote_addr: str | None,
-    ) -> TriggerProcessingResult: ...
+    ) -> TriggerProcessingResult:
+        raise NotImplementedError  # pragma: no cover
+
+    def answer_pending_user_question(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+    ) -> UserQuestionAnswerStatus:
+        raise NotImplementedError  # pragma: no cover
+
+    def has_message_record(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+    ) -> bool:
+        raise NotImplementedError  # pragma: no cover
+
+    def record_consumed_user_question_answer(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+        reason: str,
+    ) -> None:
+        raise NotImplementedError  # pragma: no cover
 
     def get_chat_summary(
         self,
@@ -64,7 +92,8 @@ class FeishuMessagePoolServiceLike(Protocol):
         tenant_key: str,
         chat_id: str,
         preview_limit: int = 3,
-    ) -> FeishuChatQueueSummary: ...
+    ) -> FeishuChatQueueSummary:
+        raise NotImplementedError  # pragma: no cover
 
     def clear_chat(
         self,
@@ -72,7 +101,8 @@ class FeishuMessagePoolServiceLike(Protocol):
         trigger_id: str,
         tenant_key: str,
         chat_id: str,
-    ) -> FeishuChatQueueClearResult: ...
+    ) -> FeishuChatQueueClearResult:
+        raise NotImplementedError  # pragma: no cover
 
 
 class FeishuTriggerHandler:
@@ -153,21 +183,81 @@ class FeishuTriggerHandler:
                 ignored=True,
                 reason="sender_is_bot",
             )
-        trigger_rule = runtime_config.source.trigger_rule
-        if (
-            trigger_rule == "mention_only"
-            and chat_type == "group"
-            and not normalized.mentioned
-        ):
+        if not normalized.trigger_text.strip():
             return TriggerProcessingResult(
                 status="ignored",
                 trigger_id=runtime_config.trigger_id,
                 trigger_name=runtime_config.trigger_name,
                 event_id=normalized.event_id,
                 ignored=True,
-                reason="mention_required",
+                reason="empty_trigger_text",
             )
+        if self._message_pool_service.has_message_record(
+            runtime_config=runtime_config,
+            normalized=normalized,
+        ):
+            return TriggerProcessingResult(
+                status="accepted",
+                trigger_id=runtime_config.trigger_id,
+                trigger_name=runtime_config.trigger_name,
+                event_id=normalized.event_id,
+                duplicate=True,
+            )
+        answer_status = self._message_pool_service.answer_pending_user_question(
+            runtime_config=runtime_config,
+            normalized=normalized,
+        )
+        if answer_status == UserQuestionAnswerStatus.INVALID_REPLY:
+            self._message_pool_service.record_consumed_user_question_answer(
+                runtime_config=runtime_config,
+                normalized=normalized,
+                reason="invalid_user_question_answer",
+            )
+            self._send_command_response(
+                chat_id=normalized.chat_id,
+                chat_type=normalized.chat_type,
+                message_id=normalized.message_id,
+                text="请按问题数量逐行回答后再发送。",
+                runtime_config=runtime_config,
+            )
+            return TriggerProcessingResult(
+                status="answered",
+                trigger_id=runtime_config.trigger_id,
+                trigger_name=runtime_config.trigger_name,
+                event_id=normalized.event_id,
+                reason="invalid_user_question_answer",
+            )
+        if answer_status == UserQuestionAnswerStatus.ANSWERED:
+            self._message_pool_service.record_consumed_user_question_answer(
+                runtime_config=runtime_config,
+                normalized=normalized,
+                reason="user_question_answer",
+            )
+            self._send_command_response(
+                chat_id=normalized.chat_id,
+                chat_type=normalized.chat_type,
+                message_id=normalized.message_id,
+                text="已收到回答，正在继续处理。",
+                runtime_config=runtime_config,
+            )
+            return TriggerProcessingResult(
+                status="answered",
+                trigger_id=runtime_config.trigger_id,
+                trigger_name=runtime_config.trigger_name,
+                event_id=normalized.event_id,
+                reason="user_question_answer",
+            )
+        trigger_rule = runtime_config.source.trigger_rule
         if trigger_rule == "mention_only" and chat_type == "group":
+            if not normalized.mentioned:
+                return TriggerProcessingResult(
+                    status="ignored",
+                    trigger_id=runtime_config.trigger_id,
+                    trigger_name=runtime_config.trigger_name,
+                    event_id=normalized.event_id,
+                    ignored=True,
+                    reason="mention_required",
+                )
             if not _mention_targets_app(
                 mention_names=normalized.mention_names,
                 app_name=runtime_config.source.app_name,
@@ -180,15 +270,6 @@ class FeishuTriggerHandler:
                     ignored=True,
                     reason="mention_not_for_app",
                 )
-        if not normalized.trigger_text.strip():
-            return TriggerProcessingResult(
-                status="ignored",
-                trigger_id=runtime_config.trigger_id,
-                trigger_name=runtime_config.trigger_name,
-                event_id=normalized.event_id,
-                ignored=True,
-                reason="empty_trigger_text",
-            )
         command_result = self._im_session_command_service.handle_feishu_command(
             runtime_config=runtime_config,
             message=normalized,

--- a/src/relay_teams/gateway/gateway_session_service.py
+++ b/src/relay_teams/gateway/gateway_session_service.py
@@ -284,6 +284,17 @@ class GatewaySessionService:
     def get_session(self, gateway_session_id: str) -> GatewaySessionRecord:
         return self._repository.get(gateway_session_id)
 
+    def get_by_external_session(
+        self,
+        *,
+        channel_type: GatewayChannelType,
+        external_session_id: str,
+    ) -> GatewaySessionRecord | None:
+        return self._repository.get_by_external(
+            channel_type=channel_type,
+            external_session_id=external_session_id,
+        )
+
     def get_by_internal_session_id(
         self,
         internal_session_id: str,

--- a/src/relay_teams/gateway/im/context.py
+++ b/src/relay_teams/gateway/im/context.py
@@ -21,7 +21,9 @@ from relay_teams.gateway.gateway_models import GatewayChannelType, GatewaySessio
 from relay_teams.sessions.session_models import ProjectKind, SessionRecord
 from relay_teams.tools.registry.registry import ToolResolutionContext
 
-IM_IMPLICIT_TOOLS: tuple[str, ...] = ("im_send",)
+IM_SEND_IMPLICIT_TOOLS: tuple[str, ...] = ("im_send",)
+IM_IMPLICIT_TOOLS: tuple[str, ...] = ("im_send", "ask_question")
+XIAOLUBAN_IM_IMPLICIT_TOOLS: tuple[str, ...] = ("ask_question",)
 
 
 class _SessionLookup(Protocol):
@@ -209,6 +211,18 @@ def resolve_discord_chat_context(
     )
 
 
+def is_xiaoluban_im_session(
+    *,
+    gateway_session_lookup: _GatewaySessionLookup,
+    session_id: str,
+) -> bool:
+    gateway_session = gateway_session_lookup.get_by_internal_session_id(session_id)
+    return (
+        gateway_session is not None
+        and gateway_session.channel_type == GatewayChannelType.XIAOLUBAN
+    )
+
+
 class ImToolContextResolver:
     def __init__(
         self,
@@ -238,7 +252,20 @@ class ImToolContextResolver:
             session_id=session_id,
         )
         if chat_context is None:
+            if self._gateway_session_lookup is None:
+                return ()
+            if is_xiaoluban_im_session(
+                gateway_session_lookup=self._gateway_session_lookup,
+                session_id=session_id,
+            ):
+                return XIAOLUBAN_IM_IMPLICIT_TOOLS
             return ()
+        try:
+            session = self._session_repo.get(session_id)
+        except KeyError:
+            return IM_IMPLICIT_TOOLS
+        if _uses_automation_delivery_binding(session):
+            return IM_SEND_IMPLICIT_TOOLS
         return IM_IMPLICIT_TOOLS
 
 
@@ -274,6 +301,15 @@ def _resolve_from_session(
         chat_type=chat_type,
         reply_to_message_id=message_id,
         prefer_reply=(not prefer_direct_send and message_id is not None),
+    )
+
+
+def _uses_automation_delivery_binding(session: SessionRecord) -> bool:
+    metadata = session.metadata
+    return (
+        session.project_kind == ProjectKind.AUTOMATION
+        and str(metadata.get(FEISHU_METADATA_PLATFORM_KEY, "")).strip()
+        != FEISHU_PLATFORM
     )
 
 

--- a/src/relay_teams/gateway/user_questions.py
+++ b/src/relay_teams/gateway/user_questions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Protocol, cast
 
@@ -191,9 +192,11 @@ async def answer_pending_user_question_status_async(
     run_service: UserQuestionRunServiceAsync,
     run_id: str,
     text: str,
+    message_created_at: datetime | None = None,
 ) -> UserQuestionAnswerStatus:
     record = _latest_requested_question(
-        await run_service.list_user_questions_async(run_id)
+        await run_service.list_user_questions_async(run_id),
+        message_created_at=message_created_at,
     )
     return await _answer_pending_user_question_record_async(
         run_service=run_service,
@@ -207,9 +210,11 @@ async def answer_pending_user_question_for_session_status_async(
     run_service: UserQuestionSessionRunServiceAsync,
     session_id: str,
     text: str,
+    message_created_at: datetime | None = None,
 ) -> tuple[UserQuestionAnswerStatus, str | None]:
     record = _latest_requested_question(
-        await run_service.list_user_questions_by_session_async(session_id)
+        await run_service.list_user_questions_by_session_async(session_id),
+        message_created_at=message_created_at,
     )
     status = await _answer_pending_user_question_record_async(
         run_service=run_service,
@@ -400,6 +405,8 @@ def _matches_option_label(text: str, question: UserQuestionPrompt) -> bool:
 
 def _latest_requested_question(
     raw_records: list[dict[str, JsonValue]],
+    *,
+    message_created_at: datetime | None = None,
 ) -> UserQuestionRequestRecord | None:
     requested: list[UserQuestionRequestRecord] = []
     for item in raw_records:
@@ -407,11 +414,22 @@ def _latest_requested_question(
             record = UserQuestionRequestRecord.model_validate(item)
         except ValueError:
             continue
-        if record.status == UserQuestionRequestStatus.REQUESTED:
-            requested.append(record)
+        if record.status != UserQuestionRequestStatus.REQUESTED:
+            continue
+        if message_created_at is not None and _utc_datetime(
+            record.created_at
+        ) > _utc_datetime(message_created_at):
+            continue
+        requested.append(record)
     if not requested:
         return None
     return max(requested, key=lambda question_record: question_record.created_at)
+
+
+def _utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _requested_question(

--- a/src/relay_teams/gateway/user_questions.py
+++ b/src/relay_teams/gateway/user_questions.py
@@ -1,0 +1,476 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import re
+from enum import Enum
+from typing import Protocol, cast
+
+from pydantic import JsonValue
+
+from relay_teams.sessions.runs.user_question_models import (
+    NONE_OF_THE_ABOVE_OPTION_LABEL,
+    UserQuestionAnswer,
+    UserQuestionAnswerSubmission,
+    UserQuestionPrompt,
+    UserQuestionRequestRecord,
+    UserQuestionRequestStatus,
+    UserQuestionSelection,
+)
+
+
+class UserQuestionAnswerStatus(str, Enum):
+    NOT_PENDING = "not_pending"
+    ANSWERED = "answered"
+    INVALID_REPLY = "invalid_reply"
+
+
+class UserQuestionRunService(Protocol):
+    def list_user_questions(self, run_id: str) -> list[dict[str, JsonValue]]:
+        raise NotImplementedError  # pragma: no cover
+
+    def answer_user_question(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class UserQuestionRunServiceAsync(Protocol):
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class UserQuestionSessionRunServiceAsync(UserQuestionRunServiceAsync, Protocol):
+    async def list_user_questions_by_session_async(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        raise NotImplementedError  # pragma: no cover
+
+
+def format_user_question_request(
+    *,
+    question_id: str,
+    questions: tuple[UserQuestionPrompt, ...],
+) -> str:
+    lines = [
+        "需要你补充信息后我才能继续。",
+        "",
+        f"问题编号: {question_id}",
+    ]
+    if len(questions) > 1:
+        lines.append("请按问题顺序逐行回复。")
+    lines.append(
+        "直接回复选项文字；如果选项都不合适，直接回复补充内容。多选请用逗号分隔。"
+    )
+    for index, question in enumerate(questions, start=1):
+        lines.append("")
+        heading = question.header.strip()
+        if heading:
+            lines.append(f"{index}. {heading}")
+            lines.append(question.question)
+        else:
+            lines.append(f"{index}. {question.question}")
+        option_lines = _format_options(question)
+        if option_lines:
+            lines.append("选项:")
+            lines.extend(option_lines)
+    return "\n".join(lines)
+
+
+def format_user_question_event(payload_json: str) -> str | None:
+    parsed = parse_user_question_event(payload_json)
+    if parsed is None:
+        return None
+    question_id, questions = parsed
+    return format_user_question_request(
+        question_id=question_id,
+        questions=questions,
+    )
+
+
+def parse_user_question_event(
+    payload_json: str,
+) -> tuple[str, tuple[UserQuestionPrompt, ...]] | None:
+    payload = _json_object(payload_json)
+    if payload is None:
+        return None
+    question_id = _payload_text(payload, "question_id")
+    raw_questions = payload.get("questions")
+    if not question_id or not isinstance(raw_questions, list):
+        return None
+    questions = _load_prompts(raw_questions)
+    if not questions:
+        return None
+    return question_id, questions
+
+
+def answer_pending_user_question(
+    *,
+    run_service: UserQuestionRunService,
+    run_id: str,
+    text: str,
+) -> bool:
+    return (
+        answer_pending_user_question_status(
+            run_service=run_service,
+            run_id=run_id,
+            text=text,
+        )
+        == UserQuestionAnswerStatus.ANSWERED
+    )
+
+
+def answer_pending_user_question_status(
+    *,
+    run_service: UserQuestionRunService,
+    run_id: str,
+    text: str,
+) -> UserQuestionAnswerStatus:
+    record = _latest_requested_question(run_service.list_user_questions(run_id))
+    return _answer_pending_user_question_record(
+        run_service=run_service,
+        record=record,
+        text=text,
+    )
+
+
+def _answer_pending_user_question_record(
+    *,
+    run_service: UserQuestionRunService,
+    record: UserQuestionRequestRecord | None,
+    text: str,
+) -> UserQuestionAnswerStatus:
+    if record is None:
+        return UserQuestionAnswerStatus.NOT_PENDING
+    submission = try_build_answer_submission(text=text, questions=record.questions)
+    if submission is None:
+        return UserQuestionAnswerStatus.INVALID_REPLY
+    _ = run_service.answer_user_question(
+        run_id=record.run_id,
+        question_id=record.question_id,
+        answers=submission,
+    )
+    return UserQuestionAnswerStatus.ANSWERED
+
+
+async def answer_pending_user_question_async(
+    *,
+    run_service: UserQuestionRunServiceAsync,
+    run_id: str,
+    text: str,
+) -> bool:
+    return (
+        await answer_pending_user_question_status_async(
+            run_service=run_service,
+            run_id=run_id,
+            text=text,
+        )
+        == UserQuestionAnswerStatus.ANSWERED
+    )
+
+
+async def answer_pending_user_question_status_async(
+    *,
+    run_service: UserQuestionRunServiceAsync,
+    run_id: str,
+    text: str,
+) -> UserQuestionAnswerStatus:
+    record = _latest_requested_question(
+        await run_service.list_user_questions_async(run_id)
+    )
+    return await _answer_pending_user_question_record_async(
+        run_service=run_service,
+        record=record,
+        text=text,
+    )
+
+
+async def answer_pending_user_question_for_session_status_async(
+    *,
+    run_service: UserQuestionSessionRunServiceAsync,
+    session_id: str,
+    text: str,
+) -> tuple[UserQuestionAnswerStatus, str | None]:
+    record = _latest_requested_question(
+        await run_service.list_user_questions_by_session_async(session_id)
+    )
+    status = await _answer_pending_user_question_record_async(
+        run_service=run_service,
+        record=record,
+        text=text,
+    )
+    return status, record.run_id if record is not None else None
+
+
+async def _answer_pending_user_question_record_async(
+    *,
+    run_service: UserQuestionRunServiceAsync,
+    record: UserQuestionRequestRecord | None,
+    text: str,
+) -> UserQuestionAnswerStatus:
+    if record is None:
+        return UserQuestionAnswerStatus.NOT_PENDING
+    submission = try_build_answer_submission(text=text, questions=record.questions)
+    if submission is None:
+        return UserQuestionAnswerStatus.INVALID_REPLY
+    _ = await run_service.answer_user_question_async(
+        run_id=record.run_id,
+        question_id=record.question_id,
+        answers=submission,
+    )
+    return UserQuestionAnswerStatus.ANSWERED
+
+
+def is_user_question_requested(
+    *,
+    run_service: UserQuestionRunService,
+    run_id: str,
+    question_id: str,
+) -> bool:
+    return (
+        _requested_question(
+            run_service.list_user_questions(run_id),
+            question_id=question_id,
+        )
+        is not None
+    )
+
+
+async def is_user_question_requested_async(
+    *,
+    run_service: UserQuestionRunServiceAsync,
+    run_id: str,
+    question_id: str,
+) -> bool:
+    return (
+        _requested_question(
+            await run_service.list_user_questions_async(run_id),
+            question_id=question_id,
+        )
+        is not None
+    )
+
+
+def build_answer_submission(
+    *,
+    text: str,
+    questions: tuple[UserQuestionPrompt, ...],
+) -> UserQuestionAnswerSubmission:
+    submission = try_build_answer_submission(text=text, questions=questions)
+    if submission is None:
+        raise ValueError("Reply must include one non-empty line for each question")
+    return submission
+
+
+def try_build_answer_submission(
+    *,
+    text: str,
+    questions: tuple[UserQuestionPrompt, ...],
+) -> UserQuestionAnswerSubmission | None:
+    answer_texts = _answer_texts(text=text, questions=questions)
+    if answer_texts is None:
+        return None
+    return UserQuestionAnswerSubmission(
+        answers=tuple(
+            _answer_for_prompt(text=answer_texts[index], question=question)
+            for index, question in enumerate(questions)
+        )
+    )
+
+
+def _answer_texts(
+    *,
+    text: str,
+    questions: tuple[UserQuestionPrompt, ...],
+) -> tuple[str, ...] | None:
+    normalized = text.strip()
+    question_count = len(questions)
+    if question_count <= 1:
+        return (normalized,)
+    lines = tuple(line.strip() for line in normalized.splitlines() if line.strip())
+    if len(lines) == question_count:
+        return tuple(
+            _strip_number_prefix(
+                line,
+                question=questions[index],
+                position=index + 1,
+            )
+            for index, line in enumerate(lines)
+        )
+    stripped_lines = tuple(
+        _strip_number_prefix(
+            line,
+            question=questions[min(index, question_count - 1)],
+            position=index + 1,
+        )
+        for index, line in enumerate(lines)
+    )
+    if len(stripped_lines) > question_count:
+        return stripped_lines[: question_count - 1] + (
+            "\n".join(stripped_lines[question_count - 1 :]),
+        )
+    return None
+
+
+def _answer_for_prompt(
+    *, text: str, question: UserQuestionPrompt
+) -> UserQuestionAnswer:
+    normalized = text.strip()
+    labels_by_key = {
+        option.label.casefold(): option.label
+        for option in question.options
+        if option.label != NONE_OF_THE_ABOVE_OPTION_LABEL
+    }
+    selected_labels: list[str] = []
+    candidates = _split_selection_candidates(normalized) if question.multiple else ()
+    if question.multiple:
+        for candidate in candidates:
+            label = labels_by_key.get(candidate.casefold())
+            if label is None:
+                return _free_text_answer(normalized)
+            if label not in selected_labels:
+                selected_labels.append(label)
+    else:
+        label = labels_by_key.get(normalized.casefold())
+        if label is not None:
+            selected_labels.append(label)
+    if selected_labels:
+        return UserQuestionAnswer(
+            selections=tuple(
+                UserQuestionSelection(label=label) for label in selected_labels
+            )
+        )
+    return _free_text_answer(normalized)
+
+
+def _free_text_answer(text: str) -> UserQuestionAnswer:
+    return UserQuestionAnswer(
+        selections=(
+            UserQuestionSelection(
+                label=NONE_OF_THE_ABOVE_OPTION_LABEL,
+                supplement=text or None,
+            ),
+        )
+    )
+
+
+def _split_selection_candidates(text: str) -> tuple[str, ...]:
+    return tuple(
+        item.strip() for item in re.split(r"[,，;；\n]+", text) if item.strip()
+    )
+
+
+def _strip_number_prefix(
+    text: str,
+    *,
+    question: UserQuestionPrompt,
+    position: int,
+) -> str:
+    normalized = text.strip()
+    if _matches_option_label(normalized, question):
+        return normalized
+    return re.sub(rf"^\s*{position}[.)、]\s+", "", normalized).strip()
+
+
+def _matches_option_label(text: str, question: UserQuestionPrompt) -> bool:
+    normalized = text.casefold()
+    return any(
+        option.label.casefold() == normalized
+        for option in question.options
+        if option.label != NONE_OF_THE_ABOVE_OPTION_LABEL
+    )
+
+
+def _latest_requested_question(
+    raw_records: list[dict[str, JsonValue]],
+) -> UserQuestionRequestRecord | None:
+    requested: list[UserQuestionRequestRecord] = []
+    for item in raw_records:
+        try:
+            record = UserQuestionRequestRecord.model_validate(item)
+        except ValueError:
+            continue
+        if record.status == UserQuestionRequestStatus.REQUESTED:
+            requested.append(record)
+    if not requested:
+        return None
+    return max(requested, key=lambda question_record: question_record.created_at)
+
+
+def _requested_question(
+    raw_records: list[dict[str, JsonValue]],
+    *,
+    question_id: str,
+) -> UserQuestionRequestRecord | None:
+    normalized_question_id = question_id.strip()
+    if not normalized_question_id:
+        return None
+    for item in raw_records:
+        try:
+            record = UserQuestionRequestRecord.model_validate(item)
+        except ValueError:
+            continue
+        if (
+            record.question_id == normalized_question_id
+            and record.status == UserQuestionRequestStatus.REQUESTED
+        ):
+            return record
+    return None
+
+
+def _format_options(question: UserQuestionPrompt) -> list[str]:
+    lines: list[str] = []
+    for option in question.options:
+        if option.label == NONE_OF_THE_ABOVE_OPTION_LABEL:
+            continue
+        if option.description:
+            lines.append(f"- {option.label}: {option.description}")
+        else:
+            lines.append(f"- {option.label}")
+    return lines
+
+
+def _json_object(payload_json: str) -> dict[str, JsonValue] | None:
+    try:
+        payload = json.loads(payload_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return {
+        str(key): cast(JsonValue, value)
+        for key, value in payload.items()
+        if isinstance(key, str)
+    }
+
+
+def _payload_text(payload: dict[str, JsonValue], key: str) -> str:
+    value = payload.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _load_prompts(raw_questions: list[JsonValue]) -> tuple[UserQuestionPrompt, ...]:
+    prompts: list[UserQuestionPrompt] = []
+    for item in raw_questions:
+        try:
+            prompts.append(UserQuestionPrompt.model_validate(item))
+        except ValueError:
+            continue
+    return tuple(prompts)

--- a/src/relay_teams/gateway/wechat/service.py
+++ b/src/relay_teams/gateway/wechat/service.py
@@ -21,13 +21,20 @@ import qrcode
 import qrcode.image.svg
 import httpx
 
-from relay_teams.gateway.gateway_models import GatewayChannelType
+from relay_teams.gateway.gateway_models import GatewayChannelType, GatewaySessionRecord
 from relay_teams.validation import require_force_delete
 from relay_teams.gateway.gateway_session_service import GatewaySessionService
 from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressBusyPolicy,
     GatewaySessionIngressRequest,
     GatewaySessionIngressService,
+)
+from relay_teams.gateway.user_questions import (
+    UserQuestionAnswerStatus,
+    answer_pending_user_question_status,
+    format_user_question_request,
+    is_user_question_requested,
+    parse_user_question_event,
 )
 from relay_teams.gateway.wechat.inbound_queue_repository import (
     WeChatInboundQueueRepository,
@@ -580,6 +587,43 @@ class WeChatGatewayService:
                 "last_inbound_at": now.isoformat(),
             },
         )
+        if self._has_inbound_message_record(
+            account_id=account.account_id,
+            message=message,
+            peer_user_id=peer_user_id,
+        ):
+            return
+        active_run_id = self._active_run_id(gateway_session.internal_session_id)
+        if active_run_id is not None:
+            answer_status = self._try_answer_user_question(
+                run_id=active_run_id,
+                text=text,
+            )
+            if answer_status != UserQuestionAnswerStatus.NOT_PENDING:
+                if not self._record_answer_message_consumed(
+                    account_id=account.account_id,
+                    message=message,
+                    gateway_session=gateway_session,
+                    peer_user_id=peer_user_id,
+                    text=text,
+                ):
+                    return
+                if answer_status == UserQuestionAnswerStatus.ANSWERED:
+                    answer_text = "已收到回答，正在继续处理。"
+                    event_name = "wechat.user_question.answer"
+                else:
+                    answer_text = "请按问题数量逐行回答后再发送。"
+                    event_name = "wechat.user_question.invalid_answer"
+                self._send_intermediate_text(
+                    account_id=account.account_id,
+                    gateway_session_id=gateway_session.gateway_session_id,
+                    peer_user_id=peer_user_id,
+                    context_token=message.context_token,
+                    text=answer_text,
+                    event_name=event_name,
+                    failure_message="Failed to send WeChat user question answer acknowledgement",
+                )
+                return
         command_result = self._im_session_command_service.handle_wechat_command(
             session_id=gateway_session.internal_session_id,
             gateway_session_id=gateway_session.gateway_session_id,
@@ -642,6 +686,52 @@ class WeChatGatewayService:
             event_name="wechat.receipt",
             failure_message="Failed to send WeChat receipt",
         )
+
+    def _has_inbound_message_record(
+        self,
+        *,
+        account_id: str,
+        message: WeChatInboundMessage,
+        peer_user_id: str,
+    ) -> bool:
+        try:
+            _ = self._inbound_queue_repo.get_by_message_key(
+                account_id=account_id,
+                peer_user_id=peer_user_id,
+                message_key=self._message_key(message),
+            )
+        except KeyError:
+            return False
+        return True
+
+    def _record_answer_message_consumed(
+        self,
+        *,
+        account_id: str,
+        message: WeChatInboundMessage,
+        gateway_session: GatewaySessionRecord,
+        peer_user_id: str,
+        text: str,
+    ) -> bool:
+        now = datetime.now(tz=timezone.utc)
+        _record, created = self._inbound_queue_repo.create_or_get(
+            WeChatInboundQueueRecord(
+                inbound_queue_id=f"wq_{uuid4().hex[:16]}",
+                account_id=account_id,
+                message_key=self._message_key(message),
+                gateway_session_id=gateway_session.gateway_session_id,
+                session_id=gateway_session.internal_session_id,
+                peer_user_id=peer_user_id,
+                context_token=message.context_token,
+                text=text,
+                status=WeChatInboundQueueStatus.COMPLETED,
+                run_id=None,
+                created_at=now,
+                updated_at=now,
+                completed_at=now,
+            )
+        )
+        return created
 
     def _start_run_watcher(
         self,
@@ -712,8 +802,77 @@ class WeChatGatewayService:
         context_token: str | None,
     ) -> None:
         try:
-            async for event in self._run_service.stream_run_events(run_id):
-                if event.event_type == RunEventType.RUN_PAUSED:
+            after_event_id = 0
+            while True:
+                skipped_question_pause = False
+                skip_next_pause_after_user_question = False
+                async for event in self._run_service.stream_run_events(
+                    run_id,
+                    after_event_id=after_event_id,
+                ):
+                    if event.event_type == RunEventType.USER_QUESTION_REQUESTED:
+                        parsed = parse_user_question_event(event.payload_json)
+                        if parsed is None:
+                            continue
+                        question_id, questions = parsed
+                        is_requested = await asyncio.to_thread(
+                            is_user_question_requested,
+                            run_service=self._run_service,
+                            run_id=run_id,
+                            question_id=question_id,
+                        )
+                        if not is_requested:
+                            skip_next_pause_after_user_question = True
+                            continue
+                        text = format_user_question_request(
+                            question_id=question_id,
+                            questions=questions,
+                        )
+                        await self._im_tool_service.send_text_to_wechat_peer(
+                            account_id=account_id,
+                            peer_user_id=peer_user_id,
+                            text=text,
+                            context_token=context_token,
+                        )
+                        self._record_pause_notice(
+                            account_id=account_id,
+                            occurred_at=datetime.now(tz=timezone.utc),
+                        )
+                        skip_next_pause_after_user_question = True
+                        continue
+                    if event.event_type == RunEventType.RUN_PAUSED:
+                        if skip_next_pause_after_user_question:
+                            if event.event_id is not None:
+                                after_event_id = event.event_id
+                            else:
+                                after_event_id = -1
+                            skipped_question_pause = True
+                            break
+                        account = self._repository.get_account(account_id)
+                        token = self._secret_store.get_bot_token(
+                            self._config_dir, account_id
+                        )
+                        if token is None:
+                            raise RuntimeError(
+                                f"WeChat reply failed because bot token is missing for {account_id}."
+                            )
+                        text = self._paused_text(event)
+                        await self._send_typing_async(
+                            account, token, peer_user_id, context_token, 2
+                        )
+                        await self._im_tool_service.send_text_to_wechat_peer(
+                            account_id=account_id,
+                            peer_user_id=peer_user_id,
+                            text=text,
+                            context_token=context_token,
+                        )
+                        self._record_pause_notice(
+                            account_id=account_id,
+                            occurred_at=datetime.now(tz=timezone.utc),
+                        )
+                        return
+                    if event.event_type not in _TERMINAL_EVENT_TYPES:
+                        continue
                     account = self._repository.get_account(account_id)
                     token = self._secret_store.get_bot_token(
                         self._config_dir, account_id
@@ -722,9 +881,21 @@ class WeChatGatewayService:
                         raise RuntimeError(
                             f"WeChat reply failed because bot token is missing for {account_id}."
                         )
-                    text = self._paused_text(event)
+                    text = self._terminal_text(event)
                     await self._send_typing_async(
                         account, token, peer_user_id, context_token, 2
+                    )
+                    log_event(
+                        LOGGER,
+                        logging.INFO,
+                        event="wechat.reply.attempted",
+                        message="Attempting to send WeChat reply",
+                        payload={
+                            "account_id": account_id,
+                            "gateway_session_id": gateway_session_id,
+                            "run_id": run_id,
+                            "peer_user_id": peer_user_id,
+                        },
                     )
                     await self._im_tool_service.send_text_to_wechat_peer(
                         account_id=account_id,
@@ -732,54 +903,21 @@ class WeChatGatewayService:
                         text=text,
                         context_token=context_token,
                     )
-                    self._record_pause_notice(
+                    now = datetime.now(tz=timezone.utc)
+                    self._record_reply_success(
                         account_id=account_id,
-                        occurred_at=datetime.now(tz=timezone.utc),
+                        gateway_session_id=gateway_session_id,
+                        run_id=run_id,
+                        peer_user_id=peer_user_id,
+                        context_token=context_token,
+                        occurred_at=now,
                     )
                     return
-                if event.event_type not in _TERMINAL_EVENT_TYPES:
+                if skipped_question_pause:
                     continue
-                account = self._repository.get_account(account_id)
-                token = self._secret_store.get_bot_token(self._config_dir, account_id)
-                if token is None:
-                    raise RuntimeError(
-                        f"WeChat reply failed because bot token is missing for {account_id}."
-                    )
-                text = self._terminal_text(event)
-                await self._send_typing_async(
-                    account, token, peer_user_id, context_token, 2
+                raise RuntimeError(
+                    f"WeChat reply watcher ended before a stop event for {run_id}."
                 )
-                log_event(
-                    LOGGER,
-                    logging.INFO,
-                    event="wechat.reply.attempted",
-                    message="Attempting to send WeChat reply",
-                    payload={
-                        "account_id": account_id,
-                        "gateway_session_id": gateway_session_id,
-                        "run_id": run_id,
-                        "peer_user_id": peer_user_id,
-                    },
-                )
-                await self._im_tool_service.send_text_to_wechat_peer(
-                    account_id=account_id,
-                    peer_user_id=peer_user_id,
-                    text=text,
-                    context_token=context_token,
-                )
-                now = datetime.now(tz=timezone.utc)
-                self._record_reply_success(
-                    account_id=account_id,
-                    gateway_session_id=gateway_session_id,
-                    run_id=run_id,
-                    peer_user_id=peer_user_id,
-                    context_token=context_token,
-                    occurred_at=now,
-                )
-                return
-            raise RuntimeError(
-                f"WeChat reply watcher ended before a stop event for {run_id}."
-            )
         except Exception as exc:
             self._record_reply_failure(
                 account_id=account_id,
@@ -1318,6 +1456,29 @@ class WeChatGatewayService:
         if isinstance(run_id, str) and run_id.strip():
             return run_id.strip()
         return None
+
+    def _try_answer_user_question(
+        self,
+        *,
+        run_id: str,
+        text: str,
+    ) -> UserQuestionAnswerStatus:
+        try:
+            return answer_pending_user_question_status(
+                run_service=self._run_service,
+                run_id=run_id,
+                text=text,
+            )
+        except (KeyError, RuntimeError, ValueError, AttributeError) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="wechat.user_question.answer_failed",
+                message="Failed to answer pending WeChat user question",
+                payload={"run_id": run_id, "error": str(exc)},
+                exc_info=exc,
+            )
+            return UserQuestionAnswerStatus.NOT_PENDING
 
     def _build_receipt_text(self, record: WeChatInboundQueueRecord) -> str:
         if record.status == WeChatInboundQueueStatus.FAILED:

--- a/src/relay_teams/gateway/wechat/service.py
+++ b/src/relay_teams/gateway/wechat/service.py
@@ -802,76 +802,44 @@ class WeChatGatewayService:
         context_token: str | None,
     ) -> None:
         try:
-            after_event_id = 0
-            while True:
-                skipped_question_pause = False
-                skip_next_pause_after_user_question = False
-                async for event in self._run_service.stream_run_events(
-                    run_id,
-                    after_event_id=after_event_id,
-                ):
-                    if event.event_type == RunEventType.USER_QUESTION_REQUESTED:
-                        parsed = parse_user_question_event(event.payload_json)
-                        if parsed is None:
-                            continue
-                        question_id, questions = parsed
-                        is_requested = await asyncio.to_thread(
-                            is_user_question_requested,
-                            run_service=self._run_service,
-                            run_id=run_id,
-                            question_id=question_id,
-                        )
-                        if not is_requested:
-                            skip_next_pause_after_user_question = True
-                            continue
-                        text = format_user_question_request(
-                            question_id=question_id,
-                            questions=questions,
-                        )
-                        await self._im_tool_service.send_text_to_wechat_peer(
-                            account_id=account_id,
-                            peer_user_id=peer_user_id,
-                            text=text,
-                            context_token=context_token,
-                        )
-                        self._record_pause_notice(
-                            account_id=account_id,
-                            occurred_at=datetime.now(tz=timezone.utc),
-                        )
+            skip_next_pause_after_user_question = False
+            async for event in self._run_service.stream_run_events(
+                run_id,
+                stop_on_pause=False,
+            ):
+                if event.event_type == RunEventType.USER_QUESTION_REQUESTED:
+                    parsed = parse_user_question_event(event.payload_json)
+                    if parsed is None:
+                        continue
+                    question_id, questions = parsed
+                    is_requested = await asyncio.to_thread(
+                        is_user_question_requested,
+                        run_service=self._run_service,
+                        run_id=run_id,
+                        question_id=question_id,
+                    )
+                    if not is_requested:
                         skip_next_pause_after_user_question = True
                         continue
-                    if event.event_type == RunEventType.RUN_PAUSED:
-                        if skip_next_pause_after_user_question:
-                            if event.event_id is not None:
-                                after_event_id = event.event_id
-                            else:
-                                after_event_id = -1
-                            skipped_question_pause = True
-                            break
-                        account = self._repository.get_account(account_id)
-                        token = self._secret_store.get_bot_token(
-                            self._config_dir, account_id
-                        )
-                        if token is None:
-                            raise RuntimeError(
-                                f"WeChat reply failed because bot token is missing for {account_id}."
-                            )
-                        text = self._paused_text(event)
-                        await self._send_typing_async(
-                            account, token, peer_user_id, context_token, 2
-                        )
-                        await self._im_tool_service.send_text_to_wechat_peer(
-                            account_id=account_id,
-                            peer_user_id=peer_user_id,
-                            text=text,
-                            context_token=context_token,
-                        )
-                        self._record_pause_notice(
-                            account_id=account_id,
-                            occurred_at=datetime.now(tz=timezone.utc),
-                        )
-                        return
-                    if event.event_type not in _TERMINAL_EVENT_TYPES:
+                    text = format_user_question_request(
+                        question_id=question_id,
+                        questions=questions,
+                    )
+                    await self._im_tool_service.send_text_to_wechat_peer(
+                        account_id=account_id,
+                        peer_user_id=peer_user_id,
+                        text=text,
+                        context_token=context_token,
+                    )
+                    self._record_pause_notice(
+                        account_id=account_id,
+                        occurred_at=datetime.now(tz=timezone.utc),
+                    )
+                    skip_next_pause_after_user_question = True
+                    continue
+                if event.event_type == RunEventType.RUN_PAUSED:
+                    if skip_next_pause_after_user_question:
+                        skip_next_pause_after_user_question = False
                         continue
                     account = self._repository.get_account(account_id)
                     token = self._secret_store.get_bot_token(
@@ -881,21 +849,9 @@ class WeChatGatewayService:
                         raise RuntimeError(
                             f"WeChat reply failed because bot token is missing for {account_id}."
                         )
-                    text = self._terminal_text(event)
+                    text = self._paused_text(event)
                     await self._send_typing_async(
                         account, token, peer_user_id, context_token, 2
-                    )
-                    log_event(
-                        LOGGER,
-                        logging.INFO,
-                        event="wechat.reply.attempted",
-                        message="Attempting to send WeChat reply",
-                        payload={
-                            "account_id": account_id,
-                            "gateway_session_id": gateway_session_id,
-                            "run_id": run_id,
-                            "peer_user_id": peer_user_id,
-                        },
                     )
                     await self._im_tool_service.send_text_to_wechat_peer(
                         account_id=account_id,
@@ -903,21 +859,54 @@ class WeChatGatewayService:
                         text=text,
                         context_token=context_token,
                     )
-                    now = datetime.now(tz=timezone.utc)
-                    self._record_reply_success(
+                    self._record_pause_notice(
                         account_id=account_id,
-                        gateway_session_id=gateway_session_id,
-                        run_id=run_id,
-                        peer_user_id=peer_user_id,
-                        context_token=context_token,
-                        occurred_at=now,
+                        occurred_at=datetime.now(tz=timezone.utc),
                     )
                     return
-                if skipped_question_pause:
+                if event.event_type not in _TERMINAL_EVENT_TYPES:
                     continue
-                raise RuntimeError(
-                    f"WeChat reply watcher ended before a stop event for {run_id}."
+                account = self._repository.get_account(account_id)
+                token = self._secret_store.get_bot_token(self._config_dir, account_id)
+                if token is None:
+                    raise RuntimeError(
+                        f"WeChat reply failed because bot token is missing for {account_id}."
+                    )
+                text = self._terminal_text(event)
+                await self._send_typing_async(
+                    account, token, peer_user_id, context_token, 2
                 )
+                log_event(
+                    LOGGER,
+                    logging.INFO,
+                    event="wechat.reply.attempted",
+                    message="Attempting to send WeChat reply",
+                    payload={
+                        "account_id": account_id,
+                        "gateway_session_id": gateway_session_id,
+                        "run_id": run_id,
+                        "peer_user_id": peer_user_id,
+                    },
+                )
+                await self._im_tool_service.send_text_to_wechat_peer(
+                    account_id=account_id,
+                    peer_user_id=peer_user_id,
+                    text=text,
+                    context_token=context_token,
+                )
+                now = datetime.now(tz=timezone.utc)
+                self._record_reply_success(
+                    account_id=account_id,
+                    gateway_session_id=gateway_session_id,
+                    run_id=run_id,
+                    peer_user_id=peer_user_id,
+                    context_token=context_token,
+                    occurred_at=now,
+                )
+                return
+            raise RuntimeError(
+                f"WeChat reply watcher ended before a stop event for {run_id}."
+            )
         except Exception as exc:
             self._record_reply_failure(
                 account_id=account_id,

--- a/src/relay_teams/gateway/xiaoluban/service.py
+++ b/src/relay_teams/gateway/xiaoluban/service.py
@@ -19,6 +19,14 @@ from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressRequest,
     GatewaySessionIngressService,
 )
+from relay_teams.gateway.user_questions import (
+    UserQuestionAnswerStatus,
+    answer_pending_user_question_for_session_status_async,
+    answer_pending_user_question_status,
+    format_user_question_request,
+    is_user_question_requested,
+    parse_user_question_event,
+)
 from relay_teams.gateway.xiaoluban.account_repository import XiaolubanAccountRepository
 from relay_teams.gateway.xiaoluban.client import XiaolubanClient
 from relay_teams.gateway.xiaoluban.models import (
@@ -105,6 +113,8 @@ class XiaolubanGatewayService:
         )
         self._im_terminal_suppressed_run_ids: dict[str, float] = {}
         self._im_terminal_suppression_lock = threading.Lock()
+        self._im_question_notice_keys: set[str] = set()
+        self._im_question_notice_lock = threading.Lock()
         self._pending_im_replies: dict[str, _IMReplyContext] = {}
         self._pending_im_replies_lock = threading.Lock()
         self._im_poller_started = False
@@ -491,7 +501,7 @@ class XiaolubanGatewayService:
 
     # NOTE: Xiaoluban IM forwarding URLs have a platform-enforced length limit.
     # Adding ?auth= pushes URLs past that limit, breaking the forwarding command.
-    # DO NOT add auth tokens to the callback URL — this is intentionally omitted.
+    # DO NOT add auth tokens to the callback URL; this is intentionally omitted.
     def get_im_callback_auth_token(self, account_id: str) -> str:
         account = self._repository.get_account(account_id)
         if account.status != XiaolubanAccountStatus.ENABLED:
@@ -985,6 +995,77 @@ class XiaolubanGatewayService:
             receiver_uid=reply_target,
         )
 
+    def _find_im_gateway_session(
+        self,
+        external_session_id: str,
+    ) -> GatewaySessionRecord | None:
+        gateway_session_service = self._gateway_session_service
+        if gateway_session_service is None:
+            return None
+        for gateway_session in gateway_session_service.list_all():
+            if (
+                gateway_session.channel_type == GatewayChannelType.XIAOLUBAN
+                and gateway_session.external_session_id == external_session_id
+            ):
+                return gateway_session
+        return None
+
+    async def _try_answer_im_user_question(
+        self,
+        *,
+        account_id: str,
+        workspace_id: str,
+        gateway_session: GatewaySessionRecord,
+        text: str,
+        reply_target: str,
+    ) -> bool:
+        active_run_id = await asyncio.to_thread(
+            self._active_run_id, gateway_session.internal_session_id
+        )
+        if active_run_id is None:
+            (
+                answer_status,
+                active_run_id,
+            ) = await self._try_answer_user_question_for_session_async(
+                session_id=gateway_session.internal_session_id,
+                text=text,
+            )
+            if active_run_id is None:
+                return False
+        else:
+            answer_status = await asyncio.to_thread(
+                self._try_answer_user_question,
+                run_id=active_run_id,
+                text=text,
+            )
+        if answer_status == UserQuestionAnswerStatus.NOT_PENDING:
+            return False
+        if answer_status == UserQuestionAnswerStatus.ANSWERED:
+            await asyncio.to_thread(
+                self._register_im_reply,
+                account_id=account_id,
+                gateway_session_id=gateway_session.gateway_session_id,
+                workspace_id=workspace_id,
+                session_id=gateway_session.internal_session_id,
+                run_id=active_run_id,
+                reply_target=reply_target,
+            )
+            await asyncio.to_thread(self._ensure_poller_started)
+            status = "answered"
+            body = "已收到回答，正在继续处理。"
+        else:
+            status = "invalid_answer"
+            body = "请按问题数量逐行回答后再发送。"
+        await self.send_notification_message(
+            account_id=account_id,
+            workspace_id=workspace_id,
+            session_id=gateway_session.internal_session_id,
+            status=status,
+            body=body,
+            receiver_uid=reply_target,
+        )
+        return True
+
     async def _handle_im_inbound(
         self,
         account_id: str,
@@ -1026,6 +1107,27 @@ class XiaolubanGatewayService:
             )
             return
         if text.startswith("/"):
+            external_session_id = await asyncio.to_thread(
+                self._resolve_effective_external_session_id,
+                account_id,
+                message,
+                workspace_id,
+            )
+            existing_gateway_session = await asyncio.to_thread(
+                self._find_im_gateway_session,
+                external_session_id,
+            )
+            if (
+                existing_gateway_session is not None
+                and await self._try_answer_im_user_question(
+                    account_id=account_id,
+                    workspace_id=workspace_id,
+                    gateway_session=existing_gateway_session,
+                    text=text,
+                    reply_target=reply_target,
+                )
+            ):
+                return
             result = await self._try_handle_command(
                 account_id=account_id,
                 message=message,
@@ -1095,6 +1197,14 @@ class XiaolubanGatewayService:
                 "external_session_id": external_session_id,
             },
         )
+        if await self._try_answer_im_user_question(
+            account_id=account_id,
+            workspace_id=workspace_id,
+            gateway_session=gateway_session,
+            text=text,
+            reply_target=reply_target,
+        ):
+            return
         active_run_id = await asyncio.to_thread(
             self._active_run_id, gateway_session.internal_session_id
         )
@@ -1280,6 +1390,24 @@ class XiaolubanGatewayService:
             pending = list(self._pending_im_replies.items())
         for run_id, ctx in pending:
             try:
+                question_key, question_text = self._user_question_text_for_run(run_id)
+                if question_text:
+                    should_send_question = False
+                    with self._im_question_notice_lock:
+                        if question_key not in self._im_question_notice_keys:
+                            should_send_question = True
+                    if should_send_question:
+                        await self.send_notification_message(
+                            account_id=ctx.account_id,
+                            workspace_id=ctx.workspace_id,
+                            session_id=ctx.session_id,
+                            status="input_required",
+                            body=question_text,
+                            receiver_uid=ctx.reply_target,
+                        )
+                        with self._im_question_notice_lock:
+                            self._im_question_notice_keys.add(question_key)
+                        continue
                 terminal_text = self._terminal_text_for_run(run_id)
                 if not terminal_text:
                     continue
@@ -1330,6 +1458,91 @@ class XiaolubanGatewayService:
         )
         with self._pending_im_replies_lock:
             self._pending_im_replies[run_id] = ctx
+
+    def _try_answer_user_question(
+        self,
+        *,
+        run_id: str,
+        text: str,
+    ) -> UserQuestionAnswerStatus:
+        run_service = self._run_service
+        if run_service is None:
+            return UserQuestionAnswerStatus.NOT_PENDING
+        try:
+            return answer_pending_user_question_status(
+                run_service=run_service,
+                run_id=run_id,
+                text=text,
+            )
+        except (KeyError, RuntimeError, ValueError, AttributeError) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="gateway.xiaoluban.user_question.answer_failed",
+                message="Failed to answer pending Xiaoluban user question",
+                payload={"run_id": run_id, "error": str(exc)},
+                exc_info=exc,
+            )
+            return UserQuestionAnswerStatus.NOT_PENDING
+
+    async def _try_answer_user_question_for_session_async(
+        self,
+        *,
+        session_id: str,
+        text: str,
+    ) -> tuple[UserQuestionAnswerStatus, str | None]:
+        run_service = self._run_service
+        if run_service is None:
+            return UserQuestionAnswerStatus.NOT_PENDING, None
+        try:
+            return await answer_pending_user_question_for_session_status_async(
+                run_service=run_service,
+                session_id=session_id,
+                text=text,
+            )
+        except (KeyError, RuntimeError, ValueError) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="gateway.xiaoluban.user_question.session_answer_failed",
+                message="Failed to answer pending Xiaoluban user question by session",
+                payload={"session_id": session_id, "error": str(exc)},
+                exc_info=exc,
+            )
+            return UserQuestionAnswerStatus.NOT_PENDING, None
+
+    def _user_question_text_for_run(self, run_id: str) -> tuple[str, str]:
+        if self._event_log is None:
+            return "", ""
+        for row in reversed(self._event_log.list_by_trace_with_ids(run_id)):
+            try:
+                event_type = RunEventType(str(row["event_type"]))
+            except ValueError:
+                continue
+            if event_type != RunEventType.USER_QUESTION_REQUESTED:
+                continue
+            event_id = row.get("id")
+            event_key = f"{run_id}:{event_id}" if isinstance(event_id, int) else run_id
+            payload_json = str(row["payload_json"] or "{}")
+            parsed = parse_user_question_event(payload_json)
+            if parsed is None:
+                continue
+            question_id, questions = parsed
+            run_service = self._run_service
+            if run_service is None:
+                return "", ""
+            if not is_user_question_requested(
+                run_service=run_service,
+                run_id=run_id,
+                question_id=question_id,
+            ):
+                continue
+            text = format_user_question_request(
+                question_id=question_id,
+                questions=questions,
+            )
+            return event_key, text
+        return "", ""
 
     def _terminal_text_for_run(self, run_id: str) -> str:
         if self._event_log is None:

--- a/src/relay_teams/sessions/runs/run_interactions.py
+++ b/src/relay_teams/sessions/runs/run_interactions.py
@@ -644,6 +644,16 @@ class RunInteractionService:
             for item in await repo.list_by_run_async(run_id)
         ]
 
+    async def list_user_questions_by_session_async(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        repo = self._require_user_question_repo()
+        return [
+            cast(dict[str, JsonValue], item.model_dump(mode="json"))
+            for item in await repo.list_by_session_async(session_id)
+        ]
+
     def answer_user_question(
         self,
         *,

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -2498,6 +2498,13 @@ class SessionRunService:
     ) -> list[dict[str, JsonValue]]:
         return await self._interaction_service.list_user_questions_async(run_id)
 
+    async def list_user_questions_by_session_async(
+        self, session_id: str
+    ) -> list[dict[str, JsonValue]]:
+        return await self._interaction_service.list_user_questions_by_session_async(
+            session_id
+        )
+
     def answer_user_question(
         self,
         *,

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -1679,7 +1679,7 @@ class SessionRunService:
         stop_on_pause: bool = True,
     ):
         queue = self._run_event_hub.subscribe(run_id)
-        terminal_reached = False
+        final_terminal_reached = False
         try:
             replay_high_watermark = 0
             if after_event_id >= 0 and self._event_log is not None:
@@ -1715,8 +1715,10 @@ class SessionRunService:
                         RunEventType.RUN_COMPLETED,
                         RunEventType.RUN_FAILED,
                         RunEventType.RUN_STOPPED,
-                    ) or (stop_on_pause and event_type == RunEventType.RUN_PAUSED):
-                        terminal_reached = True
+                    ):
+                        final_terminal_reached = True
+                        return
+                    if stop_on_pause and event_type == RunEventType.RUN_PAUSED:
                         return
 
             while True:
@@ -1732,12 +1734,14 @@ class SessionRunService:
                     RunEventType.RUN_COMPLETED,
                     RunEventType.RUN_FAILED,
                     RunEventType.RUN_STOPPED,
-                ) or (stop_on_pause and event.event_type == RunEventType.RUN_PAUSED):
-                    terminal_reached = True
+                ):
+                    final_terminal_reached = True
+                    break
+                if stop_on_pause and event.event_type == RunEventType.RUN_PAUSED:
                     break
         finally:
             self._run_event_hub.unsubscribe(run_id, queue)
-            if terminal_reached:
+            if final_terminal_reached:
                 self._run_event_hub.unsubscribe_all(run_id)
 
     async def stream_multiplexed_run_events(

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -1671,7 +1671,13 @@ class SessionRunService:
         if cancellation_requested:
             raise asyncio.CancelledError
 
-    async def stream_run_events(self, run_id: str, after_event_id: int = 0):
+    async def stream_run_events(
+        self,
+        run_id: str,
+        after_event_id: int = 0,
+        *,
+        stop_on_pause: bool = True,
+    ):
         queue = self._run_event_hub.subscribe(run_id)
         terminal_reached = False
         try:
@@ -1706,11 +1712,10 @@ class SessionRunService:
                     replay_high_watermark = max(replay_high_watermark, row_id)
                     yield replay_event
                     if event_type in (
-                        RunEventType.RUN_PAUSED,
                         RunEventType.RUN_COMPLETED,
                         RunEventType.RUN_FAILED,
                         RunEventType.RUN_STOPPED,
-                    ):
+                    ) or (stop_on_pause and event_type == RunEventType.RUN_PAUSED):
                         terminal_reached = True
                         return
 
@@ -1724,11 +1729,10 @@ class SessionRunService:
                     continue
                 yield event
                 if event.event_type in (
-                    RunEventType.RUN_PAUSED,
                     RunEventType.RUN_COMPLETED,
                     RunEventType.RUN_FAILED,
                     RunEventType.RUN_STOPPED,
-                ):
+                ) or (stop_on_pause and event.event_type == RunEventType.RUN_PAUSED):
                     terminal_reached = True
                     break
         finally:

--- a/tests/unit_tests/feishu/test_inbound_runtime.py
+++ b/tests/unit_tests/feishu/test_inbound_runtime.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 
 import pytest
+from pydantic import JsonValue
 
 from relay_teams.gateway.feishu.inbound_runtime import FeishuInboundRuntime
 from relay_teams.gateway.feishu.models import (
@@ -15,11 +17,16 @@ from relay_teams.gateway.feishu.models import (
     FeishuTriggerSourceConfig,
     FeishuTriggerTargetConfig,
 )
+from relay_teams.gateway.session_ingress_service import GatewaySessionIngressService
+from relay_teams.gateway.user_questions import UserQuestionAnswerStatus
 from relay_teams.providers.token_usage_repo import SessionTokenUsage
 from relay_teams.sessions.external_session_binding_repository import (
     ExternalSessionBindingRepository,
 )
 from relay_teams.sessions.runs.run_models import IntentInput, RunThinkingConfig
+from relay_teams.sessions.runs.user_question_models import (
+    UserQuestionAnswerSubmission,
+)
 from relay_teams.sessions.session_metadata import (
     SESSION_METADATA_SOURCE_LABEL_KEY,
     SESSION_METADATA_SOURCE_PROVIDER_KEY,
@@ -35,6 +42,7 @@ class _FakeSessionService:
     def __init__(self) -> None:
         self.sessions: dict[str, SessionRecord] = {}
         self.created_count = 0
+        self.fail_sync_get = False
 
     def create_session(
         self,
@@ -62,6 +70,13 @@ class _FakeSessionService:
         return record
 
     def get_session(self, session_id: str) -> SessionRecord:
+        if self.fail_sync_get:
+            raise AssertionError("sync get_session should not be used")
+        if session_id not in self.sessions:
+            raise KeyError(session_id)
+        return self.sessions[session_id]
+
+    async def get_session_async(self, session_id: str) -> SessionRecord:
         if session_id not in self.sessions:
             raise KeyError(session_id)
         return self.sessions[session_id]
@@ -96,6 +111,10 @@ class _FakeRunService:
     def __init__(self) -> None:
         self.created: list[IntentInput] = []
         self.started: list[str] = []
+        self.user_questions: list[dict[str, JsonValue]] = []
+        self.answered_questions: list[
+            tuple[str, str, UserQuestionAnswerSubmission]
+        ] = []
 
     def create_run(self, intent: IntentInput) -> tuple[str, str]:
         return self.create_detached_run(intent)
@@ -115,6 +134,33 @@ class _FakeRunService:
 
     def stop_run(self, run_id: str) -> None:
         self.started.append(f"stopped:{run_id}")
+
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        _ = run_id
+        return self.user_questions
+
+    async def list_user_questions_by_session_async(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        return [
+            record
+            for record in self.user_questions
+            if record.get("session_id") == session_id
+        ]
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        self.answered_questions.append((run_id, question_id, answers))
+        return {"run_id": run_id, "question_id": question_id}
 
 
 class _FakeFeishuClient:
@@ -149,6 +195,16 @@ class _FakeFeishuClient:
     ) -> str | None:
         _ = (chat_id, environment)
         return self.user_names.get(open_id)
+
+
+class _FakeSessionIngressService:
+    def __init__(self, active_run_id: str | None = None) -> None:
+        self.active_run_id = active_run_id
+        self.queries: list[str] = []
+
+    async def active_run_id_async(self, session_id: str) -> str | None:
+        self.queries.append(session_id)
+        return self.active_run_id
 
 
 def _build_runtime(
@@ -366,3 +422,219 @@ async def test_resolve_session_id_preserves_manual_title(tmp_path: Path) -> None
         ]
         == SESSION_TITLE_SOURCE_MANUAL
     )
+
+
+async def test_answer_pending_question_without_ingress_uses_session_binding(
+    tmp_path: Path,
+) -> None:
+    session_service = _FakeSessionService()
+    run_service = _FakeRunService()
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-detached",
+            "session_id": "session-existing",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [
+                {
+                    "question": "Pick a target",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        }
+    ]
+    bindings = ExternalSessionBindingRepository(tmp_path / "bindings.db")
+    runtime = FeishuInboundRuntime(
+        session_service=session_service,
+        run_service=run_service,
+        external_session_binding_repo=bindings,
+    )
+    session = session_service.create_session(
+        session_id="session-existing",
+        workspace_id="default",
+    )
+    session_service.fail_sync_get = True
+    bindings.upsert_binding(
+        platform="feishu",
+        trigger_id="trg_manual",
+        tenant_key="tenant-1",
+        external_chat_id="oc_group_1",
+        session_id=session.session_id,
+    )
+
+    status = await runtime.answer_pending_user_question_async(
+        runtime_config=_build_runtime(
+            trigger_id="trg_manual",
+            trigger_name="manual",
+            app_name="bot-manual",
+        ),
+        message=_build_message(
+            event_id="evt-answer",
+            message_id="om_answer",
+            chat_id="oc_group_1",
+            chat_type="group",
+            trigger_text="Ship",
+        ),
+    )
+
+    assert status == UserQuestionAnswerStatus.ANSWERED
+    assert run_service.answered_questions[0][0] == "run-detached"
+    assert run_service.answered_questions[0][1] == "question-1"
+
+
+async def test_answer_pending_question_returns_not_pending_for_missing_session(
+    tmp_path: Path,
+) -> None:
+    session_service = _FakeSessionService()
+    run_service = _FakeRunService()
+    bindings = ExternalSessionBindingRepository(tmp_path / "bindings.db")
+    bindings.upsert_binding(
+        platform="feishu",
+        trigger_id="trg_manual",
+        tenant_key="tenant-1",
+        external_chat_id="oc_group_1",
+        session_id="session-missing",
+    )
+    runtime = FeishuInboundRuntime(
+        session_service=session_service,
+        run_service=run_service,
+        external_session_binding_repo=bindings,
+    )
+
+    status = await runtime.answer_pending_user_question_async(
+        runtime_config=_build_runtime(
+            trigger_id="trg_manual",
+            trigger_name="manual",
+            app_name="bot-manual",
+        ),
+        message=_build_message(
+            event_id="evt-answer",
+            message_id="om_answer",
+            chat_id="oc_group_1",
+            chat_type="group",
+            trigger_text="Ship",
+        ),
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+    assert run_service.answered_questions == []
+
+
+async def test_answer_pending_question_returns_not_pending_without_active_ingress_run(
+    tmp_path: Path,
+) -> None:
+    session_service = _FakeSessionService()
+    run_service = _FakeRunService()
+    bindings = ExternalSessionBindingRepository(tmp_path / "bindings.db")
+    session = session_service.create_session(
+        session_id="session-existing",
+        workspace_id="default",
+    )
+    bindings.upsert_binding(
+        platform="feishu",
+        trigger_id="trg_manual",
+        tenant_key="tenant-1",
+        external_chat_id="oc_group_1",
+        session_id=session.session_id,
+    )
+    ingress_service = _FakeSessionIngressService()
+    runtime = FeishuInboundRuntime(
+        session_service=session_service,
+        run_service=run_service,
+        external_session_binding_repo=bindings,
+        session_ingress_service=cast(GatewaySessionIngressService, ingress_service),
+    )
+
+    status = await runtime.answer_pending_user_question_async(
+        runtime_config=_build_runtime(
+            trigger_id="trg_manual",
+            trigger_name="manual",
+            app_name="bot-manual",
+        ),
+        message=_build_message(
+            event_id="evt-answer",
+            message_id="om_answer",
+            chat_id="oc_group_1",
+            chat_type="group",
+            trigger_text="Ship",
+        ),
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+    assert ingress_service.queries == ["session-existing"]
+    assert run_service.answered_questions == []
+
+
+async def test_answer_pending_question_uses_active_ingress_run(
+    tmp_path: Path,
+) -> None:
+    session_service = _FakeSessionService()
+    run_service = _FakeRunService()
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-active",
+            "session_id": "session-existing",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [
+                {
+                    "question": "Pick a target",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        }
+    ]
+    bindings = ExternalSessionBindingRepository(tmp_path / "bindings.db")
+    session = session_service.create_session(
+        session_id="session-existing",
+        workspace_id="default",
+    )
+    bindings.upsert_binding(
+        platform="feishu",
+        trigger_id="trg_manual",
+        tenant_key="tenant-1",
+        external_chat_id="oc_group_1",
+        session_id=session.session_id,
+    )
+    ingress_service = _FakeSessionIngressService(active_run_id="run-active")
+    runtime = FeishuInboundRuntime(
+        session_service=session_service,
+        run_service=run_service,
+        external_session_binding_repo=bindings,
+        session_ingress_service=cast(GatewaySessionIngressService, ingress_service),
+    )
+
+    status = await runtime.answer_pending_user_question_async(
+        runtime_config=_build_runtime(
+            trigger_id="trg_manual",
+            trigger_name="manual",
+            app_name="bot-manual",
+        ),
+        message=_build_message(
+            event_id="evt-answer",
+            message_id="om_answer",
+            chat_id="oc_group_1",
+            chat_type="group",
+            trigger_text="Ship",
+        ),
+    )
+
+    assert status == UserQuestionAnswerStatus.ANSWERED
+    assert ingress_service.queries == ["session-existing"]
+    assert run_service.answered_questions[0][0] == "run-active"

--- a/tests/unit_tests/feishu/test_message_pool_service.py
+++ b/tests/unit_tests/feishu/test_message_pool_service.py
@@ -600,6 +600,72 @@ async def test_message_pool_does_not_consume_older_queued_message_as_answer(
     assert len(run_service.created) == 1
 
 
+async def test_message_pool_sends_invalid_user_question_reply(
+    tmp_path: Path,
+) -> None:
+    service, repo, feishu_client, _runtime_repo, _event_log, run_service = (
+        _build_service(tmp_path)
+    )
+    runtime = _build_runtime()
+    session = service._inbound_runtime._session_service.create_session(
+        workspace_id="default"
+    )
+    service._inbound_runtime._external_session_binding_repo.upsert_binding(
+        platform=FEISHU_PLATFORM,
+        trigger_id=runtime.trigger_id,
+        tenant_key="tenant-1",
+        external_chat_id="oc_group_1",
+        session_id=session.session_id,
+    )
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-1",
+            "session_id": session.session_id,
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [
+                {"question": "Deploy?", "options": [{"label": "Ship"}]},
+                {"question": "Notify?", "options": [{"label": "Yes"}]},
+            ],
+            "status": "requested",
+            "answers": [],
+            "created_at": datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc).isoformat(),
+            "updated_at": datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc).isoformat(),
+            "resolved_at": None,
+        }
+    ]
+    queued = service.enqueue_message(
+        runtime_config=runtime,
+        normalized=_build_message(
+            event_id="evt-invalid",
+            message_id="om_invalid",
+            text="Ship",
+        ),
+        raw_body="{}",
+        headers={},
+        remote_addr=None,
+    )
+    assert queued.status == "accepted"
+
+    assert await service._process_queued_messages() is True
+
+    record = repo.get_by_message_key(
+        trigger_id=runtime.trigger_id,
+        tenant_key="tenant-1",
+        message_key="om_invalid",
+    )
+    assert record.processing_status == FeishuMessageProcessingStatus.COMPLETED
+    assert record.final_reply_status == FeishuMessageDeliveryStatus.SENT
+    assert record.final_reply_text == "请按问题数量逐行回答后再发送。"
+    assert feishu_client.reply_messages == [
+        ("om_invalid", "请按问题数量逐行回答后再发送。")
+    ]
+    assert len(run_service.created) == 0
+
+
 async def test_enqueue_message_uses_queue_aware_ack(tmp_path: Path) -> None:
     service, repo, feishu_client, _run_runtime_repo, _event_log, _run_service = (
         _build_service(tmp_path)

--- a/tests/unit_tests/feishu/test_message_pool_service.py
+++ b/tests/unit_tests/feishu/test_message_pool_service.py
@@ -333,12 +333,34 @@ async def test_run_answer_check_runs_without_existing_loop() -> None:
     assert status == UserQuestionAnswerStatus.ANSWERED
 
 
+async def test_run_answer_check_uses_bound_loop_from_worker_thread() -> None:
+    loop = asyncio.get_running_loop()
+    observed_loops: list[asyncio.AbstractEventLoop] = []
+
+    async def answer() -> UserQuestionAnswerStatus:
+        observed_loops.append(asyncio.get_running_loop())
+        return UserQuestionAnswerStatus.ANSWERED
+
+    status = await asyncio.to_thread(lambda: _run_answer_check(answer, loop=loop))
+
+    assert status == UserQuestionAnswerStatus.ANSWERED
+    assert observed_loops == [loop]
+
+
 async def test_run_answer_check_rejects_existing_loop() -> None:
     async def answer() -> UserQuestionAnswerStatus:
         return UserQuestionAnswerStatus.INVALID_REPLY
 
     with pytest.raises(RuntimeError, match="active event loop"):
         _run_answer_check(answer)
+
+
+async def test_run_answer_check_rejects_bound_loop_reentry() -> None:
+    async def answer() -> UserQuestionAnswerStatus:
+        return UserQuestionAnswerStatus.INVALID_REPLY
+
+    with pytest.raises(RuntimeError, match="service loop"):
+        _run_answer_check(answer, loop=asyncio.get_running_loop())
 
 
 async def test_run_answer_check_raises_worker_errors() -> None:

--- a/tests/unit_tests/feishu/test_message_pool_service.py
+++ b/tests/unit_tests/feishu/test_message_pool_service.py
@@ -22,6 +22,7 @@ from relay_teams.gateway.feishu.message_pool_service import (
     _user_question_events_async,
 )
 from relay_teams.gateway.feishu.models import (
+    FEISHU_PLATFORM,
     FeishuEnvironment,
     FeishuMessageDeliveryStatus,
     FeishuMessageProcessingStatus,
@@ -529,6 +530,74 @@ async def test_message_pool_records_consumed_question_answers(
     assert record.processing_status == FeishuMessageProcessingStatus.COMPLETED
     assert record.final_reply_status == FeishuMessageDeliveryStatus.SKIPPED
     assert record.command_name == "answered_user_question"
+
+
+async def test_message_pool_does_not_consume_older_queued_message_as_answer(
+    tmp_path: Path,
+) -> None:
+    service, repo, _client, _runtime_repo, _event_log, run_service = _build_service(
+        tmp_path
+    )
+    runtime = _build_runtime()
+    old_message_time = datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc)
+    question_time = old_message_time + timedelta(seconds=5)
+    session = service._inbound_runtime._session_service.create_session(
+        workspace_id="default"
+    )
+    service._inbound_runtime._external_session_binding_repo.upsert_binding(
+        platform=FEISHU_PLATFORM,
+        trigger_id=runtime.trigger_id,
+        tenant_key="tenant-1",
+        external_chat_id="oc_group_1",
+        session_id=session.session_id,
+    )
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-1",
+            "session_id": session.session_id,
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [{"question": "Proceed?", "options": [{"label": "Ship"}]}],
+            "status": "requested",
+            "answers": [],
+            "created_at": question_time.isoformat(),
+            "updated_at": question_time.isoformat(),
+            "resolved_at": None,
+        }
+    ]
+    queued = service.enqueue_message(
+        runtime_config=runtime,
+        normalized=_build_message(
+            event_id="evt-old",
+            message_id="om_old",
+            text="Ship",
+        ),
+        raw_body="{}",
+        headers={},
+        remote_addr=None,
+    )
+    assert queued.status == "accepted"
+    record = repo.get_by_message_key(
+        trigger_id=runtime.trigger_id,
+        tenant_key="tenant-1",
+        message_key="om_old",
+    )
+    record = repo.update(
+        record.message_pool_id,
+        created_at=old_message_time,
+        updated_at=old_message_time,
+    )
+
+    assert await service._process_queued_messages() is True
+
+    updated = repo.get(record.message_pool_id)
+    assert updated is not None
+    assert updated.processing_status == FeishuMessageProcessingStatus.WAITING_RESULT
+    assert updated.final_reply_text is None
+    assert len(run_service.created) == 1
 
 
 async def test_enqueue_message_uses_queue_aware_ack(tmp_path: Path) -> None:

--- a/tests/unit_tests/feishu/test_message_pool_service.py
+++ b/tests/unit_tests/feishu/test_message_pool_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from pydantic import JsonValue
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -16,6 +17,9 @@ from relay_teams.gateway.feishu.message_pool_service import (
     FeishuMessagePoolService,
     _build_pause_reply,
     _build_queue_reply_text,
+    _run_answer_check,
+    _user_question_events,
+    _user_question_events_async,
 )
 from relay_teams.gateway.feishu.models import (
     FeishuEnvironment,
@@ -26,6 +30,7 @@ from relay_teams.gateway.feishu.models import (
     FeishuTriggerSourceConfig,
     FeishuTriggerTargetConfig,
 )
+from relay_teams.gateway.user_questions import UserQuestionAnswerStatus
 from relay_teams.media import content_parts_from_text
 from relay_teams.providers.token_usage_repo import SessionTokenUsage
 from relay_teams.sessions.external_session_binding_repository import (
@@ -34,6 +39,9 @@ from relay_teams.sessions.external_session_binding_repository import (
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.run_models import IntentInput, RunEvent, RunResult
+from relay_teams.sessions.runs.user_question_models import (
+    UserQuestionAnswerSubmission,
+)
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
     RunRuntimeRepository,
@@ -82,6 +90,11 @@ class _FakeSessionService:
             raise KeyError(session_id)
         return self.sessions[session_id]
 
+    async def get_session_async(self, session_id: str) -> SessionRecord:
+        if session_id not in self.sessions:
+            raise KeyError(session_id)
+        return self.sessions[session_id]
+
     def sync_session_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
         record = self.get_session(session_id)
         self.sessions[session_id] = record.model_copy(update={"metadata": metadata})
@@ -114,6 +127,7 @@ class _FakeRunService:
         self.started: list[str] = []
         self.stopped: list[str] = []
         self.fail_start_error: RuntimeError | None = None
+        self.user_questions: list[dict[str, JsonValue]] = []
 
     def create_run(self, intent: IntentInput) -> tuple[str, str]:
         return self.create_detached_run(intent)
@@ -136,6 +150,33 @@ class _FakeRunService:
     def stop_run(self, run_id: str) -> None:
         self.stopped.append(run_id)
 
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        _ = run_id
+        return self.user_questions
+
+    async def list_user_questions_by_session_async(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        return [
+            record
+            for record in self.user_questions
+            if record.get("session_id") == session_id
+        ]
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        _ = answers
+        return {"run_id": run_id, "question_id": question_id}
+
 
 class _FakeRuntimeConfigLookup:
     def __init__(self, runtime_config: FeishuTriggerRuntimeConfig) -> None:
@@ -156,6 +197,7 @@ class _FakeFeishuClient:
         self.reply_messages: list[tuple[str, str]] = []
         self.reactions: list[tuple[str, str]] = []
         self.user_names: dict[str, str] = {}
+        self.fail_reply_text = False
 
     async def send_text_message(
         self,
@@ -176,6 +218,8 @@ class _FakeFeishuClient:
         environment: FeishuEnvironment | None = None,
     ) -> str:
         _ = environment
+        if self.fail_reply_text:
+            raise RuntimeError("reply failed")
         self.reply_messages.append((message_id, text))
         return f"om_reply_{len(self.reply_messages)}"
 
@@ -277,6 +321,214 @@ def _build_service(
         automation_queue_repo=AutomationBoundSessionQueueRepository(db_path),
     )
     return service, repo, feishu_client, run_runtime_repo, event_log, run_service
+
+
+async def test_run_answer_check_runs_without_existing_loop() -> None:
+    async def answer() -> UserQuestionAnswerStatus:
+        return UserQuestionAnswerStatus.ANSWERED
+
+    status = await asyncio.to_thread(_run_answer_check, answer)
+
+    assert status == UserQuestionAnswerStatus.ANSWERED
+
+
+async def test_run_answer_check_rejects_existing_loop() -> None:
+    async def answer() -> UserQuestionAnswerStatus:
+        return UserQuestionAnswerStatus.INVALID_REPLY
+
+    with pytest.raises(RuntimeError, match="active event loop"):
+        _run_answer_check(answer)
+
+
+async def test_run_answer_check_raises_worker_errors() -> None:
+    async def answer() -> UserQuestionAnswerStatus:
+        raise ValueError("bad answer")
+
+    with pytest.raises(ValueError, match="bad answer"):
+        await asyncio.to_thread(_run_answer_check, answer)
+
+
+async def test_user_question_event_helpers_filter_invalid_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_log = EventLog(tmp_path / "events.db")
+    rows: tuple[dict[str, JsonValue], ...] = (
+        {
+            "id": 1,
+            "event_type": RunEventType.RUN_COMPLETED.value,
+            "trace_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "payload_json": "{}",
+            "occurred_at": "2026-05-12T00:00:00+00:00",
+        },
+        {
+            "id": "bad-id",
+            "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+            "trace_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "payload_json": "{}",
+            "occurred_at": "2026-05-12T00:00:00+00:00",
+        },
+        {
+            "id": 2,
+            "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+            "trace_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "payload_json": "{}",
+            "occurred_at": "2026-05-12T00:00:00+00:00",
+        },
+        {
+            "id": 3,
+            "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+            "trace_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "payload_json": (
+                '{"question_id":"question-1","questions":[{"question":"Pick",'
+                '"options":[{"label":"Ship"}]}]}'
+            ),
+            "occurred_at": "2026-05-12T00:00:00+00:00",
+        },
+    )
+
+    def list_sync(_run_id: str) -> tuple[dict[str, JsonValue], ...]:
+        return rows
+
+    async def list_async(_run_id: str) -> tuple[dict[str, JsonValue], ...]:
+        return rows
+
+    monkeypatch.setattr(event_log, "list_by_trace_with_ids", list_sync)
+    monkeypatch.setattr(event_log, "list_by_trace_with_ids_async", list_async)
+
+    assert _user_question_events(run_id="run-1", event_log=event_log)[0][1] == (
+        "question-1"
+    )
+    async_events = await _user_question_events_async(
+        run_id="run-1",
+        event_log=event_log,
+    )
+    assert async_events[0][1] == "question-1"
+
+    def raise_sync(_run_id: str) -> tuple[dict[str, JsonValue], ...]:
+        raise ValueError("bad rows")
+
+    async def raise_async(_run_id: str) -> tuple[dict[str, JsonValue], ...]:
+        raise ValueError("bad rows")
+
+    monkeypatch.setattr(event_log, "list_by_trace_with_ids", raise_sync)
+    monkeypatch.setattr(event_log, "list_by_trace_with_ids_async", raise_async)
+
+    assert _user_question_events(run_id="run-1", event_log=event_log) == ()
+    assert await _user_question_events_async(run_id="run-1", event_log=event_log) == ()
+
+
+async def test_message_pool_answer_pending_user_question_maps_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _repo, _client, _runtime_repo, _event_log, _run_service = _build_service(
+        tmp_path
+    )
+
+    async def answer(
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        message: FeishuNormalizedMessage,
+    ) -> UserQuestionAnswerStatus:
+        _ = (runtime_config, message)
+        return UserQuestionAnswerStatus.ANSWERED
+
+    monkeypatch.setattr(
+        service._inbound_runtime,
+        "answer_pending_user_question_async",
+        answer,
+    )
+
+    status = await asyncio.to_thread(
+        service.answer_pending_user_question,
+        runtime_config=_build_runtime(),
+        normalized=_build_message(
+            event_id="evt-answer",
+            message_id="om_answer",
+            text="Ship",
+        ),
+    )
+
+    assert status == UserQuestionAnswerStatus.ANSWERED
+
+
+async def test_message_pool_answer_pending_user_question_handles_runtime_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _repo, _client, _runtime_repo, _event_log, _run_service = _build_service(
+        tmp_path
+    )
+
+    async def answer(
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        message: FeishuNormalizedMessage,
+    ) -> UserQuestionAnswerStatus:
+        _ = (runtime_config, message)
+        raise ValueError("bad answer")
+
+    monkeypatch.setattr(
+        service._inbound_runtime,
+        "answer_pending_user_question_async",
+        answer,
+    )
+
+    status = await asyncio.to_thread(
+        service.answer_pending_user_question,
+        runtime_config=_build_runtime(),
+        normalized=_build_message(
+            event_id="evt-answer",
+            message_id="om_answer",
+            text="Ship",
+        ),
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+
+
+async def test_message_pool_records_consumed_question_answers(
+    tmp_path: Path,
+) -> None:
+    service, repo, _client, _runtime_repo, _event_log, _run_service = _build_service(
+        tmp_path
+    )
+    runtime = _build_runtime()
+    message = _build_message(event_id="evt-answer", message_id="om_answer", text="Ship")
+
+    assert (
+        service.has_message_record(runtime_config=runtime, normalized=message) is False
+    )
+    service.record_consumed_user_question_answer(
+        runtime_config=runtime,
+        normalized=message,
+        reason="answered_user_question",
+    )
+
+    assert (
+        service.has_message_record(runtime_config=runtime, normalized=message) is True
+    )
+    record = repo.get_by_message_key(
+        trigger_id=runtime.trigger_id,
+        tenant_key=message.tenant_key,
+        message_key="om_answer",
+    )
+    assert record.processing_status == FeishuMessageProcessingStatus.COMPLETED
+    assert record.final_reply_status == FeishuMessageDeliveryStatus.SKIPPED
+    assert record.command_name == "answered_user_question"
 
 
 async def test_enqueue_message_uses_queue_aware_ack(tmp_path: Path) -> None:
@@ -802,6 +1054,207 @@ async def test_stalled_waiting_result_is_requeued(tmp_path: Path) -> None:
     )
     assert record.processing_status == FeishuMessageProcessingStatus.RETRYABLE_FAILED
     assert record.last_error == "no running event loop"
+
+
+async def test_user_question_notice_skips_answered_question(tmp_path: Path) -> None:
+    service, repo, feishu_client, _run_runtime_repo, event_log, run_service = (
+        _build_service(tmp_path)
+    )
+    runtime = _build_runtime()
+    _ = service.enqueue_message(
+        runtime_config=runtime,
+        normalized=_build_message(event_id="evt-1", message_id="om_1", text="hello"),
+        raw_body="{}",
+        headers={},
+        remote_addr=None,
+    )
+    assert await service._process_queued_messages() is True
+    record = repo.get_by_message_key(
+        trigger_id="trg_feishu",
+        tenant_key="tenant-1",
+        message_key="om_1",
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            event_type=RunEventType.USER_QUESTION_REQUESTED,
+            payload_json=(
+                '{"question_id":"question-1","questions":[{"question":"Pick one",'
+                '"options":[{"label":"Ship"}]}]}'
+            ),
+        )
+    )
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [{"question": "Pick one", "options": [{"label": "Ship"}]}],
+            "status": "answered",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": "2026-05-12T00:00:01+00:00",
+        }
+    ]
+
+    assert await service._notify_user_question_request(record) is False
+    assert feishu_client.reply_messages == []
+
+
+async def test_user_question_notice_scans_past_answered_latest_question(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, repo, feishu_client, _run_runtime_repo, event_log, run_service = (
+        _build_service(tmp_path)
+    )
+    runtime = _build_runtime()
+    _ = service.enqueue_message(
+        runtime_config=runtime,
+        normalized=_build_message(event_id="evt-1", message_id="om_1", text="hello"),
+        raw_body="{}",
+        headers={},
+        remote_addr=None,
+    )
+    assert await service._process_queued_messages() is True
+    record = repo.get_by_message_key(
+        trigger_id="trg_feishu",
+        tenant_key="tenant-1",
+        message_key="om_1",
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            event_type=RunEventType.USER_QUESTION_REQUESTED,
+            payload_json=(
+                '{"question_id":"question-old","questions":[{"question":"Old one",'
+                '"options":[{"label":"Ship"}]}]}'
+            ),
+        )
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            event_type=RunEventType.USER_QUESTION_REQUESTED,
+            payload_json=(
+                '{"question_id":"question-new","questions":[{"question":"New one",'
+                '"options":[{"label":"Wait"}]}]}'
+            ),
+        )
+    )
+    run_service.user_questions = [
+        {
+            "question_id": "question-old",
+            "run_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [{"question": "Old one", "options": [{"label": "Ship"}]}],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        },
+        {
+            "question_id": "question-new",
+            "run_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-2",
+            "instance_id": "instance-2",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [{"question": "New one", "options": [{"label": "Wait"}]}],
+            "status": "answered",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:01+00:00",
+            "updated_at": "2026-05-12T00:00:02+00:00",
+            "resolved_at": "2026-05-12T00:00:02+00:00",
+        },
+    ]
+
+    def fail_sync_event_read(_run_id: str) -> tuple[dict[str, JsonValue], ...]:
+        raise AssertionError("sync event log reads should not be used")
+
+    monkeypatch.setattr(event_log, "list_by_trace_with_ids", fail_sync_event_read)
+
+    assert await service._notify_user_question_request(record) is True
+    assert feishu_client.reply_messages
+    assert "question-old" in feishu_client.reply_messages[-1][1]
+    assert "question-new" not in feishu_client.reply_messages[-1][1]
+    assert await service._notify_user_question_request(record) is False
+
+
+async def test_user_question_notice_returns_false_when_send_fails(
+    tmp_path: Path,
+) -> None:
+    service, repo, feishu_client, _run_runtime_repo, event_log, run_service = (
+        _build_service(tmp_path)
+    )
+    runtime = _build_runtime()
+    _ = service.enqueue_message(
+        runtime_config=runtime,
+        normalized=_build_message(event_id="evt-1", message_id="om_1", text="hello"),
+        raw_body="{}",
+        headers={},
+        remote_addr=None,
+    )
+    assert await service._process_queued_messages() is True
+    record = repo.get_by_message_key(
+        trigger_id="trg_feishu",
+        tenant_key="tenant-1",
+        message_key="om_1",
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            event_type=RunEventType.USER_QUESTION_REQUESTED,
+            payload_json=(
+                '{"question_id":"question-1","questions":[{"question":"Pick one",'
+                '"options":[{"label":"Ship"}]}]}'
+            ),
+        )
+    )
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [{"question": "Pick one", "options": [{"label": "Ship"}]}],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        }
+    ]
+    feishu_client.fail_reply_text = True
+
+    assert await service._notify_user_question_request(record) is False
+    assert feishu_client.reply_messages == []
 
 
 async def test_waiting_message_without_runtime_is_retried(tmp_path: Path) -> None:

--- a/tests/unit_tests/feishu/test_subscription_service.py
+++ b/tests/unit_tests/feishu/test_subscription_service.py
@@ -27,6 +27,7 @@ from relay_teams.gateway.feishu.models import (
 )
 from relay_teams.gateway.feishu.subscription_service import (
     FeishuSubscriptionService,
+    P2ImMessageReceiveV1,
     WsClientLike,
     _FeishuWsController,
     _FeishuWsHub,
@@ -90,6 +91,27 @@ class _FakeHandler:
             trigger_id="trg_test",
             ignored=True,
             reason="test",
+        )
+
+
+class _RecordingHandler:
+    def __init__(self) -> None:
+        self.raw_bodies: list[str] = []
+
+    def handle_sdk_event(
+        self,
+        *,
+        trigger_id: str,
+        event: P2ImMessageReceiveV1,
+        raw_body: str,
+        headers: dict[str, str],
+        remote_addr: str | None,
+    ) -> TriggerProcessingResult:
+        _ = (trigger_id, event, headers, remote_addr)
+        self.raw_bodies.append(raw_body)
+        return TriggerProcessingResult(
+            status="processed",
+            trigger_id="trg_test",
         )
 
 
@@ -505,6 +527,34 @@ def test_feishu_ws_controller_http_client_uses_runtime_net_proxy_loader(
         assert controller._create_feishu_http_client() is fake_http_client
     finally:
         asyncio.run(fake_http_client.aclose())
+
+
+@pytest.mark.asyncio
+async def test_feishu_ws_controller_processes_sdk_events_in_receive_order() -> None:
+    handler = _RecordingHandler()
+    controller = _FeishuWsController(
+        runtime_config=_build_runtime(
+            trigger_id="trg_a",
+            name="bot_a",
+            app_id="cli_demo",
+            app_name="bot-a",
+            app_secret="secret-demo",
+        ),
+        event_handler=handler,
+    )
+
+    controller._enqueue_sdk_event(
+        event=cast(P2ImMessageReceiveV1, object()),
+        raw_body="first",
+    )
+    controller._enqueue_sdk_event(
+        event=cast(P2ImMessageReceiveV1, object()),
+        raw_body="second",
+    )
+    await controller._handler_queue.join()
+    await controller._stop_handler_worker()
+
+    assert handler.raw_bodies == ["first", "second"]
 
 
 def test_import_lark_ws_client_module_suppresses_known_deprecations(

--- a/tests/unit_tests/feishu/test_trigger_handler.py
+++ b/tests/unit_tests/feishu/test_trigger_handler.py
@@ -27,6 +27,7 @@ from relay_teams.gateway.feishu.trigger_handler import FeishuTriggerHandler
 from relay_teams.gateway.gateway_session_service import GatewaySessionService
 from relay_teams.gateway.im.command_service import ImSessionCommandService
 from relay_teams.gateway.im.service import ImToolService
+from relay_teams.gateway.user_questions import UserQuestionAnswerStatus
 from relay_teams.providers.token_usage_repo import SessionTokenUsage
 from relay_teams.sessions.external_session_binding_repository import (
     ExternalSessionBindingRepository,
@@ -233,6 +234,10 @@ class _FakeImToolService:
 class _FakeMessagePoolService:
     def __init__(self) -> None:
         self.enqueued: list[FeishuNormalizedMessage] = []
+        self.answered: list[FeishuNormalizedMessage] = []
+        self.consumed_answers: list[tuple[FeishuNormalizedMessage, str]] = []
+        self.known_messages: set[str] = set()
+        self.answer_result = UserQuestionAnswerStatus.NOT_PENDING
         self.chat_summary = FeishuChatQueueSummary(
             trigger_id="trg_feishu",
             tenant_key="tenant-1",
@@ -264,6 +269,36 @@ class _FakeMessagePoolService:
             trigger_name="feishu_main",
             event_id=normalized.event_id,
         )
+
+    def answer_pending_user_question(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+    ) -> UserQuestionAnswerStatus:
+        _ = runtime_config
+        self.answered.append(normalized)
+        return self.answer_result
+
+    def has_message_record(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+    ) -> bool:
+        _ = runtime_config
+        return normalized.message_id in self.known_messages
+
+    def record_consumed_user_question_answer(
+        self,
+        *,
+        runtime_config: FeishuTriggerRuntimeConfig,
+        normalized: FeishuNormalizedMessage,
+        reason: str,
+    ) -> None:
+        _ = runtime_config
+        self.known_messages.add(normalized.message_id)
+        self.consumed_answers.append((normalized, reason))
 
     def get_chat_summary(
         self,
@@ -465,6 +500,103 @@ def test_group_command_requires_mention_under_mention_only(tmp_path: Path) -> No
 
     assert result.status == "ignored"
     assert result.reason == "mention_required"
+    assert message_pool_service.enqueued == []
+    assert feishu_client.sent_messages == []
+    assert feishu_client.reply_messages == []
+
+
+def test_pending_question_answer_bypasses_group_mention_requirement(
+    tmp_path: Path,
+) -> None:
+    handler, _session_service, message_pool_service, _bindings, feishu_client = (
+        _build_handler(tmp_path=tmp_path)
+    )
+    message_pool_service.answer_result = UserQuestionAnswerStatus.ANSWERED
+    raw_body = _build_event(
+        message_id="om_answer_group",
+        chat_id="oc_group_answer",
+        event_id="evt-answer-group",
+        text="Ship",
+        chat_type="group",
+    )
+
+    result = handler.handle_sdk_event(
+        trigger_id="trg_feishu",
+        event=_build_sdk_event(raw_body),
+        raw_body=raw_body,
+        headers={},
+        remote_addr=None,
+    )
+
+    assert result.status == "answered"
+    assert result.reason == "user_question_answer"
+    assert message_pool_service.enqueued == []
+    assert len(message_pool_service.answered) == 1
+    assert message_pool_service.consumed_answers[0][1] == "user_question_answer"
+    assert message_pool_service.answered[0].trigger_text == "Ship"
+    assert feishu_client.sent_messages == []
+    assert len(feishu_client.reply_messages) == 1
+    assert feishu_client.reply_messages[0][0] == "om_answer_group"
+    assert "已收到回答" in feishu_client.reply_messages[0][1]
+
+
+def test_pending_question_answer_bypasses_command_handling(tmp_path: Path) -> None:
+    handler, _session_service, message_pool_service, _bindings, feishu_client = (
+        _build_handler(tmp_path=tmp_path)
+    )
+    message_pool_service.answer_result = UserQuestionAnswerStatus.ANSWERED
+    raw_body = _build_event(
+        message_id="om_answer_help",
+        chat_id="oc_cmd",
+        event_id="evt-answer-help",
+        text="help",
+    )
+
+    result = handler.handle_sdk_event(
+        trigger_id="trg_feishu",
+        event=_build_sdk_event(raw_body),
+        raw_body=raw_body,
+        headers={},
+        remote_addr=None,
+    )
+
+    assert result.status == "answered"
+    assert message_pool_service.enqueued == []
+    assert len(message_pool_service.answered) == 1
+    assert len(feishu_client.sent_messages) == 1
+    assert "help" not in feishu_client.sent_messages[0][1]
+    assert "已收到回答" in feishu_client.sent_messages[0][1]
+
+
+def test_duplicate_answer_event_is_consumed_before_command_handling(
+    tmp_path: Path,
+) -> None:
+    handler, _session_service, message_pool_service, _bindings, feishu_client = (
+        _build_handler(
+            tmp_path=tmp_path,
+            runtime_config=_build_runtime(trigger_rule="all_messages"),
+        )
+    )
+    message_pool_service.known_messages.add("om_answer_help")
+    message_pool_service.answer_result = UserQuestionAnswerStatus.ANSWERED
+    raw_body = _build_event(
+        message_id="om_answer_help",
+        chat_id="oc_cmd",
+        event_id="evt-answer-help-redelivery",
+        text="help",
+        chat_type="p2p",
+    )
+
+    result = handler.handle_sdk_event(
+        trigger_id="trg_feishu",
+        event=_build_sdk_event(raw_body),
+        raw_body=raw_body,
+        headers={},
+        remote_addr=None,
+    )
+
+    assert result.duplicate is True
+    assert message_pool_service.answered == []
     assert message_pool_service.enqueued == []
     assert feishu_client.sent_messages == []
     assert feishu_client.reply_messages == []

--- a/tests/unit_tests/gateway/im/__init__.py
+++ b/tests/unit_tests/gateway/im/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/gateway/im/test_user_questions.py
+++ b/tests/unit_tests/gateway/im/test_user_questions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 from pydantic import JsonValue
+from datetime import datetime, timezone
 
 from relay_teams.gateway.user_questions import (
     UserQuestionAnswerStatus,
@@ -210,6 +211,7 @@ def _question_record(
     question_id: str = "question-1",
     run_id: str = "run-1",
     status: str = "requested",
+    created_at: str = "2026-05-12T00:00:00+00:00",
 ) -> dict[str, JsonValue]:
     return {
         "question_id": question_id,
@@ -227,8 +229,8 @@ def _question_record(
         ],
         "status": status,
         "answers": [],
-        "created_at": "2026-05-12T00:00:00+00:00",
-        "updated_at": "2026-05-12T00:00:00+00:00",
+        "created_at": created_at,
+        "updated_at": created_at,
         "resolved_at": None,
     }
 
@@ -374,6 +376,26 @@ async def test_answer_pending_user_question_for_session_status_async_returns_run
     assert status == UserQuestionAnswerStatus.ANSWERED
     assert run_id == "run-1"
     assert service.answered == [("run-1", "question-1")]
+
+
+@pytest.mark.asyncio
+async def test_answer_pending_user_question_ignores_questions_newer_than_message() -> (
+    None
+):
+    service = _FakeAsyncRunService(
+        [_question_record(created_at="2026-05-12T00:00:05+00:00")]
+    )
+
+    status, run_id = await answer_pending_user_question_for_session_status_async(
+        run_service=service,
+        session_id="session-1",
+        text="Yes",
+        message_created_at=datetime(2026, 5, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+    assert run_id is None
+    assert service.answered == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/gateway/im/test_user_questions.py
+++ b/tests/unit_tests/gateway/im/test_user_questions.py
@@ -1,0 +1,555 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+from pydantic import JsonValue
+
+from relay_teams.gateway.user_questions import (
+    UserQuestionAnswerStatus,
+    answer_pending_user_question,
+    answer_pending_user_question_async,
+    answer_pending_user_question_for_session_status_async,
+    answer_pending_user_question_status,
+    answer_pending_user_question_status_async,
+    build_answer_submission,
+    format_user_question_event,
+    format_user_question_request,
+    is_user_question_requested,
+    is_user_question_requested_async,
+    parse_user_question_event,
+)
+from relay_teams.sessions.runs.user_question_models import (
+    NONE_OF_THE_ABOVE_OPTION_LABEL,
+    UserQuestionAnswerSubmission,
+    UserQuestionPrompt,
+)
+
+
+def test_format_user_question_request_lists_options() -> None:
+    text = format_user_question_request(
+        question_id="question-1",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {
+                    "header": "Version",
+                    "question": "Pick the release target",
+                    "options": [
+                        {"label": "1.0", "description": "Stable"},
+                        {"label": "2.0"},
+                    ],
+                }
+            ),
+        ),
+    )
+
+    assert "question-1" in text
+    assert "Pick the release target" in text
+    assert "- 1.0: Stable" in text
+    assert "- 2.0" in text
+
+
+def test_format_user_question_request_notes_multi_question_order() -> None:
+    text = format_user_question_request(
+        question_id="question-1",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {"question": "Pick version", "options": [{"label": "1.0"}]}
+            ),
+            UserQuestionPrompt.model_validate(
+                {"question": "Pick action", "options": [{"label": "Ship"}]}
+            ),
+        ),
+    )
+
+    assert "1. Pick version" in text
+    assert "2. Pick action" in text
+
+
+def test_build_answer_submission_uses_matching_option() -> None:
+    submission = build_answer_submission(
+        text="Ship",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick one",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ),
+        ),
+    )
+
+    assert submission.answers[0].selections[0].label == "Ship"
+    assert submission.answers[0].selections[0].supplement is None
+
+
+def test_build_answer_submission_uses_supplement_for_free_text() -> None:
+    submission = build_answer_submission(
+        text="Use the beta channel",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick one",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ),
+        ),
+    )
+
+    selection = submission.answers[0].selections[0]
+    assert selection.label == NONE_OF_THE_ABOVE_OPTION_LABEL
+    assert selection.supplement == "Use the beta channel"
+
+
+def test_build_answer_submission_splits_multiple_selection() -> None:
+    submission = build_answer_submission(
+        text="Docs, Tests",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick items",
+                    "multiple": True,
+                    "options": [
+                        {"label": "Docs"},
+                        {"label": "Tests"},
+                        {"label": "Deploy"},
+                    ],
+                }
+            ),
+        ),
+    )
+
+    assert tuple(item.label for item in submission.answers[0].selections) == (
+        "Docs",
+        "Tests",
+    )
+
+
+def test_build_answer_submission_preserves_unknown_multiple_selection() -> None:
+    submission = build_answer_submission(
+        text="Docs, Deployy",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick items",
+                    "multiple": True,
+                    "options": [
+                        {"label": "Docs"},
+                        {"label": "Tests"},
+                        {"label": "Deploy"},
+                    ],
+                }
+            ),
+        ),
+    )
+
+    selection = submission.answers[0].selections[0]
+    assert selection.label == NONE_OF_THE_ABOVE_OPTION_LABEL
+    assert selection.supplement == "Docs, Deployy"
+
+
+class _FakeRunService:
+    def __init__(self, records: list[dict[str, JsonValue]]) -> None:
+        self.records = records
+        self.answered: list[tuple[str, str]] = []
+
+    def list_user_questions(self, run_id: str) -> list[dict[str, JsonValue]]:
+        _ = run_id
+        return self.records
+
+    def list_user_questions_by_session(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        _ = session_id
+        return self.records
+
+    def answer_user_question(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: object,
+    ) -> dict[str, JsonValue]:
+        _ = answers
+        self.answered.append((run_id, question_id))
+        return {"run_id": run_id, "question_id": question_id}
+
+
+class _FakeAsyncRunService:
+    def __init__(self, records: list[dict[str, JsonValue]]) -> None:
+        self.records = records
+        self.answered: list[tuple[str, str]] = []
+
+    async def list_user_questions_async(
+        self, run_id: str
+    ) -> list[dict[str, JsonValue]]:
+        _ = run_id
+        return self.records
+
+    async def list_user_questions_by_session_async(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        _ = session_id
+        return self.records
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        _ = answers
+        self.answered.append((run_id, question_id))
+        return {"run_id": run_id, "question_id": question_id}
+
+
+def _question_record(
+    *,
+    question_id: str = "question-1",
+    run_id: str = "run-1",
+    status: str = "requested",
+) -> dict[str, JsonValue]:
+    return {
+        "question_id": question_id,
+        "run_id": run_id,
+        "session_id": "session-1",
+        "task_id": "task-1",
+        "instance_id": "instance-1",
+        "role_id": "role-1",
+        "tool_name": "ask_question",
+        "questions": [
+            {
+                "question": "Proceed?",
+                "options": [{"label": "Yes"}, {"label": "No"}],
+            }
+        ],
+        "status": status,
+        "answers": [],
+        "created_at": "2026-05-12T00:00:00+00:00",
+        "updated_at": "2026-05-12T00:00:00+00:00",
+        "resolved_at": None,
+    }
+
+
+def test_parse_user_question_event_rejects_invalid_payloads() -> None:
+    assert parse_user_question_event("{") is None
+    assert parse_user_question_event("[]") is None
+    assert parse_user_question_event('{"question_id": "", "questions": []}') is None
+    assert (
+        parse_user_question_event('{"question_id": "question-1", "questions": {}}')
+        is None
+    )
+    assert (
+        parse_user_question_event(
+            '{"question_id": "question-1", "questions": [{"options": []}]}'
+        )
+        is None
+    )
+
+
+def test_format_user_question_event_formats_valid_payload() -> None:
+    text = format_user_question_event(
+        """
+        {
+            "question_id": "question-1",
+            "ignored": "value",
+            "questions": [{"question": "Proceed?", "options": [{"label": "Yes"}]}]
+        }
+        """
+    )
+
+    assert text is not None
+    assert "question-1" in text
+    assert "Proceed?" in text
+
+
+def test_answer_pending_user_question_bool_wrapper() -> None:
+    service = _FakeRunService([_question_record()])
+
+    assert (
+        answer_pending_user_question(
+            run_service=service,
+            run_id="run-1",
+            text="Yes",
+        )
+        is True
+    )
+
+
+def test_answer_pending_user_question_returns_not_pending_for_bad_records() -> None:
+    service = _FakeRunService([{"question_id": "bad"}])
+
+    status = answer_pending_user_question_status(
+        run_service=service,
+        run_id="run-1",
+        text="Yes",
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+    assert service.answered == []
+
+
+def test_is_user_question_requested_filters_empty_and_bad_records() -> None:
+    service = _FakeRunService([{"question_id": "bad"}, _question_record()])
+
+    assert (
+        is_user_question_requested(
+            run_service=service,
+            run_id="run-1",
+            question_id=" ",
+        )
+        is False
+    )
+    assert (
+        is_user_question_requested(
+            run_service=service,
+            run_id="run-1",
+            question_id=" question-1 ",
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_answer_pending_user_question_async_bool_wrapper() -> None:
+    service = _FakeAsyncRunService([_question_record()])
+
+    assert (
+        await answer_pending_user_question_async(
+            run_service=service,
+            run_id="run-1",
+            text="Yes",
+        )
+        is True
+    )
+    assert service.answered == [("run-1", "question-1")]
+
+
+@pytest.mark.asyncio
+async def test_answer_pending_user_question_status_async_invalid_reply() -> None:
+    service = _FakeAsyncRunService(
+        [
+            _question_record(),
+            {
+                **_question_record(question_id="question-2"),
+                "questions": [
+                    {
+                        "question": "Proceed?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                    {
+                        "question": "Notify?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                ],
+                "created_at": "2026-05-12T00:01:00+00:00",
+            },
+        ]
+    )
+
+    status = await answer_pending_user_question_status_async(
+        run_service=service,
+        run_id="run-1",
+        text="Yes",
+    )
+
+    assert status == UserQuestionAnswerStatus.INVALID_REPLY
+    assert service.answered == []
+
+
+@pytest.mark.asyncio
+async def test_answer_pending_user_question_for_session_status_async_returns_run() -> (
+    None
+):
+    service = _FakeAsyncRunService([_question_record()])
+
+    status, run_id = await answer_pending_user_question_for_session_status_async(
+        run_service=service,
+        session_id="session-1",
+        text="Yes",
+    )
+
+    assert status == UserQuestionAnswerStatus.ANSWERED
+    assert run_id == "run-1"
+    assert service.answered == [("run-1", "question-1")]
+
+
+@pytest.mark.asyncio
+async def test_is_user_question_requested_async_ignores_non_requested() -> None:
+    service = _FakeAsyncRunService(
+        [_question_record(question_id="question-1", status="answered")]
+    )
+
+    assert (
+        await is_user_question_requested_async(
+            run_service=service,
+            run_id="run-1",
+            question_id="question-1",
+        )
+        is False
+    )
+
+
+def test_build_answer_submission_rejects_partial_multi_question_reply() -> None:
+    with pytest.raises(ValueError, match="one non-empty line"):
+        build_answer_submission(
+            text="Yes",
+            questions=(
+                UserQuestionPrompt.model_validate(
+                    {
+                        "question": "Proceed?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    }
+                ),
+                UserQuestionPrompt.model_validate(
+                    {
+                        "question": "Notify users?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    }
+                ),
+            ),
+        )
+
+
+def test_answer_pending_user_question_marks_partial_reply_invalid() -> None:
+    service = _FakeRunService(
+        [
+            {
+                "question_id": "question-1",
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "task_id": "task-1",
+                "instance_id": "instance-1",
+                "role_id": "role-1",
+                "tool_name": "ask_question",
+                "questions": [
+                    {
+                        "question": "Proceed?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                    {
+                        "question": "Notify users?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                ],
+                "status": "requested",
+                "answers": [],
+                "created_at": "2026-05-12T00:00:00+00:00",
+                "updated_at": "2026-05-12T00:00:00+00:00",
+                "resolved_at": None,
+            }
+        ]
+    )
+
+    status = answer_pending_user_question_status(
+        run_service=service,
+        run_id="run-1",
+        text="Yes",
+    )
+
+    assert status == UserQuestionAnswerStatus.INVALID_REPLY
+    assert service.answered == []
+
+
+def test_build_answer_submission_preserves_decimal_option_labels() -> None:
+    submission = build_answer_submission(
+        text="1.0\n2. Notify users",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick version",
+                    "options": [{"label": "1.0"}, {"label": "2.0"}],
+                }
+            ),
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick action",
+                    "options": [{"label": "Notify users"}, {"label": "Skip"}],
+                }
+            ),
+        ),
+    )
+
+    assert submission.answers[0].selections[0].label == "1.0"
+    assert submission.answers[1].selections[0].label == "Notify users"
+
+
+def test_build_answer_submission_preserves_numbered_option_label() -> None:
+    submission = build_answer_submission(
+        text="1. High\n2. Now",
+        questions=(
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick priority",
+                    "options": [{"label": "1. High"}, {"label": "2. Low"}],
+                }
+            ),
+            UserQuestionPrompt.model_validate(
+                {
+                    "question": "Pick timing",
+                    "options": [{"label": "Now"}, {"label": "Later"}],
+                }
+            ),
+        ),
+    )
+
+    assert submission.answers[0].selections[0].label == "1. High"
+    assert submission.answers[1].selections[0].label == "Now"
+
+
+def test_answer_pending_user_question_uses_latest_requested_question() -> None:
+    service = _FakeRunService(
+        [
+            {
+                "question_id": "question-old",
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "task_id": "task-1",
+                "instance_id": "instance-1",
+                "role_id": "role-1",
+                "tool_name": "ask_question",
+                "questions": [
+                    {
+                        "question": "Old question",
+                        "options": [{"label": "Old"}],
+                    }
+                ],
+                "status": "requested",
+                "answers": [],
+                "created_at": "2026-05-12T00:00:00+00:00",
+                "updated_at": "2026-05-12T00:00:00+00:00",
+                "resolved_at": None,
+            },
+            {
+                "question_id": "question-new",
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "task_id": "task-1",
+                "instance_id": "instance-1",
+                "role_id": "role-1",
+                "tool_name": "ask_question",
+                "questions": [
+                    {
+                        "question": "New question",
+                        "options": [{"label": "New"}],
+                    }
+                ],
+                "status": "requested",
+                "answers": [],
+                "created_at": "2026-05-12T00:01:00+00:00",
+                "updated_at": "2026-05-12T00:01:00+00:00",
+                "resolved_at": None,
+            },
+        ]
+    )
+
+    status = answer_pending_user_question_status(
+        run_service=service,
+        run_id="run-1",
+        text="New",
+    )
+
+    assert status == UserQuestionAnswerStatus.ANSWERED
+    assert service.answered == [("run-1", "question-new")]

--- a/tests/unit_tests/gateway/test_discord_gateway.py
+++ b/tests/unit_tests/gateway/test_discord_gateway.py
@@ -46,6 +46,7 @@ from relay_teams.gateway.im.command_service import (
     ImSessionCommandService,
     _FeishuQueueLookup,
 )
+from relay_teams.gateway.user_questions import UserQuestionAnswerStatus
 from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressRequest,
     GatewaySessionIngressResult,
@@ -54,6 +55,9 @@ from relay_teams.gateway.session_ingress_service import (
 )
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import IntentInput
+from relay_teams.sessions.runs.user_question_models import (
+    UserQuestionAnswerSubmission,
+)
 from relay_teams.sessions.external_session_binding_repository import (
     ExternalSessionBindingRepository,
 )
@@ -1336,6 +1340,375 @@ async def test_discord_service_watcher_and_future_edges(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_discord_watcher_sends_user_question_notice(tmp_path: Path) -> None:
+    fake_im_tool = _FakeImToolService()
+    run_service = _FakeRunService(
+        (
+            _FakeRunEvent(
+                event_type=RunEventType.USER_QUESTION_REQUESTED,
+                payload_json=json.dumps(
+                    {
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick a target",
+                                "options": [
+                                    {"label": "Ship"},
+                                    {"label": "Wait"},
+                                ],
+                            }
+                        ],
+                    }
+                ),
+            ),
+            _FakeRunEvent(
+                event_type=RunEventType.RUN_PAUSED,
+                payload_json=json.dumps({"error_message": "waiting for input"}),
+            ),
+            _FakeRunEvent(event_type=RunEventType.RUN_COMPLETED, payload_json="{}"),
+        )
+    )
+    run_service.user_questions = [_user_question_record(run_id="run-question")]
+    service = _build_service(
+        tmp_path,
+        run_service=run_service,
+        im_tool_service=fake_im_tool,
+    )
+
+    await service._await_terminal_and_reply(
+        account_id="bot-1",
+        gateway_session_id="gws-1",
+        run_id="run-question",
+        channel_id="channel-1",
+        reply_to_message_id="message-1",
+    )
+
+    assert "Pick a target" in fake_im_tool.sent_texts[0].text
+    assert fake_im_tool.sent_texts[1].text == "Completed."
+    assert len(fake_im_tool.sent_texts) == 2
+
+
+@pytest.mark.asyncio
+async def test_discord_watcher_uses_live_stream_after_question_pause_without_event_id(
+    tmp_path: Path,
+) -> None:
+    class NoEventIdRunService(_FakeRunService):
+        def __init__(self) -> None:
+            super().__init__(())
+            self.offsets: list[int] = []
+
+        def stream_run_events(
+            self,
+            run_id: str,
+            after_event_id: int = 0,
+        ) -> AsyncIterator[_FakeRunEvent]:
+            _ = run_id
+            self.offsets.append(after_event_id)
+            return self._events_for_offset(after_event_id)
+
+        async def _events_for_offset(
+            self,
+            after_event_id: int,
+        ) -> AsyncIterator[_FakeRunEvent]:
+            if after_event_id == 0:
+                yield _FakeRunEvent(
+                    event_type=RunEventType.USER_QUESTION_REQUESTED,
+                    payload_json=json.dumps(
+                        {
+                            "question_id": "question-1",
+                            "questions": [
+                                {
+                                    "question": "Pick one",
+                                    "options": [{"label": "Ship"}],
+                                }
+                            ],
+                        }
+                    ),
+                )
+                yield _FakeRunEvent(
+                    event_type=RunEventType.RUN_PAUSED,
+                    payload_json=json.dumps({"error_message": "waiting"}),
+                )
+                return
+            yield _FakeRunEvent(
+                event_type=RunEventType.RUN_COMPLETED,
+                payload_json="{}",
+            )
+
+    fake_im_tool = _FakeImToolService()
+    run_service = NoEventIdRunService()
+    run_service.user_questions = [_user_question_record(run_id="run-question")]
+    service = _build_service(
+        tmp_path,
+        run_service=run_service,
+        im_tool_service=fake_im_tool,
+    )
+
+    await service._await_terminal_and_reply(
+        account_id="bot-1",
+        gateway_session_id="gws-1",
+        run_id="run-question",
+        channel_id="channel-1",
+        reply_to_message_id="message-1",
+    )
+
+    assert run_service.offsets == [0, -1]
+    assert "Pick one" in fake_im_tool.sent_texts[0].text
+    assert fake_im_tool.sent_texts[1].text == "Completed."
+
+
+@pytest.mark.asyncio
+async def test_discord_watcher_sends_later_pause_after_user_question_pause(
+    tmp_path: Path,
+) -> None:
+    fake_im_tool = _FakeImToolService()
+    run_service = _FakeRunService(
+        (
+            _FakeRunEvent(
+                event_type=RunEventType.USER_QUESTION_REQUESTED,
+                payload_json=json.dumps(
+                    {
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick a target",
+                                "options": [
+                                    {"label": "Ship"},
+                                    {"label": "Wait"},
+                                ],
+                            }
+                        ],
+                    }
+                ),
+            ),
+            _FakeRunEvent(
+                event_type=RunEventType.RUN_PAUSED,
+                payload_json=json.dumps({"error_message": "waiting for input"}),
+            ),
+            _FakeRunEvent(
+                event_type=RunEventType.RUN_PAUSED,
+                payload_json=json.dumps({"error_message": "needs recovery"}),
+            ),
+            _FakeRunEvent(event_type=RunEventType.RUN_COMPLETED, payload_json="{}"),
+        )
+    )
+    run_service.user_questions = [_user_question_record(run_id="run-question")]
+    service = _build_service(
+        tmp_path,
+        run_service=run_service,
+        im_tool_service=fake_im_tool,
+    )
+
+    await service._await_terminal_and_reply(
+        account_id="bot-1",
+        gateway_session_id="gws-1",
+        run_id="run-question",
+        channel_id="channel-1",
+        reply_to_message_id="message-1",
+    )
+
+    assert "Pick a target" in fake_im_tool.sent_texts[0].text
+    assert (
+        fake_im_tool.sent_texts[1].text
+        == "Run paused: needs recovery\nSend resume to continue."
+    )
+    assert fake_im_tool.sent_texts[2].text == "Completed."
+
+
+@pytest.mark.asyncio
+async def test_discord_inbound_answers_pending_user_question(tmp_path: Path) -> None:
+    run_service = _FakeRunService(())
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-active",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [
+                {
+                    "question": "Pick a target",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        }
+    ]
+    fake_im_tool = _FakeImToolService()
+    command_service = _FakeImCommandService(
+        ImSessionCommandResult(text="command response")
+    )
+    repository = DiscordAccountRepository(tmp_path / "discord.db")
+    await repository.upsert_account(_discord_account())
+    ingress_service = _FakeIngressService(
+        run_id=None,
+        active_run_id="run-active",
+    )
+    service = _build_service(
+        tmp_path,
+        repository=repository,
+        run_service=run_service,
+        im_tool_service=fake_im_tool,
+        im_command_service=command_service,
+        session_ingress_service=ingress_service,
+    )
+    watcher_calls: list[dict[str, object]] = []
+    service._start_run_watcher = lambda **kwargs: watcher_calls.append(kwargs)
+
+    await service.handle_inbound_message(
+        account_id="bot-1",
+        message=DiscordInboundMessage(
+            message_id="answer-1",
+            channel_id="dm-channel-1",
+            author_id="user-1",
+            author_name="Alex",
+            content="Ship",
+            is_dm=True,
+        ),
+    )
+
+    assert run_service.created_intents == []
+    assert run_service.answered_questions[0][0] == "run-active"
+    assert run_service.answered_questions[0][1] == "question-1"
+    assert run_service.answered_questions[0][2].answers[0].selections[0].label == "Ship"
+    assert fake_im_tool.sent_texts[0].text == "Answer received. Continuing."
+    assert command_service.calls == []
+    assert watcher_calls == []
+    consumed = await service._inbound_queue_repo.get_by_message_key(
+        account_id="bot-1",
+        channel_id="dm-channel-1",
+        message_key="mid:answer-1",
+    )
+    assert consumed.status == DiscordInboundQueueStatus.COMPLETED
+    assert consumed.run_id is None
+
+    ingress_service._active_run_id = None
+    await service.handle_inbound_message(
+        account_id="bot-1",
+        message=DiscordInboundMessage(
+            message_id="answer-1",
+            channel_id="dm-channel-1",
+            author_id="user-1",
+            author_name="Alex",
+            content="/help",
+            is_dm=True,
+        ),
+    )
+
+    assert len(run_service.answered_questions) == 1
+    assert len(fake_im_tool.sent_texts) == 1
+    assert command_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_discord_question_answer_failure_returns_not_pending(
+    tmp_path: Path,
+) -> None:
+    run_service = _FakeRunService(())
+    run_service.user_questions = [_user_question_record(run_id="run-active")]
+    run_service.answer_error = RuntimeError("answer failed")
+    repository = DiscordAccountRepository(tmp_path / "discord.db")
+    service = _build_service(
+        tmp_path,
+        repository=repository,
+        run_service=run_service,
+    )
+
+    status = await service._try_answer_user_question(
+        run_id="run-active",
+        text="Ship",
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_reply_answers_pending_question_without_mention(
+    tmp_path: Path,
+) -> None:
+    run_service = _FakeRunService(())
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-active",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [
+                {
+                    "question": "Pick a target",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        }
+    ]
+    fake_im_tool = _FakeImToolService()
+    command_service = _FakeImCommandService(
+        ImSessionCommandResult(text="command response")
+    )
+    repository = DiscordAccountRepository(tmp_path / "discord.db")
+    await repository.upsert_account(_discord_account())
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    _ = fake_gateway_sessions.resolve_or_create_session(
+        channel_type=GatewayChannelType.DISCORD,
+        external_session_id="discord:bot-1:guild:guild-1:channel:channel-1",
+        workspace_id="workspace-1",
+        peer_user_id="user-1",
+        peer_chat_id="channel-1",
+        capabilities={"chat_type": "guild"},
+        channel_state={"channel_id": "channel-1"},
+    )
+    service = _build_service(
+        tmp_path,
+        repository=repository,
+        gateway_session_service=fake_gateway_sessions,
+        run_service=run_service,
+        im_tool_service=fake_im_tool,
+        im_command_service=command_service,
+        session_ingress_service=_FakeIngressService(
+            run_id=None,
+            active_run_id="run-active",
+        ),
+    )
+    watcher_calls: list[dict[str, object]] = []
+    service._start_run_watcher = lambda **kwargs: watcher_calls.append(kwargs)
+
+    await service.handle_inbound_message(
+        account_id="bot-1",
+        message=DiscordInboundMessage(
+            message_id="answer-guild-1",
+            channel_id="channel-1",
+            guild_id="guild-1",
+            author_id="user-1",
+            author_name="Alex",
+            content="Ship",
+            is_dm=False,
+            mentions_bot=False,
+        ),
+    )
+
+    assert run_service.answered_questions[0][0] == "run-active"
+    assert run_service.answered_questions[0][1] == "question-1"
+    assert run_service.answered_questions[0][2].answers[0].selections[0].label == "Ship"
+    assert fake_im_tool.sent_texts[0].text == "Answer received. Continuing."
+    assert command_service.calls == []
+    assert watcher_calls == []
+
+
+@pytest.mark.asyncio
 async def test_discord_reply_watcher_completes_queue_after_pause(
     tmp_path: Path,
 ) -> None:
@@ -1830,6 +2203,20 @@ class _FakeGatewaySessionService:
         self._records[record.gateway_session_id] = record
         return record
 
+    def get_by_external_session(
+        self,
+        *,
+        channel_type: GatewayChannelType,
+        external_session_id: str,
+    ) -> GatewaySessionRecord | None:
+        for record in self._records.values():
+            if (
+                record.channel_type == channel_type
+                and record.external_session_id == external_session_id
+            ):
+                return record
+        return None
+
     def bind_active_run(
         self,
         gateway_session_id: str,
@@ -1926,6 +2313,34 @@ class _FakeRunEvent:
     def __init__(self, *, event_type: RunEventType, payload_json: str) -> None:
         self.event_type = event_type
         self.payload_json = payload_json
+        self.event_id: int | None = None
+
+
+def _user_question_record(
+    *,
+    question_id: str = "question-1",
+    run_id: str = "run-active",
+) -> dict[str, JsonValue]:
+    return {
+        "question_id": question_id,
+        "run_id": run_id,
+        "session_id": "session-1",
+        "task_id": "task-1",
+        "instance_id": "instance-1",
+        "role_id": "role-1",
+        "tool_name": "ask_question",
+        "questions": [
+            {
+                "question": "Pick a target",
+                "options": [{"label": "Ship"}, {"label": "Wait"}],
+            }
+        ],
+        "status": "requested",
+        "answers": [],
+        "created_at": "2026-05-12T00:00:00+00:00",
+        "updated_at": "2026-05-12T00:00:00+00:00",
+        "resolved_at": None,
+    }
 
 
 class _FakeRunService:
@@ -1933,6 +2348,11 @@ class _FakeRunService:
         self._events = events
         self.created_intents: list[IntentInput] = []
         self.started_run_ids: list[str] = []
+        self.user_questions: list[dict[str, JsonValue]] = []
+        self.answered_questions: list[
+            tuple[str, str, UserQuestionAnswerSubmission]
+        ] = []
+        self.answer_error: Exception | None = None
 
     @property
     def bound_event_loop(self) -> asyncio.AbstractEventLoop | None:
@@ -1941,9 +2361,13 @@ class _FakeRunService:
         except RuntimeError:
             return None
 
-    def stream_run_events(self, run_id: str) -> AsyncIterator[_FakeRunEvent]:
+    def stream_run_events(
+        self,
+        run_id: str,
+        after_event_id: int = 0,
+    ) -> AsyncIterator[_FakeRunEvent]:
         _ = run_id
-        return self._iter_events()
+        return self._iter_events(after_event_id=after_event_id)
 
     async def create_run_async(self, intent: IntentInput) -> tuple[str, str]:
         self.created_intents.append(intent)
@@ -1952,8 +2376,34 @@ class _FakeRunService:
     async def ensure_run_started_async(self, run_id: str) -> None:
         self.started_run_ids.append(run_id)
 
-    async def _iter_events(self) -> AsyncIterator[_FakeRunEvent]:
-        for event in self._events:
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        _ = run_id
+        return self.user_questions
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        if self.answer_error is not None:
+            raise self.answer_error
+        self.answered_questions.append((run_id, question_id, answers))
+        return {"run_id": run_id, "question_id": question_id}
+
+    async def _iter_events(
+        self,
+        *,
+        after_event_id: int,
+    ) -> AsyncIterator[_FakeRunEvent]:
+        for index, event in enumerate(self._events, start=1):
+            if index <= after_event_id:
+                continue
+            event.event_id = index
             yield event
 
 
@@ -2005,6 +2455,7 @@ class _FakeImToolService:
 class _FakeImCommandService:
     def __init__(self, result: ImSessionCommandResult | None = None) -> None:
         self._result = result
+        self.calls: list[dict[str, str]] = []
 
     def handle_discord_command(
         self,
@@ -2013,7 +2464,13 @@ class _FakeImCommandService:
         gateway_session_id: str,
         text: str,
     ) -> ImSessionCommandResult | None:
-        _ = (session_id, gateway_session_id, text)
+        self.calls.append(
+            {
+                "session_id": session_id,
+                "gateway_session_id": gateway_session_id,
+                "text": text,
+            }
+        )
         return self._result
 
 

--- a/tests/unit_tests/gateway/test_discord_gateway.py
+++ b/tests/unit_tests/gateway/test_discord_gateway.py
@@ -1396,40 +1396,41 @@ async def test_discord_watcher_uses_live_stream_after_question_pause_without_eve
         def __init__(self) -> None:
             super().__init__(())
             self.offsets: list[int] = []
+            self.stop_on_pause_values: list[bool] = []
 
         def stream_run_events(
             self,
             run_id: str,
             after_event_id: int = 0,
+            *,
+            stop_on_pause: bool = True,
         ) -> AsyncIterator[_FakeRunEvent]:
             _ = run_id
             self.offsets.append(after_event_id)
-            return self._events_for_offset(after_event_id)
+            self.stop_on_pause_values.append(stop_on_pause)
+            return self._events_for_offset()
 
         async def _events_for_offset(
             self,
-            after_event_id: int,
         ) -> AsyncIterator[_FakeRunEvent]:
-            if after_event_id == 0:
-                yield _FakeRunEvent(
-                    event_type=RunEventType.USER_QUESTION_REQUESTED,
-                    payload_json=json.dumps(
-                        {
-                            "question_id": "question-1",
-                            "questions": [
-                                {
-                                    "question": "Pick one",
-                                    "options": [{"label": "Ship"}],
-                                }
-                            ],
-                        }
-                    ),
-                )
-                yield _FakeRunEvent(
-                    event_type=RunEventType.RUN_PAUSED,
-                    payload_json=json.dumps({"error_message": "waiting"}),
-                )
-                return
+            yield _FakeRunEvent(
+                event_type=RunEventType.USER_QUESTION_REQUESTED,
+                payload_json=json.dumps(
+                    {
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick one",
+                                "options": [{"label": "Ship"}],
+                            }
+                        ],
+                    }
+                ),
+            )
+            yield _FakeRunEvent(
+                event_type=RunEventType.RUN_PAUSED,
+                payload_json=json.dumps({"error_message": "waiting"}),
+            )
             yield _FakeRunEvent(
                 event_type=RunEventType.RUN_COMPLETED,
                 payload_json="{}",
@@ -1452,7 +1453,8 @@ async def test_discord_watcher_uses_live_stream_after_question_pause_without_eve
         reply_to_message_id="message-1",
     )
 
-    assert run_service.offsets == [0, -1]
+    assert run_service.offsets == [0]
+    assert run_service.stop_on_pause_values == [False]
     assert "Pick one" in fake_im_tool.sent_texts[0].text
     assert fake_im_tool.sent_texts[1].text == "Completed."
 
@@ -2365,8 +2367,10 @@ class _FakeRunService:
         self,
         run_id: str,
         after_event_id: int = 0,
+        *,
+        stop_on_pause: bool = True,
     ) -> AsyncIterator[_FakeRunEvent]:
-        _ = run_id
+        _ = (run_id, stop_on_pause)
         return self._iter_events(after_event_id=after_event_id)
 
     async def create_run_async(self, intent: IntentInput) -> tuple[str, str]:

--- a/tests/unit_tests/gateway/test_xiaoluban_im.py
+++ b/tests/unit_tests/gateway/test_xiaoluban_im.py
@@ -17,6 +17,7 @@ from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressService,
     GatewaySessionIngressStatus,
 )
+from relay_teams.gateway.user_questions import UserQuestionAnswerStatus
 from relay_teams.gateway.xiaoluban import (
     format_xiaoluban_notification_text,
     XiaolubanAccountCreateInput,
@@ -34,6 +35,9 @@ from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.run_models import IntentInput
 from relay_teams.sessions.runs.run_service import SessionRunService
+from relay_teams.sessions.runs.user_question_models import (
+    UserQuestionAnswerSubmission,
+)
 from relay_teams.sessions.session_models import SessionRecord
 
 
@@ -167,6 +171,226 @@ async def test_handle_im_inbound_starts_run_and_replies_terminal_output(
         "uidself",
     )
     assert service.should_suppress_xiaoluban_terminal_notification("run-1") is True
+
+
+@pytest.mark.asyncio
+async def test_im_reply_drain_sends_terminal_after_user_question_notice(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    run_service = _FakeRunService()
+    run_service.user_questions = [_user_question_record(run_id="run-1")]
+    fake_event_log = _FakeEventLog(
+        rows=(
+            {
+                "id": 1,
+                "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+                "payload_json": json.dumps(
+                    {
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick a target",
+                                "options": [{"label": "Ship"}, {"label": "Wait"}],
+                            }
+                        ],
+                    }
+                ),
+            },
+            {
+                "id": 2,
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "payload_json": json.dumps({"output": "done after answer"}),
+            },
+        )
+    )
+    service = _build_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+        event_log=fake_event_log,
+        run_service=run_service,
+    )
+    account = service.create_account(
+        XiaolubanAccountCreateInput(
+            display_name="Xiaoluban",
+            token="uidself_1234567890abcdef1234567890abcdef",
+        )
+    )
+    service.update_im_config(
+        account.account_id,
+        XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
+    )
+
+    await service.handle_im_inbound_async(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="inspect this repo",
+            receiver="uidself",
+            sender="uidself",
+            session_id="session-1",
+        ),
+    )
+
+    await service._drain_im_replies_async()
+    assert "Pick a target" in fake_client.sent_messages[-1][0]
+    await service._drain_im_replies_async()
+    assert fake_client.sent_messages[-1] == (
+        _formatted_xiaoluban_text(
+            session_id="session-1",
+            body="done after answer",
+            status="completed",
+        ),
+        "uidself",
+    )
+
+
+@pytest.mark.asyncio
+async def test_im_reply_drain_retries_user_question_notice_after_send_failure(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient(fail_send_when_contains="Pick a target")
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    run_service = _FakeRunService()
+    run_service.user_questions = [_user_question_record(run_id="run-1")]
+    fake_event_log = _FakeEventLog(
+        rows=(
+            {
+                "id": 1,
+                "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+                "payload_json": json.dumps(
+                    {
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick a target",
+                                "options": [{"label": "Ship"}, {"label": "Wait"}],
+                            }
+                        ],
+                    }
+                ),
+            },
+        )
+    )
+    service = _build_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+        event_log=fake_event_log,
+        run_service=run_service,
+    )
+    account = service.create_account(
+        XiaolubanAccountCreateInput(
+            display_name="Xiaoluban",
+            token="uidself_1234567890abcdef1234567890abcdef",
+        )
+    )
+    service.update_im_config(
+        account.account_id,
+        XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
+    )
+
+    await service.handle_im_inbound_async(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="inspect this repo",
+            receiver="uidself",
+            sender="uidself",
+            session_id="session-1",
+        ),
+    )
+    sent_count = len(fake_client.sent_messages)
+
+    await service._drain_im_replies_async()
+    assert len(fake_client.sent_messages) == sent_count
+    assert service._im_question_notice_keys == set()
+
+    fake_client.clear_send_failure()
+    await service._drain_im_replies_async()
+
+    assert "Pick a target" in fake_client.sent_messages[-1][0]
+
+
+@pytest.mark.asyncio
+async def test_im_reply_drain_skips_answered_user_question_notice(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    run_service = _FakeRunService()
+    answered_record = _user_question_record(run_id="run-1")
+    answered_record["status"] = "answered"
+    run_service.user_questions = [answered_record]
+    fake_event_log = _FakeEventLog(
+        rows=(
+            {
+                "id": 1,
+                "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+                "payload_json": json.dumps(
+                    {
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick a target",
+                                "options": [{"label": "Ship"}, {"label": "Wait"}],
+                            }
+                        ],
+                    }
+                ),
+            },
+            {
+                "id": 2,
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "payload_json": json.dumps({"output": "done after answer"}),
+            },
+        )
+    )
+    service = _build_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+        event_log=fake_event_log,
+        run_service=run_service,
+    )
+    account = service.create_account(
+        XiaolubanAccountCreateInput(
+            display_name="Xiaoluban",
+            token="uidself_1234567890abcdef1234567890abcdef",
+        )
+    )
+    service.update_im_config(
+        account.account_id,
+        XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
+    )
+
+    await service.handle_im_inbound_async(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="inspect this repo",
+            receiver="uidself",
+            sender="uidself",
+            session_id="session-1",
+        ),
+    )
+
+    await service._drain_im_replies_async()
+
+    assert fake_client.sent_messages[-1] == (
+        _formatted_xiaoluban_text(
+            session_id="session-1",
+            body="done after answer",
+            status="completed",
+        ),
+        "uidself",
+    )
+    assert "Pick a target" not in fake_client.sent_messages[-1][0]
 
 
 @pytest.mark.asyncio
@@ -319,6 +543,286 @@ async def test_handle_im_inbound_busy_session_replies_without_second_run(
 
 
 @pytest.mark.asyncio
+async def test_handle_im_inbound_answer_registers_reply_polling(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService(active_run_id="run-active")
+    run_service = _FakeRunService()
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-active",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [
+                {
+                    "question": "Pick a target",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        }
+    ]
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+    service._run_service = cast(SessionRunService, run_service)
+
+    await service.handle_im_inbound_async(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="Ship",
+            receiver="uidself",
+            sender="uidself",
+            session_id="session-1",
+        ),
+    )
+
+    assert run_service.answered_questions[0][0] == "run-active"
+    assert run_service.answered_questions[0][1] == "question-1"
+    assert "run-active" in service._pending_im_replies
+    assert "已收到回答" in fake_client.sent_messages[-1][0]
+
+
+@pytest.mark.asyncio
+async def test_handle_im_inbound_answer_without_ingress_uses_pending_question(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    run_service = _FakeRunService()
+    run_service.user_questions = [_user_question_record(run_id="run-detached")]
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=None,
+    )
+    service._run_service = cast(SessionRunService, run_service)
+    _ = fake_gateway_sessions.resolve_or_create_session(
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id=(
+            f"xiaoluban:{account.account_id}:im-workspace:welink-session-1"
+        ),
+        workspace_id="im-workspace",
+    )
+
+    await service.handle_im_inbound_async(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="Ship",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert run_service.answered_questions[0][0] == "run-detached"
+    assert run_service.answered_questions[0][1] == "question-1"
+    assert "run-detached" in service._pending_im_replies
+    assert fake_client.sent_messages[-1][1] == "uidself"
+
+
+@pytest.mark.asyncio
+async def test_handle_im_inbound_invalid_answer_sends_retry_notice(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService(active_run_id="run-active")
+    run_service = _FakeRunService()
+    question = _user_question_record(run_id="run-active")
+    question["questions"] = [
+        {
+            "question": "Pick a target",
+            "options": [{"label": "Ship"}, {"label": "Wait"}],
+        },
+        {
+            "question": "Pick a release",
+            "options": [{"label": "Now"}, {"label": "Later"}],
+        },
+    ]
+    run_service.user_questions = [question]
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+    service._run_service = cast(SessionRunService, run_service)
+
+    await service.handle_im_inbound_async(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="Ship",
+            receiver="uidself",
+            sender="uidself",
+            session_id="session-1",
+        ),
+    )
+
+    assert run_service.answered_questions == []
+    assert len(fake_client.sent_messages) == 1
+
+
+def test_xiaoluban_find_im_gateway_session_without_gateway_service(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+
+    assert service._find_im_gateway_session("missing") is None
+
+
+def test_xiaoluban_question_answer_failure_returns_not_pending(tmp_path: Path) -> None:
+    run_service = _FakeRunService()
+    run_service.user_questions = [_user_question_record(run_id="run-active")]
+    run_service.answer_error = RuntimeError("answer failed")
+    service = _build_service(tmp_path, run_service=run_service)
+
+    status = service._try_answer_user_question(
+        run_id="run-active",
+        text="Ship",
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+
+
+@pytest.mark.asyncio
+async def test_xiaoluban_session_question_answer_failure_returns_not_pending(
+    tmp_path: Path,
+) -> None:
+    run_service = _FakeRunService()
+    run_service.user_questions = [_user_question_record(run_id="run-active")]
+    run_service.answer_error = RuntimeError("answer failed")
+    service = _build_service(tmp_path, run_service=run_service)
+
+    status, run_id = await service._try_answer_user_question_for_session_async(
+        session_id="session-1",
+        text="Ship",
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
+    assert run_id is None
+
+
+def test_xiaoluban_user_question_text_filters_non_pending_events(
+    tmp_path: Path,
+) -> None:
+    run_service = _FakeRunService()
+    answered = _user_question_record(question_id="answered-question", run_id="run-1")
+    answered["status"] = "answered"
+    run_service.user_questions = [
+        answered,
+        _user_question_record(question_id="question-1", run_id="run-1"),
+    ]
+    event_log = _FakeEventLog(
+        rows=(
+            {"id": 1, "event_type": "bad-event", "payload_json": "{}"},
+            {
+                "id": 2,
+                "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+                "payload_json": json.dumps(
+                    {
+                        "question_id": "answered-question",
+                        "questions": [
+                            {
+                                "question": "Already answered",
+                                "options": [{"label": "Ship"}],
+                            }
+                        ],
+                    }
+                ),
+            },
+            {
+                "id": 3,
+                "event_type": RunEventType.USER_QUESTION_REQUESTED.value,
+                "payload_json": json.dumps(
+                    {
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick a target",
+                                "options": [{"label": "Ship"}],
+                            }
+                        ],
+                    }
+                ),
+            },
+        )
+    )
+    service = _build_service(
+        tmp_path,
+        event_log=event_log,
+        run_service=run_service,
+    )
+
+    key, text = service._user_question_text_for_run("run-1")
+
+    assert key == "run-1:3"
+    assert "Pick a target" in text
+
+
+@pytest.mark.asyncio
+async def test_handle_im_inbound_answers_pending_question_before_command(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService(active_run_id="run-active")
+    run_service = _FakeRunService()
+    question = _user_question_record(run_id="run-active")
+    question["questions"] = [
+        {
+            "question": "Pick a command",
+            "options": [{"label": "/resume"}, {"label": "/help"}],
+        }
+    ]
+    run_service.user_questions = [question]
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+    service._run_service = cast(SessionRunService, run_service)
+    _ = fake_gateway_sessions.resolve_or_create_session(
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id=(
+            f"xiaoluban:{account.account_id}:im-workspace:welink-session-1"
+        ),
+        workspace_id="im-workspace",
+    )
+
+    await service.handle_im_inbound_async(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/resume",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert run_service.answered_questions[0][0] == "run-active"
+    assert run_service.answered_questions[0][1] == "question-1"
+    assert fake_ingress.requests == []
+    assert "会话列表" not in fake_client.sent_messages[-1][0]
+    assert "已收到回答" in fake_client.sent_messages[-1][0]
+
+
+@pytest.mark.asyncio
 async def test_handle_im_inbound_rejected_submit_replies_busy(
     tmp_path: Path,
 ) -> None:
@@ -360,6 +864,7 @@ def _build_service(
     gateway_session_service: _FakeGatewaySessionService | None = None,
     session_ingress_service: _FakeIngressService | None = None,
     event_log: _FakeEventLog | None = None,
+    run_service: _FakeRunService | None = None,
     get_shell_safety_policy_enabled: Callable[[], bool] | None = None,
 ) -> XiaolubanGatewayService:
     return XiaolubanGatewayService(
@@ -372,7 +877,7 @@ def _build_service(
             GatewaySessionService | None,
             gateway_session_service,
         ),
-        run_service=None,
+        run_service=cast(SessionRunService | None, run_service),
         event_log=cast(EventLog | None, event_log),
         session_ingress_service=cast(
             GatewaySessionIngressService | None,
@@ -387,7 +892,7 @@ def _build_ready_im_service(
     *,
     client: _FakeXiaolubanClient,
     gateway_session_service: _FakeGatewaySessionService,
-    session_ingress_service: _FakeIngressService,
+    session_ingress_service: _FakeIngressService | None,
 ) -> tuple[XiaolubanGatewayService, XiaolubanAccountRecord]:
     service = _build_service(
         tmp_path,
@@ -421,6 +926,33 @@ def _formatted_xiaoluban_text(
         status=status,
         body=body,
     )
+
+
+def _user_question_record(
+    *,
+    question_id: str = "question-1",
+    run_id: str = "run-active",
+) -> dict[str, JsonValue]:
+    return {
+        "question_id": question_id,
+        "run_id": run_id,
+        "session_id": "session-1",
+        "task_id": "task-1",
+        "instance_id": "instance-1",
+        "role_id": "role-1",
+        "tool_name": "ask_question",
+        "questions": [
+            {
+                "question": "Pick a target",
+                "options": [{"label": "Ship"}, {"label": "Wait"}],
+            }
+        ],
+        "status": "requested",
+        "answers": [],
+        "created_at": "2026-05-12T00:00:00+00:00",
+        "updated_at": "2026-05-12T00:00:00+00:00",
+        "resolved_at": None,
+    }
 
 
 class _FakeSecretStore:
@@ -486,6 +1018,9 @@ class _FakeXiaolubanClient:
             raise RuntimeError("simulated xiaoluban send failure")
         self.sent_messages.append((text, receiver_uid))
         return _FakeSendResponse()
+
+    def clear_send_failure(self) -> None:
+        self._fail_send_when_contains = None
 
 
 class _FakeSendResponse:
@@ -1940,6 +2475,11 @@ class _FakeRunService:
     def __init__(self) -> None:
         self.create_run_calls = 0
         self.ensure_started_calls = 0
+        self.user_questions: list[dict[str, JsonValue]] = []
+        self.answered_questions: list[
+            tuple[str, str, UserQuestionAnswerSubmission]
+        ] = []
+        self.answer_error: Exception | None = None
 
     def create_run(self, intent: IntentInput) -> tuple[str, str]:
         _ = intent
@@ -1949,6 +2489,51 @@ class _FakeRunService:
     def ensure_run_started(self, run_id: str) -> None:
         _ = run_id
         self.ensure_started_calls += 1
+
+    def list_user_questions(self, run_id: str) -> list[dict[str, JsonValue]]:
+        _ = run_id
+        return self.user_questions
+
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        return self.list_user_questions(run_id)
+
+    async def list_user_questions_by_session_async(
+        self,
+        session_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        return [
+            record
+            for record in self.user_questions
+            if record.get("session_id") == session_id
+        ]
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        return self.answer_user_question(
+            run_id=run_id,
+            question_id=question_id,
+            answers=answers,
+        )
+
+    def answer_user_question(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        if self.answer_error is not None:
+            raise self.answer_error
+        self.answered_questions.append((run_id, question_id, answers))
+        return {"run_id": run_id, "question_id": question_id}
 
 
 class _FakeRunServiceWithDetached(_FakeRunService):
@@ -1967,12 +2552,16 @@ class _FakeEventLog:
         self,
         event_type: str | None = None,
         payload: dict[str, str] | None = None,
+        rows: tuple[dict[str, JsonValue], ...] | None = None,
     ) -> None:
         self._event_type = event_type
         self._payload = payload
+        self._rows = rows
 
     def list_by_trace_with_ids(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
         _ = trace_id
+        if self._rows is not None:
+            return self._rows
         if self._event_type is None:
             return (
                 {

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -289,6 +289,12 @@ class _InteractionDelegateSpy:
         self.calls.append(f"questions:{run_id}")
         return [{"run_id": run_id, "status": "pending"}]
 
+    async def list_user_questions_by_session_async(
+        self, session_id: str
+    ) -> list[dict[str, JsonValue]]:
+        self.calls.append(f"session-questions:{session_id}")
+        return [{"session_id": session_id, "status": "pending"}]
+
 
 def _media_role_registry() -> RoleRegistry:
     registry = RoleRegistry()
@@ -450,6 +456,51 @@ def test_run_service_compatibility_facade_delegates_to_split_services(
         "persist-shell:none:approved",
         "questions:run-interaction",
     ]
+
+
+@pytest.mark.asyncio
+async def test_list_user_questions_by_session_async_delegates_to_interactions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _build_manager(tmp_path / "run_service_session_questions.db")
+    interactions = _InteractionDelegateSpy()
+    monkeypatch.setattr(manager, "_interaction_service", interactions)
+
+    result = await manager.list_user_questions_by_session_async("session-1")
+
+    assert result == [{"session_id": "session-1", "status": "pending"}]
+    assert interactions.calls == ["session-questions:session-1"]
+
+
+@pytest.mark.asyncio
+async def test_run_interactions_list_user_questions_by_session_async_reads_repo(
+    tmp_path: Path,
+) -> None:
+    manager = _build_manager(tmp_path / "run_interactions_session_questions.db")
+    repo = manager._require_user_question_repo()
+    repo.upsert_requested(
+        question_id="question-1",
+        run_id="run-1",
+        session_id="session-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        role_id="Coordinator",
+        tool_name="ask_question",
+        questions=(
+            UserQuestionPrompt(
+                question="Pick one",
+                options=(UserQuestionOption(label="Only", description="Only"),),
+            ),
+        ),
+    )
+
+    result = await manager._interaction_service.list_user_questions_by_session_async(
+        "session-1"
+    )
+
+    assert result[0]["question_id"] == "question-1"
+    assert result[0]["session_id"] == "session-1"
 
 
 def test_prepare_intent_resolves_topology_with_policy_override(tmp_path: Path) -> None:

--- a/tests/unit_tests/sessions/runs/test_run_service_stream_events.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_stream_events.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimePhase,
+    RunRuntimeRepository,
+    RunRuntimeStatus,
+)
+from tests.unit_tests.sessions.runs.test_run_service_recovery import _build_manager
+
+
+@pytest.mark.asyncio
+async def test_stream_run_events_can_continue_after_run_paused(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_stream_continue_after_pause.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    manager._running_run_ids.add("run-existing")
+
+    for event in (
+        RunEvent(
+            session_id="session-1",
+            run_id="run-existing",
+            trace_id="run-existing",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"session_id":"session-1"}',
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-existing",
+            trace_id="run-existing",
+            event_type=RunEventType.RUN_PAUSED,
+            payload_json='{"error_message":"waiting for input"}',
+        ),
+        RunEvent(
+            session_id="session-1",
+            run_id="run-existing",
+            trace_id="run-existing",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed"}',
+        ),
+    ):
+        manager._run_event_hub.publish(event)
+
+    replayed = [
+        event
+        async for event in manager.stream_run_events(
+            "run-existing",
+            stop_on_pause=False,
+        )
+    ]
+
+    assert [event.event_type for event in replayed] == [
+        RunEventType.RUN_STARTED,
+        RunEventType.RUN_PAUSED,
+        RunEventType.RUN_COMPLETED,
+    ]
+    assert manager._run_event_hub.has_subscribers("run-existing") is False

--- a/tests/unit_tests/sessions/runs/test_run_service_stream_events.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_stream_events.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncIterable, AsyncIterator
 from pathlib import Path
 
 import pytest
@@ -13,6 +15,14 @@ from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeStatus,
 )
 from tests.unit_tests.sessions.runs.test_run_service_recovery import _build_manager
+
+
+async def _collect_events(stream: AsyncIterable[RunEvent]) -> list[RunEvent]:
+    return [event async for event in stream]
+
+
+async def _next_event(stream: AsyncIterator[RunEvent]) -> RunEvent:
+    return await stream.__anext__()
 
 
 @pytest.mark.asyncio
@@ -69,4 +79,62 @@ async def test_stream_run_events_can_continue_after_run_paused(
         RunEventType.RUN_PAUSED,
         RunEventType.RUN_COMPLETED,
     ]
+    assert manager._run_event_hub.has_subscribers("run-existing") is False
+
+
+@pytest.mark.asyncio
+async def test_stream_run_events_pause_does_not_clear_other_subscribers(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_stream_pause_keeps_other_subscribers.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    manager._running_run_ids.add("run-existing")
+    default_stream = manager.stream_run_events("run-existing")
+    tolerant_stream = manager.stream_run_events(
+        "run-existing",
+        stop_on_pause=False,
+    )
+    default_task = asyncio.create_task(_collect_events(default_stream))
+    tolerant_iter = tolerant_stream.__aiter__()
+    tolerant_pause_task = asyncio.create_task(_next_event(tolerant_iter))
+    await asyncio.sleep(0)
+
+    manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-existing",
+            trace_id="run-existing",
+            event_type=RunEventType.RUN_PAUSED,
+            payload_json='{"error_message":"waiting for input"}',
+        )
+    )
+
+    default_events = await asyncio.wait_for(default_task, timeout=1)
+    tolerant_pause = await asyncio.wait_for(tolerant_pause_task, timeout=1)
+    assert [event.event_type for event in default_events] == [RunEventType.RUN_PAUSED]
+    assert tolerant_pause.event_type == RunEventType.RUN_PAUSED
+    assert manager._run_event_hub.has_subscribers("run-existing") is True
+
+    manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-existing",
+            trace_id="run-existing",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed"}',
+        )
+    )
+
+    tolerant_completed = await asyncio.wait_for(_next_event(tolerant_iter), timeout=1)
+    assert tolerant_completed.event_type == RunEventType.RUN_COMPLETED
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(_next_event(tolerant_iter), timeout=1)
     assert manager._run_event_hub.has_subscribers("run-existing") is False

--- a/tests/unit_tests/tools/im_tools/test_service.py
+++ b/tests/unit_tests/tools/im_tools/test_service.py
@@ -62,6 +62,8 @@ _WECHAT_ACCOUNT_ID = "wx-account-1"
 _WECHAT_PEER_ID = "wx-peer-1"
 _DISCORD_ACCOUNT_ID = "discord-account-1"
 _DISCORD_CHANNEL_ID = "discord-channel-1"
+_IM_SEND_TOOLS = ("im_send",)
+_IM_SEND_AND_ASK_TOOLS = ("im_send", "ask_question")
 
 
 def _make_session(
@@ -495,6 +497,26 @@ def _discord_gateway_session(
     )
 
 
+def _xiaoluban_gateway_session(
+    *,
+    session_id: str = _SESSION_ID,
+    account_id: str = "xlb-account-1",
+) -> GatewaySessionRecord:
+    return GatewaySessionRecord(
+        gateway_session_id="gws-xiaoluban-1",
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id=f"xiaoluban:{account_id}:workspace-1:session-1",
+        internal_session_id=session_id,
+        peer_user_id="xiaoluban-user-1",
+        peer_chat_id="xiaoluban-chat-1",
+        channel_state={
+            "account_id": account_id,
+            "sender": "xiaoluban-user-1",
+            "receiver": "xiaoluban-chat-1",
+        },
+    )
+
+
 async def test_resolver_returns_im_tool_for_feishu_session() -> None:
     resolver = _build_context_resolver(
         sessions=_default_sessions(),
@@ -505,7 +527,7 @@ async def test_resolver_returns_im_tool_for_feishu_session() -> None:
         ToolResolutionContext(session_id=_SESSION_ID)
     )
 
-    assert resolved == ("im_send",)
+    assert resolved == _IM_SEND_AND_ASK_TOOLS
 
 
 async def test_resolver_returns_im_tool_for_wechat_session() -> None:
@@ -518,7 +540,7 @@ async def test_resolver_returns_im_tool_for_wechat_session() -> None:
         ToolResolutionContext(session_id=_SESSION_ID)
     )
 
-    assert resolved == ("im_send",)
+    assert resolved == _IM_SEND_AND_ASK_TOOLS
 
 
 async def test_resolver_returns_im_tool_for_discord_session() -> None:
@@ -531,7 +553,20 @@ async def test_resolver_returns_im_tool_for_discord_session() -> None:
         ToolResolutionContext(session_id=_SESSION_ID)
     )
 
-    assert resolved == ("im_send",)
+    assert resolved == _IM_SEND_AND_ASK_TOOLS
+
+
+async def test_resolver_returns_ask_tool_for_xiaoluban_session() -> None:
+    resolver = _build_context_resolver(
+        configs=_default_configs(),
+        gateway_sessions={_SESSION_ID: _xiaoluban_gateway_session()},
+    )
+
+    resolved = resolver.resolve_implicit_tools(
+        ToolResolutionContext(session_id=_SESSION_ID)
+    )
+
+    assert resolved == ("ask_question",)
 
 
 async def test_resolver_returns_no_tool_without_im_context() -> None:
@@ -547,7 +582,7 @@ async def test_resolver_returns_no_tool_without_im_context() -> None:
     assert resolved == ()
 
 
-async def test_resolver_returns_im_tool_for_automation_session_binding() -> None:
+async def test_resolver_returns_send_tool_for_automation_session_binding() -> None:
     resolver = _build_context_resolver(
         sessions={_SESSION_ID: _automation_session()},
         configs=_default_configs(),
@@ -558,7 +593,7 @@ async def test_resolver_returns_im_tool_for_automation_session_binding() -> None
         ToolResolutionContext(session_id=_SESSION_ID)
     )
 
-    assert resolved == ("im_send",)
+    assert resolved == _IM_SEND_TOOLS
 
 
 async def test_resolver_returns_no_tool_for_automation_session_without_binding() -> (

--- a/tests/unit_tests/wechat/test_service.py
+++ b/tests/unit_tests/wechat/test_service.py
@@ -39,11 +39,15 @@ from relay_teams.gateway.wechat.models import (
 )
 from relay_teams.gateway.wechat.secret_store import WeChatSecretStore
 from relay_teams.gateway.wechat.service import WeChatGatewayService
+from relay_teams.gateway.user_questions import UserQuestionAnswerStatus
 from relay_teams.media import content_parts_from_text
 from relay_teams.sessions.session_service import SessionService
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_service import SessionRunService
 from relay_teams.sessions.runs.run_models import RunEvent, RunResult
+from relay_teams.sessions.runs.user_question_models import (
+    UserQuestionAnswerSubmission,
+)
 from relay_teams.sessions.session_models import SessionMode
 
 _RECEIPT_CREATED = "\u6536\u5230\uff0c\u6b63\u5728\u5904\u7406\u3002"
@@ -311,6 +315,266 @@ async def test_await_terminal_and_reply_sends_pause_notice_without_clearing_bind
     assert snapshot.last_outbound_at is not None
     assert snapshot.last_event_at == snapshot.last_outbound_at
     assert "run-1" not in service._watched_runs
+
+
+@pytest.mark.asyncio
+async def test_await_terminal_and_reply_sends_user_question_notice() -> None:
+    service, gateway_session_service, run_service, im_tool_service, _ = _build_service(
+        events=(
+            _event(
+                run_id="run-1",
+                event_type=RunEventType.USER_QUESTION_REQUESTED,
+                payload={
+                    "question_id": "question-1",
+                    "questions": [
+                        {
+                            "question": "Pick a target",
+                            "options": [{"label": "Ship"}, {"label": "Wait"}],
+                        }
+                    ],
+                },
+            ),
+            _event(
+                run_id="run-1",
+                event_type=RunEventType.RUN_PAUSED,
+                payload={"error_message": "waiting for user input"},
+            ),
+            _event(
+                run_id="run-1",
+                event_type=RunEventType.RUN_COMPLETED,
+                payload={"output": "done"},
+            ),
+        )
+    )
+    run_service.user_questions = [_user_question_record()]
+    service._watched_runs.add("run-1")
+
+    await service._await_terminal_and_reply(
+        account_id="wx-account-1",
+        gateway_session_id="gws-1",
+        run_id="run-1",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-1",
+    )
+
+    assert "Pick a target" in str(im_tool_service.send_text_calls[0]["text"])
+    assert im_tool_service.send_text_calls[1]["text"] == "done"
+    assert len(im_tool_service.send_text_calls) == 2
+    assert gateway_session_service.bind_calls == [("gws-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_await_terminal_uses_live_stream_after_question_pause_without_event_id() -> (
+    None
+):
+    class NoEventIdRunService(_FakeRunService):
+        def __init__(self) -> None:
+            super().__init__(())
+            self.offsets: list[int] = []
+
+        async def stream_run_events(
+            self,
+            run_id: str,
+            after_event_id: int = 0,
+        ) -> AsyncIterator[RunEvent]:
+            self.offsets.append(after_event_id)
+            if after_event_id == 0:
+                yield _event(
+                    run_id=run_id,
+                    event_type=RunEventType.USER_QUESTION_REQUESTED,
+                    payload={
+                        "question_id": "question-1",
+                        "questions": [
+                            {
+                                "question": "Pick one",
+                                "options": [{"label": "Ship"}],
+                            }
+                        ],
+                    },
+                ).model_copy(update={"event_id": None})
+                yield _event(
+                    run_id=run_id,
+                    event_type=RunEventType.RUN_PAUSED,
+                    payload={"error_message": "waiting for user input"},
+                ).model_copy(update={"event_id": None})
+                return
+            yield _event(
+                run_id=run_id,
+                event_type=RunEventType.RUN_COMPLETED,
+                payload={"output": "done"},
+            ).model_copy(update={"event_id": None})
+
+    run_service = NoEventIdRunService()
+    service, _gateway_session_service, _unused_run_service, im_tool_service, _ = (
+        _build_service(events=())
+    )
+    service._run_service = cast(SessionRunService, run_service)
+    run_service.user_questions = [_user_question_record()]
+    service._watched_runs.add("run-1")
+
+    await service._await_terminal_and_reply(
+        account_id="wx-account-1",
+        gateway_session_id="gws-1",
+        run_id="run-1",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-1",
+    )
+
+    assert run_service.offsets == [0, -1]
+    assert "Pick one" in str(im_tool_service.send_text_calls[0]["text"])
+    assert im_tool_service.send_text_calls[1]["text"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_await_terminal_and_reply_sends_later_pause_after_question_pause() -> (
+    None
+):
+    service, gateway_session_service, run_service, im_tool_service, _ = _build_service(
+        events=(
+            _event(
+                run_id="run-1",
+                event_type=RunEventType.USER_QUESTION_REQUESTED,
+                payload={
+                    "question_id": "question-1",
+                    "questions": [
+                        {
+                            "question": "Pick a target",
+                            "options": [{"label": "Ship"}, {"label": "Wait"}],
+                        }
+                    ],
+                },
+            ),
+            _event(
+                run_id="run-1",
+                event_type=RunEventType.RUN_PAUSED,
+                payload={"error_message": "waiting for user input"},
+            ),
+            _event(
+                run_id="run-1",
+                event_type=RunEventType.RUN_PAUSED,
+                payload={"error_message": "stream interrupted"},
+            ),
+            _event(
+                run_id="run-1",
+                event_type=RunEventType.RUN_COMPLETED,
+                payload={"output": "done"},
+            ),
+        )
+    )
+    run_service.user_questions = [_user_question_record()]
+    service._watched_runs.add("run-1")
+
+    await service._await_terminal_and_reply(
+        account_id="wx-account-1",
+        gateway_session_id="gws-1",
+        run_id="run-1",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-1",
+    )
+
+    assert "Pick a target" in str(im_tool_service.send_text_calls[0]["text"])
+    assert (
+        im_tool_service.send_text_calls[1]["text"]
+        == "Run paused: stream interrupted\nSend resume to continue."
+    )
+    assert len(im_tool_service.send_text_calls) == 2
+    assert gateway_session_service.bind_calls == []
+
+
+def test_handle_message_answers_pending_user_question() -> None:
+    service, gateway_session_service, run_service, im_tool_service, command_service = (
+        _build_service(
+            events=(),
+            command_response="[Session Commands]",
+            has_active_run=True,
+        )
+    )
+    watcher_calls: list[dict[str, object]] = []
+    service._start_run_watcher = lambda **kwargs: watcher_calls.append(kwargs)
+    run_service.user_questions = [
+        {
+            "question_id": "question-1",
+            "run_id": "run-1",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "instance_id": "instance-1",
+            "role_id": "role-1",
+            "tool_name": "ask_question",
+            "questions": [
+                {
+                    "question": "Pick a target",
+                    "options": [{"label": "Ship"}, {"label": "Wait"}],
+                }
+            ],
+            "status": "requested",
+            "answers": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+            "resolved_at": None,
+        }
+    ]
+
+    service._handle_message(
+        _account(),
+        WeChatInboundMessage(
+            message_id=1001,
+            from_user_id="wx-peer-1",
+            item_list=(_text_item("Ship"),),
+        ),
+    )
+
+    assert len(run_service.created_intents) == 0
+    assert run_service.answered_questions[0][0] == "run-1"
+    assert run_service.answered_questions[0][1] == "question-1"
+    assert run_service.answered_questions[0][2].answers[0].selections[0].label == "Ship"
+    assert command_service.calls == []
+    assert im_tool_service.send_text_calls[0]["text"] == "已收到回答，正在继续处理。"
+    assert watcher_calls == []
+    assert gateway_session_service.bind_calls == []
+    consumed = service._inbound_queue_repo.get_by_message_key(
+        account_id="wx-account-1",
+        peer_user_id="wx-peer-1",
+        message_key="mid:1001",
+    )
+    assert consumed.status == WeChatInboundQueueStatus.COMPLETED
+    assert consumed.run_id is None
+
+    run_service.user_questions = []
+    service._session_service = cast(
+        SessionService,
+        _FakeSessionService(has_active_run=False),
+    )
+    service._handle_message(
+        _account(),
+        WeChatInboundMessage(
+            message_id=1001,
+            from_user_id="wx-peer-1",
+            item_list=(_text_item("/help"),),
+        ),
+    )
+
+    assert len(run_service.answered_questions) == 1
+    assert len(im_tool_service.send_text_calls) == 1
+    assert command_service.calls == []
+
+
+def test_wechat_question_answer_failure_returns_not_pending() -> None:
+    (
+        service,
+        _gateway_session_service,
+        run_service,
+        _im_tool_service,
+        _command_service,
+    ) = _build_service(events=(), has_active_run=True)
+    run_service.user_questions = [_user_question_record()]
+    run_service.answer_error = RuntimeError("answer failed")
+
+    status = service._try_answer_user_question(
+        run_id="run-1",
+        text="Ship",
+    )
+
+    assert status == UserQuestionAnswerStatus.NOT_PENDING
 
 
 @pytest.mark.asyncio
@@ -1051,6 +1315,22 @@ class _FakeInboundQueueRepo:
     def get(self, inbound_queue_id: str) -> WeChatInboundQueueRecord | None:
         return self.records.get(inbound_queue_id)
 
+    def get_by_message_key(
+        self,
+        *,
+        account_id: str,
+        peer_user_id: str,
+        message_key: str,
+    ) -> WeChatInboundQueueRecord:
+        for record in self.records.values():
+            if (
+                record.account_id == account_id
+                and record.peer_user_id == peer_user_id
+                and record.message_key == message_key
+            ):
+                return record
+        raise KeyError(message_key)
+
     def get_latest_by_run_id(self, run_id: str) -> WeChatInboundQueueRecord | None:
         matches = [
             record
@@ -1169,15 +1449,26 @@ class _FakeRunService:
         self._event_loop: asyncio.AbstractEventLoop | None = None
         self.created_intents: list[dict[str, str | bool]] = []
         self.ensured_run_ids: list[str] = []
+        self.user_questions: list[dict[str, JsonValue]] = []
+        self.answered_questions: list[
+            tuple[str, str, UserQuestionAnswerSubmission]
+        ] = []
+        self.answer_error: Exception | None = None
 
     @property
     def bound_event_loop(self) -> asyncio.AbstractEventLoop | None:
         return self._event_loop
 
-    async def stream_run_events(self, run_id: str) -> AsyncIterator[RunEvent]:
-        for event in self._events:
+    async def stream_run_events(
+        self,
+        run_id: str,
+        after_event_id: int = 0,
+    ) -> AsyncIterator[RunEvent]:
+        for index, event in enumerate(self._events, start=1):
+            if index <= after_event_id:
+                continue
             assert event.run_id == run_id
-            yield event
+            yield event.model_copy(update={"event_id": index})
 
     def create_run(self, intent: object) -> tuple[str, str]:
         session_id = cast(str, getattr(intent, "session_id"))
@@ -1199,6 +1490,22 @@ class _FakeRunService:
 
     def ensure_run_started(self, run_id: str) -> None:
         self.ensured_run_ids.append(run_id)
+
+    def list_user_questions(self, run_id: str) -> list[dict[str, JsonValue]]:
+        _ = run_id
+        return self.user_questions
+
+    def answer_user_question(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        if self.answer_error is not None:
+            raise self.answer_error
+        self.answered_questions.append((run_id, question_id, answers))
+        return {"run_id": run_id, "question_id": question_id}
 
 
 class _FakeSessionService:
@@ -1308,6 +1615,33 @@ def _event(
         payload_json=json.dumps(payload, ensure_ascii=False),
         occurred_at=datetime.now(tz=timezone.utc),
     )
+
+
+def _user_question_record(
+    *,
+    question_id: str = "question-1",
+    run_id: str = "run-1",
+) -> dict[str, JsonValue]:
+    return {
+        "question_id": question_id,
+        "run_id": run_id,
+        "session_id": "session-1",
+        "task_id": "task-1",
+        "instance_id": "instance-1",
+        "role_id": "role-1",
+        "tool_name": "ask_question",
+        "questions": [
+            {
+                "question": "Pick a target",
+                "options": [{"label": "Ship"}, {"label": "Wait"}],
+            }
+        ],
+        "status": "requested",
+        "answers": [],
+        "created_at": "2026-05-12T00:00:00+00:00",
+        "updated_at": "2026-05-12T00:00:00+00:00",
+        "resolved_at": None,
+    }
 
 
 def test_wechat_account_update_input_rejects_empty_patch() -> None:

--- a/tests/unit_tests/wechat/test_service.py
+++ b/tests/unit_tests/wechat/test_service.py
@@ -371,33 +371,35 @@ async def test_await_terminal_uses_live_stream_after_question_pause_without_even
         def __init__(self) -> None:
             super().__init__(())
             self.offsets: list[int] = []
+            self.stop_on_pause_values: list[bool] = []
 
         async def stream_run_events(
             self,
             run_id: str,
             after_event_id: int = 0,
+            *,
+            stop_on_pause: bool = True,
         ) -> AsyncIterator[RunEvent]:
             self.offsets.append(after_event_id)
-            if after_event_id == 0:
-                yield _event(
-                    run_id=run_id,
-                    event_type=RunEventType.USER_QUESTION_REQUESTED,
-                    payload={
-                        "question_id": "question-1",
-                        "questions": [
-                            {
-                                "question": "Pick one",
-                                "options": [{"label": "Ship"}],
-                            }
-                        ],
-                    },
-                ).model_copy(update={"event_id": None})
-                yield _event(
-                    run_id=run_id,
-                    event_type=RunEventType.RUN_PAUSED,
-                    payload={"error_message": "waiting for user input"},
-                ).model_copy(update={"event_id": None})
-                return
+            self.stop_on_pause_values.append(stop_on_pause)
+            yield _event(
+                run_id=run_id,
+                event_type=RunEventType.USER_QUESTION_REQUESTED,
+                payload={
+                    "question_id": "question-1",
+                    "questions": [
+                        {
+                            "question": "Pick one",
+                            "options": [{"label": "Ship"}],
+                        }
+                    ],
+                },
+            ).model_copy(update={"event_id": None})
+            yield _event(
+                run_id=run_id,
+                event_type=RunEventType.RUN_PAUSED,
+                payload={"error_message": "waiting for user input"},
+            ).model_copy(update={"event_id": None})
             yield _event(
                 run_id=run_id,
                 event_type=RunEventType.RUN_COMPLETED,
@@ -420,7 +422,8 @@ async def test_await_terminal_uses_live_stream_after_question_pause_without_even
         context_token="ctx-1",
     )
 
-    assert run_service.offsets == [0, -1]
+    assert run_service.offsets == [0]
+    assert run_service.stop_on_pause_values == [False]
     assert "Pick one" in str(im_tool_service.send_text_calls[0]["text"])
     assert im_tool_service.send_text_calls[1]["text"] == "done"
 
@@ -1463,7 +1466,10 @@ class _FakeRunService:
         self,
         run_id: str,
         after_event_id: int = 0,
+        *,
+        stop_on_pause: bool = True,
     ) -> AsyncIterator[RunEvent]:
+        _ = stop_on_pause
         for index, event in enumerate(self._events, start=1):
             if index <= after_event_id:
                 continue


### PR DESCRIPTION
## Summary
- expose `ask_question` to IM gateway sessions that need user input
- send ask-question prompts back through WeChat, Discord, Feishu, and Xiaoluban IM channels
- route IM replies into pending user questions and keep watching for terminal run output after the answer

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/wechat/test_service.py tests/unit_tests/gateway/test_discord_gateway.py tests/unit_tests/gateway/test_xiaoluban_im.py`
- `uv run --extra dev pytest -q tests/unit_tests/tools/im_tools/test_service.py tests/unit_tests/tools/registry/test_defaults.py`

## Local validation notes
- `uv run --extra dev pytest -q tests/unit_tests` is blocked locally by an existing timeout in `tests/unit_tests/binary_tools/test_service.py::test_binary_tools_package_imports_without_net_github_cli_cycle`.
- `uv run --extra dev pytest -q tests/integration_tests` is blocked locally because Playwright Chromium is not installed in this machine's browser cache.

Closes #832