### PR TITLE
feat: promote memory entries into skill drafts

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -4161,7 +4161,8 @@ Lists Memory Bank evolution drafts for one workspace.
 
 Query fields:
 - `target`: optional `skill` or `sop_skill`.
-- `status`: optional `draft`, `applied`, `rejected`, or `superseded`.
+- `status`: optional `draft`, `applying`, `applied`, `rejected`, or
+  `superseded`.
 - `limit`: page size `1..100`, default `20`.
 - `offset`: default `0`.
 
@@ -4184,7 +4185,8 @@ Request: `ApplyMemoryEvolutionDraftRequest`
 - `instructions`: optional final `SKILL.md` body override.
 
 Response: `MemoryEvolutionDraft` with `status=applied` and `applied_skill_ref`.
-Returns `409` when the draft is no longer in `draft` status.
+Returns `400` for invalid apply payloads and `409` when the draft is no longer
+in `draft` status or another apply request has already claimed it.
 
 ### `POST /workspaces/{workspace_id}/memories/evolutions/{draft_id}:reject`
 

--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -4056,7 +4056,7 @@ Router: `src/relay_teams/interfaces/server/routers/guardrails_router.py`
 
 ## Memory Bank APIs
 
-Structured Memory Bank entries with three tiers (`working`, `medium_term`, `persistent`), three scopes (`workspace`, `session`, `role`), typed content, tags, confidence, consolidation, and search. The legacy role-memory endpoints were removed; subagent panels and the global Memory page read from these endpoints.
+Structured Memory Bank entries with three tiers (`working`, `medium_term`, `persistent`), three scopes (`workspace`, `session`, `role`), typed content, tags, confidence, consolidation, search, and governed promotion into skill drafts. The legacy role-memory endpoints were removed; subagent panels and the global Memory page read from these endpoints.
 
 ### `GET /memories`
 
@@ -4133,6 +4133,64 @@ Request: `CreateMemoryEntryRequest`
 - `expires_at`: optional ISO 8601 expiry timestamp.
 
 Response: `MemoryEntry` (full entry with generated `id`, `version`, timestamps).
+
+### `POST /workspaces/{workspace_id}/memories/evolutions`
+
+Creates a reviewable Memory Bank evolution draft. This does not mutate the
+runtime skill directory.
+
+Request: `CreateMemoryEvolutionDraftRequest`
+- `workspace_id`: path-derived.
+- `source_memory_ids[]`: active Memory Bank entry IDs in the same workspace.
+- `target`: `skill` or `sop_skill`, default `sop_skill`.
+- `skill_id`: target app-scoped skill directory ID.
+- `runtime_name`: runtime skill name written into `SKILL.md`.
+- `description`: optional skill description override.
+- `objective`: optional rendering guidance for the draft body.
+
+Response: `MemoryEvolutionDraft`. Returns `400` for missing, inactive, or
+cross-workspace source memory entries.
+
+### `GET /workspaces/{workspace_id}/memories/evolutions`
+
+Lists Memory Bank evolution drafts for one workspace.
+
+Query fields:
+- `target`: optional `skill` or `sop_skill`.
+- `status`: optional `draft`, `applied`, `rejected`, or `superseded`.
+- `limit`: page size `1..100`, default `20`.
+- `offset`: default `0`.
+
+Response: `MemoryEvolutionDraftQueryResult`.
+
+### `GET /workspaces/{workspace_id}/memories/evolutions/{draft_id}`
+
+Returns one Memory Bank evolution draft. Returns `404` when the draft does not
+exist or belongs to another workspace.
+
+### `POST /workspaces/{workspace_id}/memories/evolutions/{draft_id}:apply`
+
+Applies a draft by writing the proposed skill through the app-scoped ClawHub
+skill service and reloading the runtime skill registry.
+
+Request: `ApplyMemoryEvolutionDraftRequest`
+- `skill_id`: optional final skill directory override.
+- `runtime_name`: optional final runtime skill name override.
+- `description`: optional final description override.
+- `instructions`: optional final `SKILL.md` body override.
+
+Response: `MemoryEvolutionDraft` with `status=applied` and `applied_skill_ref`.
+Returns `409` when the draft is no longer in `draft` status.
+
+### `POST /workspaces/{workspace_id}/memories/evolutions/{draft_id}:reject`
+
+Rejects a draft without mutating skills.
+
+Request: `RejectMemoryEvolutionDraftRequest`
+- `reason`: optional rejection reason.
+
+Response: `MemoryEvolutionDraft` with `status=rejected`. Returns `409` when the
+draft is no longer in `draft` status.
 
 ### `GET /workspaces/{workspace_id}/memories/{memory_id}`
 

--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -4196,7 +4196,8 @@ Request: `RejectMemoryEvolutionDraftRequest`
 - `reason`: optional rejection reason.
 
 Response: `MemoryEvolutionDraft` with `status=rejected`. Returns `409` when the
-draft is no longer in `draft` status.
+draft is no longer in `draft` status or another apply/reject request has already
+claimed it.
 
 ### `GET /workspaces/{workspace_id}/memories/{memory_id}`
 

--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -4140,16 +4140,20 @@ Creates a reviewable Memory Bank evolution draft. This does not mutate the
 runtime skill directory.
 
 Request: `CreateMemoryEvolutionDraftRequest`
-- `workspace_id`: path-derived.
+- `workspace_id`: path-derived; clients may omit it from the JSON body.
 - `source_memory_ids[]`: active Memory Bank entry IDs in the same workspace.
 - `target`: `skill` or `sop_skill`, default `sop_skill`.
-- `skill_id`: target app-scoped skill directory ID.
-- `runtime_name`: runtime skill name written into `SKILL.md`.
+- `skill_id`: target app-scoped skill directory ID. Must start with an
+  alphanumeric character and only use letters, digits, dot, underscore, or
+  hyphen.
+- `runtime_name`: runtime skill name written into `SKILL.md`. Uses the same
+  identifier rules as `skill_id`.
 - `description`: optional skill description override.
 - `objective`: optional rendering guidance for the draft body.
 
 Response: `MemoryEvolutionDraft`. Returns `400` for missing, inactive, or
-cross-workspace source memory entries.
+cross-workspace source memory entries. Invalid request identifiers return
+`422`.
 
 ### `GET /workspaces/{workspace_id}/memories/evolutions`
 

--- a/docs/core/database-schema.md
+++ b/docs/core/database-schema.md
@@ -1908,3 +1908,39 @@ Notes:
 - Server startup reindexes active Memory Bank rows into retrieval so migrated
   records are searchable through FTS-backed memory search.
 - Repository: `src/relay_teams/memory/repository.py`
+
+### `memory_evolution_drafts`
+
+```sql
+CREATE TABLE IF NOT EXISTS memory_evolution_drafts (
+    draft_id               TEXT PRIMARY KEY,
+    workspace_id           TEXT NOT NULL,
+    target                 TEXT NOT NULL,
+    status                 TEXT NOT NULL,
+    source_memory_ids_json TEXT NOT NULL,
+    skill_id               TEXT NOT NULL,
+    runtime_name           TEXT NOT NULL,
+    description            TEXT NOT NULL DEFAULT '',
+    instructions           TEXT NOT NULL,
+    applied_skill_ref      TEXT,
+    rejection_reason       TEXT NOT NULL DEFAULT '',
+    created_at             TEXT NOT NULL,
+    updated_at             TEXT NOT NULL,
+    applied_at             TEXT,
+    rejected_at            TEXT
+);
+```
+
+Purpose: reviewable Memory Bank evolution drafts. A draft captures selected
+active memory entries and renders a proposed `SKILL.md` payload before any
+runtime skill directory is mutated.
+
+Notes:
+- `draft_id` is generated as `mem-evo-{uuid_hex}`.
+- `target` is one of: `skill`, `sop_skill`.
+- `status` is one of: `draft`, `applied`, `rejected`, `superseded`.
+- `source_memory_ids_json` stores the ordered source memory IDs used to render
+  the proposal.
+- Applying a draft writes through the app-scoped ClawHub skill service, reloads
+  the runtime skill registry, and records the applied draft and skill ref in
+  source memory metadata.

--- a/docs/modules/memory/memory-bank-architecture.md
+++ b/docs/modules/memory/memory-bank-architecture.md
@@ -145,7 +145,9 @@ conflicting final states for one draft. Apply releases the claim on skill-write
 failure or cancellation, retries final applied-state persistence, and treats
 source-memory metadata tagging as a best-effort follow-up. Tagging patches only
 metadata keys, so concurrent content, tag, status, and scoring edits are not
-overwritten by draft application.
+overwritten by draft application. Applied timestamps are recorded after the
+skill write completes, and source-memory tag patches use their own current
+patch time for recency ordering.
 
 ## API Surface
 

--- a/docs/modules/memory/memory-bank-architecture.md
+++ b/docs/modules/memory/memory-bank-architecture.md
@@ -138,9 +138,10 @@ No background path silently writes skills. Draft application is a user or API
 mutation, and source memory metadata records the applied draft and skill ref.
 Draft creation derives `workspace_id` from the API path and validates the target
 skill identifiers before persisting the draft, so invalid drafts do not fail
-later during skill application. Draft application atomically claims a draft
-before writing the skill, preventing concurrent apply requests from creating
-multiple skill outputs from one draft.
+later during skill application. Draft apply and reject mutations atomically
+claim a draft before persisting the transition or writing the skill, preventing
+concurrent requests from creating multiple skill outputs or reporting
+conflicting final states for one draft.
 
 ## API Surface
 

--- a/docs/modules/memory/memory-bank-architecture.md
+++ b/docs/modules/memory/memory-bank-architecture.md
@@ -136,6 +136,9 @@ select active Memory Bank entries
 
 No background path silently writes skills. Draft application is a user or API
 mutation, and source memory metadata records the applied draft and skill ref.
+Draft creation derives `workspace_id` from the API path and validates the target
+skill identifiers before persisting the draft, so invalid drafts do not fail
+later during skill application.
 
 ## API Surface
 

--- a/docs/modules/memory/memory-bank-architecture.md
+++ b/docs/modules/memory/memory-bank-architecture.md
@@ -11,7 +11,7 @@
 Memory Bank is the durable memory architecture for Relay Teams. It captures
 task results, manual notes, and condensed session context as typed, tagged,
 versioned entries in `memory_entries`, then makes those entries available
-through search and prompt injection.
+through search, prompt injection, and governed capability evolution.
 
 The system is organized as three memory tiers:
 
@@ -20,7 +20,7 @@ capture sources
 -> working memory
 -> medium-term memory
 -> persistent memory
--> search and prompt injection
+-> search, prompt injection, and reviewed skill drafts
 ```
 
 This tiered shape lets short-lived execution observations decay or expire
@@ -45,8 +45,9 @@ keep memory lifecycle explicit.
 
 Entries move through the architecture by consolidation. Runtime task completion
 creates working memory, consolidation can promote useful information into
-medium-term or persistent memory, and retrieval selects active entries for
-Memory page search and `## Project Memory` prompt injection.
+medium-term or persistent memory, retrieval selects active entries for
+Memory page search and `## Project Memory` prompt injection, and selected
+entries can be promoted into reviewable skill or SOP-skill drafts.
 
 ## Goals
 
@@ -54,6 +55,8 @@ Memory page search and `## Project Memory` prompt injection.
 - Support Working, Medium-term, and Persistent memory tiers.
 - Provide query, search, create, update, delete, and consolidation APIs.
 - Inject relevant Memory Bank entries into role prompts as `## Project Memory`.
+- Promote selected memory into draft skills or SOP skills before applying them
+  to the runtime skill registry.
 - Surface a global Memory page in the main frontend feature navigation.
 - Keep session compaction separate from durable memory.
 
@@ -121,6 +124,19 @@ resolve role
 Memory Bank is used before local, ACP, A2A, and CLI runtime dispatch. Adapters
 consume the already-prepared prompt and do not implement their own memory reads.
 
+Capability evolution is explicit and review-first:
+
+```text
+select active Memory Bank entries
+-> create memory_evolution_drafts row
+-> inspect generated skill/SOP draft
+-> apply through ClawHubSkillService.save_skill(...)
+-> reload runtime skill registry
+```
+
+No background path silently writes skills. Draft application is a user or API
+mutation, and source memory metadata records the applied draft and skill ref.
+
 ## API Surface
 
 Global read/search:
@@ -137,6 +153,11 @@ Workspace-scoped operations:
 - `DELETE /api/workspaces/{workspace_id}/memories/{memory_id}`
 - `POST /api/workspaces/{workspace_id}/memories/search`
 - `POST /api/workspaces/{workspace_id}/memories/consolidate`
+- `POST /api/workspaces/{workspace_id}/memories/evolutions`
+- `GET /api/workspaces/{workspace_id}/memories/evolutions`
+- `GET /api/workspaces/{workspace_id}/memories/evolutions/{draft_id}`
+- `POST /api/workspaces/{workspace_id}/memories/evolutions/{draft_id}:apply`
+- `POST /api/workspaces/{workspace_id}/memories/evolutions/{draft_id}:reject`
 
 The frontend Memory page uses the global endpoints for browsing and text search.
 The subagent memory tab uses the workspace list endpoint filtered by
@@ -161,6 +182,8 @@ The Memory page provides:
 - result list with tags and timestamps
 - detail pane for selected entries, including lifecycle fields such as status,
   source, confidence, update time, and expiry
+- controls to draft a skill or SOP skill from a selected active memory entry,
+  then apply the reviewed draft into the app-scoped skill directory
 
 The old subagent UI page for manual role summaries is removed. The subagent
 drawer now shows Memory Bank entries only.
@@ -196,5 +219,7 @@ Required coverage:
 - role prompt injection reads Memory Bank entries
 - global memory list/search endpoints work
 - workspace memory CRUD/search/consolidation endpoints work
+- memory evolution draft APIs create, list, apply, and reject drafts
+- applying a memory evolution draft writes a valid skill and reloads skills
 - subagent UI no longer renders manual summary controls
 - sidebar renders Memory below IM Gateway

--- a/docs/modules/memory/memory-bank-architecture.md
+++ b/docs/modules/memory/memory-bank-architecture.md
@@ -141,7 +141,11 @@ skill identifiers before persisting the draft, so invalid drafts do not fail
 later during skill application. Draft apply and reject mutations atomically
 claim a draft before persisting the transition or writing the skill, preventing
 concurrent requests from creating multiple skill outputs or reporting
-conflicting final states for one draft.
+conflicting final states for one draft. Apply releases the claim on skill-write
+failure or cancellation, retries final applied-state persistence, and treats
+source-memory metadata tagging as a best-effort follow-up. Tagging patches only
+metadata keys, so concurrent content, tag, status, and scoring edits are not
+overwritten by draft application.
 
 ## API Surface
 

--- a/docs/modules/memory/memory-bank-architecture.md
+++ b/docs/modules/memory/memory-bank-architecture.md
@@ -138,7 +138,9 @@ No background path silently writes skills. Draft application is a user or API
 mutation, and source memory metadata records the applied draft and skill ref.
 Draft creation derives `workspace_id` from the API path and validates the target
 skill identifiers before persisting the draft, so invalid drafts do not fail
-later during skill application.
+later during skill application. Draft application atomically claims a draft
+before writing the skill, preventing concurrent apply requests from creating
+multiple skill outputs from one draft.
 
 ## API Surface
 

--- a/frontend/dist/css/components/memory.css
+++ b/frontend/dist/css/components/memory.css
@@ -358,6 +358,61 @@
     color: var(--text-secondary);
 }
 
+.memory-evolution-panel {
+    display: grid;
+    gap: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+    border-radius: 8px;
+    padding: 0.85rem;
+    background: var(--bg-surface-muted);
+}
+
+.memory-evolution-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.65rem;
+}
+
+.memory-evolution-fields label {
+    display: grid;
+    gap: 0.32rem;
+    min-width: 0;
+    color: var(--text-secondary);
+    font-size: 0.76rem;
+}
+
+.memory-evolution-fields input {
+    min-width: 0;
+    height: 34px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 0 0.62rem;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font: inherit;
+}
+
+.memory-evolution-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.memory-evolution-actions .primary-btn,
+.memory-evolution-actions .secondary-btn {
+    min-height: 32px;
+}
+
+.memory-evolution-status {
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    line-height: 1.4;
+}
+
+.memory-evolution-status.is-error {
+    color: var(--danger);
+}
+
 .agent-panel-memory-list {
     display: grid;
     gap: 0.55rem;
@@ -465,6 +520,10 @@
     }
 
     .memory-detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .memory-evolution-fields {
         grid-template-columns: 1fr;
     }
 }

--- a/frontend/dist/js/components/memoryView.js
+++ b/frontend/dist/js/components/memoryView.js
@@ -653,6 +653,18 @@ function bindMemoryEvolutionControls() {
     }
 }
 
+function isSelectedMemoryContext(workspaceId, memoryId) {
+    const selected = memoryState.selectedEntry;
+    return memoryState.selectedId === memoryId
+        && String(selected?.id || '').trim() === memoryId
+        && String(selected?.workspace_id || '').trim() === workspaceId;
+}
+
+function isSelectedDraftContext(workspaceId, memoryId, draftId) {
+    return isSelectedMemoryContext(workspaceId, memoryId)
+        && String(memoryState.evolutionDraft?.draft_id || '').trim() === draftId;
+}
+
 async function createSelectedMemoryEvolutionDraft(target) {
     const entry = memoryState.selectedEntry;
     const workspaceId = String(entry?.workspace_id || '').trim();
@@ -680,6 +692,9 @@ async function createSelectedMemoryEvolutionDraft(target) {
             description: entry.content?.title || '',
             objective: entry.content?.body || '',
         });
+        if (!isSelectedMemoryContext(workspaceId, memoryId)) {
+            return;
+        }
         memoryState = {
             ...memoryState,
             evolutionDraft: draft,
@@ -689,6 +704,9 @@ async function createSelectedMemoryEvolutionDraft(target) {
         };
         renderMemoryContent();
     } catch (error) {
+        if (!isSelectedMemoryContext(workspaceId, memoryId)) {
+            return;
+        }
         memoryState = {
             ...memoryState,
             evolutionBusy: false,
@@ -701,9 +719,11 @@ async function createSelectedMemoryEvolutionDraft(target) {
 
 async function applySelectedMemoryEvolutionDraft() {
     const draft = memoryState.evolutionDraft;
+    const entry = memoryState.selectedEntry;
+    const memoryId = String(entry?.id || '').trim();
     const workspaceId = String(draft?.workspace_id || '').trim();
     const draftId = String(draft?.draft_id || '').trim();
-    if (!workspaceId || !draftId) {
+    if (!workspaceId || !draftId || !memoryId) {
         return;
     }
     memoryState = {
@@ -715,6 +735,9 @@ async function applySelectedMemoryEvolutionDraft() {
     renderMemoryContent();
     try {
         const applied = await applyMemoryEvolutionDraft(workspaceId, draftId, {});
+        if (!isSelectedDraftContext(workspaceId, memoryId, draftId)) {
+            return;
+        }
         memoryState = {
             ...memoryState,
             evolutionDraft: applied,
@@ -724,6 +747,9 @@ async function applySelectedMemoryEvolutionDraft() {
         };
         renderMemoryContent();
     } catch (error) {
+        if (!isSelectedDraftContext(workspaceId, memoryId, draftId)) {
+            return;
+        }
         memoryState = {
             ...memoryState,
             evolutionBusy: false,

--- a/frontend/dist/js/components/memoryView.js
+++ b/frontend/dist/js/components/memoryView.js
@@ -3,6 +3,8 @@
  * Global Memory Bank browser.
  */
 import {
+    applyMemoryEvolutionDraft,
+    createMemoryEvolutionDraft,
     fetchMemories,
     fetchWorkspaces,
     getMemory,
@@ -42,6 +44,10 @@ function createInitialMemoryState() {
         selectedId: '',
         selectedEntry: null,
         selectedLoadingId: '',
+        evolutionDraft: null,
+        evolutionBusy: false,
+        evolutionMessage: '',
+        evolutionError: '',
         loading: false,
         errorMessage: '',
     };
@@ -230,6 +236,10 @@ async function loadSelectedMemory(memoryId, token = memoryRequestToken) {
         selectedEntry: memoryState.selectedEntry?.id === memoryId
             ? memoryState.selectedEntry
             : null,
+        evolutionDraft: null,
+        evolutionBusy: false,
+        evolutionMessage: '',
+        evolutionError: '',
     };
     renderMemoryContent();
     try {
@@ -412,6 +422,7 @@ function renderMemoryContent() {
         </section>
     `;
     bindMemoryRows();
+    bindMemoryEvolutionControls();
 }
 
 function renderMemoryArchitectureMap() {
@@ -570,8 +581,157 @@ function renderMemoryDetail() {
             <div class="memory-detail-tags">
                 ${tags.map(tag => `<span>${escapeHtml(tag)}</span>`).join('')}
             </div>
+            ${renderMemoryEvolutionPanel(entry || summary, content)}
         </article>
     `;
+}
+
+function renderMemoryEvolutionPanel(entry, content) {
+    const workspaceId = String(entry?.workspace_id || '').trim();
+    const memoryId = String(entry?.id || memoryState.selectedId || '').trim();
+    if (!workspaceId || !memoryId) {
+        return '';
+    }
+    const defaults = buildEvolutionDefaults(memoryId, content);
+    const draft = memoryState.evolutionDraft;
+    const draftStatus = String(draft?.status || '').trim();
+    const canApply = draftStatus === 'draft';
+    return `
+        <section class="memory-evolution-panel" data-memory-evolution-panel>
+            <div class="memory-evolution-fields">
+                <label>
+                    <span>${escapeHtml(t('feature.memory.evolution.skill_id'))}</span>
+                    <input type="text" value="${escapeAttribute(defaults.skillId)}" data-memory-evolution-skill-id>
+                </label>
+                <label>
+                    <span>${escapeHtml(t('feature.memory.evolution.runtime_name'))}</span>
+                    <input type="text" value="${escapeAttribute(defaults.runtimeName)}" data-memory-evolution-runtime-name>
+                </label>
+            </div>
+            <div class="memory-evolution-actions">
+                <button class="secondary-btn" type="button" data-memory-evolve-target="skill" ${memoryState.evolutionBusy ? 'disabled' : ''}>
+                    ${escapeHtml(t('feature.memory.evolution.create_skill'))}
+                </button>
+                <button class="secondary-btn" type="button" data-memory-evolve-target="sop_skill" ${memoryState.evolutionBusy ? 'disabled' : ''}>
+                    ${escapeHtml(t('feature.memory.evolution.create_sop'))}
+                </button>
+                ${canApply ? `
+                    <button class="primary-btn" type="button" data-memory-evolution-apply ${memoryState.evolutionBusy ? 'disabled' : ''}>
+                        ${escapeHtml(t('feature.memory.evolution.apply'))}
+                    </button>
+                ` : ''}
+            </div>
+            ${draft ? `
+                <div class="memory-evolution-status">
+                    ${escapeHtml(formatMessage('feature.memory.evolution.draft_status', {
+                        draft: draft.draft_id || '-',
+                        status: formatEnumLabel(draft.status),
+                    }))}
+                </div>
+            ` : ''}
+            ${memoryState.evolutionMessage ? `<div class="memory-evolution-status">${escapeHtml(memoryState.evolutionMessage)}</div>` : ''}
+            ${memoryState.evolutionError ? `<div class="memory-evolution-status is-error">${escapeHtml(memoryState.evolutionError)}</div>` : ''}
+        </section>
+    `;
+}
+
+function bindMemoryEvolutionControls() {
+    const panel = els.projectViewContent.querySelector('[data-memory-evolution-panel]');
+    if (!panel || typeof panel.querySelectorAll !== 'function') {
+        return;
+    }
+    for (const button of panel.querySelectorAll('[data-memory-evolve-target]')) {
+        button.addEventListener('click', () => {
+            const target = String(button.getAttribute('data-memory-evolve-target') || '').trim();
+            void createSelectedMemoryEvolutionDraft(target);
+        });
+    }
+    if (typeof panel.querySelector === 'function') {
+        panel.querySelector('[data-memory-evolution-apply]')?.addEventListener('click', () => {
+            void applySelectedMemoryEvolutionDraft();
+        });
+    }
+}
+
+async function createSelectedMemoryEvolutionDraft(target) {
+    const entry = memoryState.selectedEntry;
+    const workspaceId = String(entry?.workspace_id || '').trim();
+    const memoryId = String(entry?.id || '').trim();
+    if (!workspaceId || !memoryId) {
+        return;
+    }
+    const controls = els.projectViewContent.querySelector('[data-memory-evolution-panel]');
+    const defaults = buildEvolutionDefaults(memoryId, entry.content || {});
+    const skillId = String(controls?.querySelector('[data-memory-evolution-skill-id]')?.value || defaults.skillId).trim();
+    const runtimeName = String(controls?.querySelector('[data-memory-evolution-runtime-name]')?.value || defaults.runtimeName).trim();
+    memoryState = {
+        ...memoryState,
+        evolutionBusy: true,
+        evolutionMessage: '',
+        evolutionError: '',
+    };
+    renderMemoryContent();
+    try {
+        const draft = await createMemoryEvolutionDraft(workspaceId, {
+            source_memory_ids: [memoryId],
+            target,
+            skill_id: skillId,
+            runtime_name: runtimeName,
+            description: entry.content?.title || '',
+            objective: entry.content?.body || '',
+        });
+        memoryState = {
+            ...memoryState,
+            evolutionDraft: draft,
+            evolutionBusy: false,
+            evolutionMessage: t('feature.memory.evolution.created'),
+            evolutionError: '',
+        };
+        renderMemoryContent();
+    } catch (error) {
+        memoryState = {
+            ...memoryState,
+            evolutionBusy: false,
+            evolutionError: String(error?.message || error || ''),
+        };
+        renderMemoryContent();
+        sysLog(`Failed to create memory evolution draft: ${error?.message || error}`, 'log-error');
+    }
+}
+
+async function applySelectedMemoryEvolutionDraft() {
+    const draft = memoryState.evolutionDraft;
+    const workspaceId = String(draft?.workspace_id || '').trim();
+    const draftId = String(draft?.draft_id || '').trim();
+    if (!workspaceId || !draftId) {
+        return;
+    }
+    memoryState = {
+        ...memoryState,
+        evolutionBusy: true,
+        evolutionMessage: '',
+        evolutionError: '',
+    };
+    renderMemoryContent();
+    try {
+        const applied = await applyMemoryEvolutionDraft(workspaceId, draftId, {});
+        memoryState = {
+            ...memoryState,
+            evolutionDraft: applied,
+            evolutionBusy: false,
+            evolutionMessage: t('feature.memory.evolution.applied'),
+            evolutionError: '',
+        };
+        renderMemoryContent();
+    } catch (error) {
+        memoryState = {
+            ...memoryState,
+            evolutionBusy: false,
+            evolutionError: String(error?.message || error || ''),
+        };
+        renderMemoryContent();
+        sysLog(`Failed to apply memory evolution draft: ${error?.message || error}`, 'log-error');
+    }
 }
 
 function renderDetailItem(label, value) {
@@ -581,6 +741,23 @@ function renderDetailItem(label, value) {
             <dd>${escapeHtml(value || '-')}</dd>
         </div>
     `;
+}
+
+function buildEvolutionDefaults(memoryId, content) {
+    const title = String(content?.title || memoryId || 'memory').trim();
+    const slug = slugify(title) || slugify(memoryId) || 'memory-skill';
+    return {
+        skillId: slug.slice(0, 96),
+        runtimeName: slug.slice(0, 96),
+    };
+}
+
+function slugify(value) {
+    return String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .replace(/-{2,}/g, '-');
 }
 
 function formatWorkspaceLabel(workspace) {

--- a/frontend/dist/js/core/api.js
+++ b/frontend/dist/js/core/api.js
@@ -17,6 +17,8 @@ export {
     markSessionTerminalRunViewed,
     updateSessionTopology,
     fetchAgentMessages,
+    applyMemoryEvolutionDraft,
+    createMemoryEvolutionDraft,
     fetchMemories,
     getMemory,
     invalidateMemoryCache,

--- a/frontend/dist/js/core/api/index.js
+++ b/frontend/dist/js/core/api/index.js
@@ -22,6 +22,8 @@ export {
 } from './sessions.js';
 
 export {
+    applyMemoryEvolutionDraft,
+    createMemoryEvolutionDraft,
     fetchMemories,
     getMemory,
     invalidateMemoryCache,

--- a/frontend/dist/js/core/api/memories.js
+++ b/frontend/dist/js/core/api/memories.js
@@ -68,6 +68,38 @@ export async function getMemory(workspaceId, memoryId, options = {}) {
     );
 }
 
+export async function createMemoryEvolutionDraft(workspaceId, payload, options = {}) {
+    const safeWorkspaceId = String(workspaceId || '').trim();
+    return requestJson(
+        `/api/workspaces/${safeWorkspaceId}/memories/evolutions`,
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                ...payload,
+                workspace_id: safeWorkspaceId,
+            }),
+            signal: options.signal,
+        },
+        'Failed to create memory evolution draft',
+    );
+}
+
+export async function applyMemoryEvolutionDraft(workspaceId, draftId, payload = {}, options = {}) {
+    const safeWorkspaceId = String(workspaceId || '').trim();
+    const safeDraftId = String(draftId || '').trim();
+    return requestJson(
+        `/api/workspaces/${safeWorkspaceId}/memories/evolutions/${safeDraftId}:apply`,
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+            signal: options.signal,
+        },
+        'Failed to apply memory evolution draft',
+    );
+}
+
 export function invalidateMemoryCache() {
     invalidateManagedRequests('memories:');
 }

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -2992,7 +2992,7 @@ Object.assign(TRANSLATIONS['en-US'], {
     'feature.memory.arch.capture_sources': 'Task results, manual notes, condensation',
     'feature.memory.arch.consolidation': 'consolidate',
     'feature.memory.arch.reuse': 'Reuse',
-    'feature.memory.arch.reuse_targets': 'Search and prompt injection',
+    'feature.memory.arch.reuse_targets': 'Search, prompt injection, and skills',
     'feature.memory.arch.working.title': 'Working',
     'feature.memory.arch.working.scope': 'Run and task scope',
     'feature.memory.arch.working.ttl': '4h TTL',
@@ -3005,6 +3005,14 @@ Object.assign(TRANSLATIONS['en-US'], {
     'feature.memory.arch.persistent.scope': 'Workspace scope',
     'feature.memory.arch.persistent.ttl': 'no TTL',
     'feature.memory.arch.persistent.copy': 'Long-lived project facts, decisions, and preferences.',
+    'feature.memory.evolution.skill_id': 'Skill ID',
+    'feature.memory.evolution.runtime_name': 'Runtime name',
+    'feature.memory.evolution.create_skill': 'Draft skill',
+    'feature.memory.evolution.create_sop': 'Draft SOP',
+    'feature.memory.evolution.apply': 'Apply',
+    'feature.memory.evolution.created': 'Draft created.',
+    'feature.memory.evolution.applied': 'Draft applied.',
+    'feature.memory.evolution.draft_status': '{draft} is {status}',
 });
 
 Object.assign(TRANSLATIONS['zh-CN'], {
@@ -3392,7 +3400,7 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'feature.memory.arch.capture_sources': '任务结果、手动记录、上下文压缩',
     'feature.memory.arch.consolidation': '沉淀',
     'feature.memory.arch.reuse': '复用',
-    'feature.memory.arch.reuse_targets': '搜索与提示词注入',
+    'feature.memory.arch.reuse_targets': '搜索、提示词注入与技能',
     'feature.memory.arch.working.title': '工作记忆',
     'feature.memory.arch.working.scope': '运行 / 任务范围',
     'feature.memory.arch.working.ttl': '4 小时 TTL',
@@ -3405,6 +3413,14 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'feature.memory.arch.persistent.scope': '工作区范围',
     'feature.memory.arch.persistent.ttl': '无默认过期',
     'feature.memory.arch.persistent.copy': '长期项目事实、决策和偏好。',
+    'feature.memory.evolution.skill_id': '技能 ID',
+    'feature.memory.evolution.runtime_name': '运行时名称',
+    'feature.memory.evolution.create_skill': '生成技能草稿',
+    'feature.memory.evolution.create_sop': '生成 SOP',
+    'feature.memory.evolution.apply': '应用',
+    'feature.memory.evolution.created': '草稿已生成。',
+    'feature.memory.evolution.applied': '草稿已应用。',
+    'feature.memory.evolution.draft_status': '{draft} 当前为 {status}',
 });
 
 Object.assign(TRANSLATIONS['en-US'], {

--- a/src/relay_teams/interfaces/cli/memories_cli.py
+++ b/src/relay_teams/interfaces/cli/memories_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from enum import Enum
 import json
+from urllib.parse import urlencode
 
 import typer
 
@@ -63,11 +64,12 @@ def build_memories_app(
             params["scope"] = scope
         if role_id is not None:
             params["role_id"] = role_id
+        path = _path_with_query(f"/api/workspaces/{workspace_id}/memories", params)
         payload = request_json(
             base_url,
             "GET",
-            f"/api/workspaces/{workspace_id}/memories",
-            params if params else None,
+            path,
+            None,
         )
         response = _require_object_response(
             payload, f"/api/workspaces/{workspace_id}/memories"
@@ -357,11 +359,15 @@ def build_memories_app(
             params["target"] = target
         if status is not None:
             params["status"] = status
+        path = _path_with_query(
+            f"/api/workspaces/{workspace_id}/memories/evolutions",
+            params,
+        )
         payload = request_json(
             base_url,
             "GET",
-            f"/api/workspaces/{workspace_id}/memories/evolutions",
-            params if params else None,
+            path,
+            None,
         )
         response = _require_object_response(
             payload, f"/api/workspaces/{workspace_id}/memories/evolutions"
@@ -494,6 +500,12 @@ def _render_memories_table(payload: dict[str, object]) -> str:
             + score
         )
     return "\n".join(lines)
+
+
+def _path_with_query(path: str, params: dict[str, object]) -> str:
+    if not params:
+        return path
+    return f"{path}?{urlencode(params)}"
 
 
 def _render_entry_detail(payload: dict[str, object]) -> str:

--- a/src/relay_teams/interfaces/cli/memories_cli.py
+++ b/src/relay_teams/interfaces/cli/memories_cli.py
@@ -269,6 +269,191 @@ def build_memories_app(
             f"{response.get('source_entry_count', 0)} source entries examined"
         )
 
+    evolve_app = typer.Typer(
+        no_args_is_help=True,
+        pretty_exceptions_enable=False,
+        help="Promote Memory Bank entries into reviewable capability drafts.",
+    )
+
+    @evolve_app.command("create")
+    def create_evolution_draft(
+        workspace_id: str = typer.Option(..., "--workspace-id"),
+        memory_ids: list[str] = typer.Option(..., "--memory-id"),
+        target: str = typer.Option("sop_skill", "--target"),
+        skill_id: str = typer.Option(..., "--skill-id"),
+        runtime_name: str = typer.Option(..., "--runtime-name"),
+        description: str = typer.Option("", "--description"),
+        objective: str = typer.Option("", "--objective"),
+        output_format: MemoriesOutputFormat = typer.Option(
+            MemoriesOutputFormat.TABLE,
+            "--format",
+            case_sensitive=False,
+        ),
+        base_url: str = typer.Option(default_base_url, "--base-url"),
+        autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
+    ) -> None:
+        auto_start_if_needed(base_url, autostart, daemon, force)
+        body: dict[str, object] = {
+            "workspace_id": workspace_id,
+            "source_memory_ids": memory_ids,
+            "target": target,
+            "skill_id": skill_id,
+            "runtime_name": runtime_name,
+            "description": description,
+            "objective": objective,
+        }
+        payload = request_json(
+            base_url,
+            "POST",
+            f"/api/workspaces/{workspace_id}/memories/evolutions",
+            body,
+        )
+        response = _require_object_response(
+            payload, f"/api/workspaces/{workspace_id}/memories/evolutions"
+        )
+        if output_format == MemoriesOutputFormat.JSON:
+            typer.echo(json.dumps(response, ensure_ascii=False))
+            return
+        typer.echo(f"Created memory evolution draft: {response.get('draft_id', '-')}")
+
+    @evolve_app.command("list")
+    def list_evolution_drafts(
+        workspace_id: str = typer.Option(..., "--workspace-id"),
+        target: str | None = typer.Option(None, "--target"),
+        status: str | None = typer.Option(None, "--status"),
+        output_format: MemoriesOutputFormat = typer.Option(
+            MemoriesOutputFormat.TABLE,
+            "--format",
+            case_sensitive=False,
+        ),
+        base_url: str = typer.Option(default_base_url, "--base-url"),
+        autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
+    ) -> None:
+        auto_start_if_needed(base_url, autostart, daemon, force)
+        params: dict[str, object] = {}
+        if target is not None:
+            params["target"] = target
+        if status is not None:
+            params["status"] = status
+        payload = request_json(
+            base_url,
+            "GET",
+            f"/api/workspaces/{workspace_id}/memories/evolutions",
+            params if params else None,
+        )
+        response = _require_object_response(
+            payload, f"/api/workspaces/{workspace_id}/memories/evolutions"
+        )
+        if output_format == MemoriesOutputFormat.JSON:
+            typer.echo(json.dumps(response, ensure_ascii=False))
+            return
+        typer.echo(_render_evolution_table(response))
+
+    @evolve_app.command("apply")
+    def apply_evolution_draft(
+        workspace_id: str = typer.Option(..., "--workspace-id"),
+        draft_id: str = typer.Option(..., "--draft-id"),
+        output_format: MemoriesOutputFormat = typer.Option(
+            MemoriesOutputFormat.TABLE,
+            "--format",
+            case_sensitive=False,
+        ),
+        base_url: str = typer.Option(default_base_url, "--base-url"),
+        autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
+    ) -> None:
+        auto_start_if_needed(base_url, autostart, daemon, force)
+        payload = request_json(
+            base_url,
+            "POST",
+            f"/api/workspaces/{workspace_id}/memories/evolutions/{draft_id}:apply",
+            {},
+        )
+        response = _require_object_response(
+            payload,
+            f"/api/workspaces/{workspace_id}/memories/evolutions/{draft_id}:apply",
+        )
+        if output_format == MemoriesOutputFormat.JSON:
+            typer.echo(json.dumps(response, ensure_ascii=False))
+            return
+        typer.echo(
+            "Applied memory evolution draft: "
+            f"{response.get('draft_id', '-')} -> {response.get('applied_skill_ref', '-')}"
+        )
+
+    @evolve_app.command("reject")
+    def reject_evolution_draft(
+        workspace_id: str = typer.Option(..., "--workspace-id"),
+        draft_id: str = typer.Option(..., "--draft-id"),
+        reason: str = typer.Option("", "--reason"),
+        output_format: MemoriesOutputFormat = typer.Option(
+            MemoriesOutputFormat.TABLE,
+            "--format",
+            case_sensitive=False,
+        ),
+        base_url: str = typer.Option(default_base_url, "--base-url"),
+        autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
+    ) -> None:
+        auto_start_if_needed(base_url, autostart, daemon, force)
+        payload = request_json(
+            base_url,
+            "POST",
+            f"/api/workspaces/{workspace_id}/memories/evolutions/{draft_id}:reject",
+            {"reason": reason},
+        )
+        response = _require_object_response(
+            payload,
+            f"/api/workspaces/{workspace_id}/memories/evolutions/{draft_id}:reject",
+        )
+        if output_format == MemoriesOutputFormat.JSON:
+            typer.echo(json.dumps(response, ensure_ascii=False))
+            return
+        typer.echo(f"Rejected memory evolution draft: {response.get('draft_id', '-')}")
+
+    memories_app.add_typer(evolve_app, name="evolve")
     return memories_app
 
 
@@ -364,6 +549,43 @@ def _render_search_table(payload: dict[str, object]) -> str:
         snippet = item.get("snippet")
         if isinstance(snippet, str) and snippet:
             lines.append(f"       {snippet[:100]}")
+    return "\n".join(lines)
+
+
+def _render_evolution_table(payload: dict[str, object]) -> str:
+    items = payload.get("items")
+    if not isinstance(items, list) or not items:
+        return "No memory evolution drafts found."
+
+    raw_total = payload.get("total_count", len(items))
+    total_count = (
+        int(str(raw_total)) if isinstance(raw_total, (int, float)) else len(items)
+    )
+    lines = [
+        f"Total: {total_count}",
+        "",
+        "Draft ID".ljust(34)
+        + "Status".ljust(12)
+        + "Target".ljust(12)
+        + "Runtime".ljust(26)
+        + "Skill",
+        "-" * 100,
+    ]
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        draft_id = str(item.get("draft_id", ""))[:32]
+        status = str(item.get("status", ""))[:10]
+        target = str(item.get("target", ""))[:10]
+        runtime_name = str(item.get("runtime_name", ""))[:24]
+        skill_id = str(item.get("skill_id", ""))[:24]
+        lines.append(
+            draft_id.ljust(34)
+            + status.ljust(12)
+            + target.ljust(12)
+            + runtime_name.ljust(26)
+            + skill_id
+        )
     return "\n".join(lines)
 
 

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -111,6 +111,7 @@ from relay_teams.gateway.discord import (
 )
 from relay_teams.memory.repository import MemoryBankRepository
 from relay_teams.memory.service import MemoryBankService
+from relay_teams.memory.evolution_service import MemoryEvolutionService
 from relay_teams.memory.event_handler import MemoryEventHandler
 from relay_teams.logger import get_logger, log_event
 from relay_teams.interfaces.server.config_status_service import ConfigStatusService
@@ -1210,6 +1211,10 @@ class ServerContainer:
             config_dir=app_config_dir,
             on_skill_mutated=self._reload_skills_config,
         )
+        self.memory_evolution_service: MemoryEvolutionService = MemoryEvolutionService(
+            repository=self.memory_bank_repo,
+            skill_service=self.clawhub_skill_service,
+        )
         self._async_closeables: tuple[AsyncCloseableRepository, ...] = (
             self.task_repo,
             self.artifact_repo,
@@ -1622,6 +1627,10 @@ class ServerContainer:
         self.clawhub_skill_service = ClawHubSkillService(
             config_dir=self.runtime.paths.config_dir,
             on_skill_mutated=self._reload_skills_config,
+        )
+        self.memory_evolution_service = MemoryEvolutionService(
+            repository=self.memory_bank_repo,
+            skill_service=self.clawhub_skill_service,
         )
         self._refresh_coordinator_runtime()
         self._refresh_runtime_dependents()

--- a/src/relay_teams/interfaces/server/deps.py
+++ b/src/relay_teams/interfaces/server/deps.py
@@ -48,6 +48,7 @@ from relay_teams.mcp.mcp_service import McpService
 from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.media import MediaAssetService
 from relay_teams.memory.service import MemoryBankService
+from relay_teams.memory.evolution_service import MemoryEvolutionService
 from relay_teams.metrics import MetricsService
 from relay_teams.net.clawhub_connectivity import ClawHubConnectivityProbeService
 from relay_teams.net.github_connectivity import (
@@ -352,3 +353,7 @@ def get_artifact_query_service(request: Request) -> ArtifactQueryService:
 
 def get_memory_bank_service(request: Request) -> MemoryBankService:
     return get_container(request).memory_bank_service
+
+
+def get_memory_evolution_service(request: Request) -> MemoryEvolutionService:
+    return get_container(request).memory_evolution_service

--- a/src/relay_teams/interfaces/server/routers/memories.py
+++ b/src/relay_teams/interfaces/server/routers/memories.py
@@ -3,23 +3,35 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Response
 
-from relay_teams.interfaces.server.deps import get_memory_bank_service
+from relay_teams.interfaces.server.deps import (
+    get_memory_bank_service,
+    get_memory_evolution_service,
+)
 from relay_teams.memory.models import (
+    ApplyMemoryEvolutionDraftRequest,
     CreateMemoryEntryRequest,
+    CreateMemoryEvolutionDraftRequest,
     GlobalMemorySearchRequest,
     MemoryConsolidationRequest,
     MemoryConsolidationResult,
     MemoryEntry,
     MemoryEntryKind,
     MemoryEntryStatus,
+    MemoryEvolutionDraft,
+    MemoryEvolutionDraftQuery,
+    MemoryEvolutionDraftQueryResult,
+    MemoryEvolutionStatus,
+    MemoryEvolutionTarget,
     MemoryQuery,
     MemoryQueryResult,
     MemoryScope,
     MemorySearchRequest,
     MemorySearchResult,
     MemoryTier,
+    RejectMemoryEvolutionDraftRequest,
     UpdateMemoryEntryRequest,
 )
+from relay_teams.memory.evolution_service import MemoryEvolutionService
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.validation import RequiredIdentifierStr
 
@@ -120,6 +132,101 @@ async def create_memory(
 ) -> MemoryEntry:
     patched = body.model_copy(update={"workspace_id": workspace_id})
     return await service.create_entry_async(patched)
+
+
+@router.post(
+    "/workspaces/{workspace_id}/memories/evolutions",
+    response_model=MemoryEvolutionDraft,
+    status_code=201,
+)
+async def create_memory_evolution_draft(
+    workspace_id: RequiredIdentifierStr = Path(),
+    body: CreateMemoryEvolutionDraftRequest = Body(...),
+    service: MemoryEvolutionService = Depends(get_memory_evolution_service),
+) -> MemoryEvolutionDraft:
+    patched = body.model_copy(update={"workspace_id": workspace_id})
+    try:
+        return await service.create_draft_async(patched)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/workspaces/{workspace_id}/memories/evolutions",
+    response_model=MemoryEvolutionDraftQueryResult,
+)
+async def list_memory_evolution_drafts(
+    workspace_id: RequiredIdentifierStr = Path(),
+    target: MemoryEvolutionTarget | None = Query(default=None),
+    status: MemoryEvolutionStatus | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    service: MemoryEvolutionService = Depends(get_memory_evolution_service),
+) -> MemoryEvolutionDraftQueryResult:
+    return await service.list_drafts_async(
+        MemoryEvolutionDraftQuery(
+            workspace_id=workspace_id,
+            target=target,
+            status=status,
+            limit=limit,
+            offset=offset,
+        )
+    )
+
+
+@router.get(
+    "/workspaces/{workspace_id}/memories/evolutions/{draft_id}",
+    response_model=MemoryEvolutionDraft,
+)
+async def get_memory_evolution_draft(
+    workspace_id: RequiredIdentifierStr = Path(),
+    draft_id: RequiredIdentifierStr = Path(),
+    service: MemoryEvolutionService = Depends(get_memory_evolution_service),
+) -> MemoryEvolutionDraft:
+    draft = await service.get_draft_async(workspace_id, draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Memory evolution draft not found")
+    return draft
+
+
+@router.post(
+    "/workspaces/{workspace_id}/memories/evolutions/{draft_id}:apply",
+    response_model=MemoryEvolutionDraft,
+)
+async def apply_memory_evolution_draft(
+    workspace_id: RequiredIdentifierStr = Path(),
+    draft_id: RequiredIdentifierStr = Path(),
+    body: ApplyMemoryEvolutionDraftRequest | None = Body(default=None),
+    service: MemoryEvolutionService = Depends(get_memory_evolution_service),
+) -> MemoryEvolutionDraft:
+    payload = body or ApplyMemoryEvolutionDraftRequest()
+    try:
+        draft = await service.apply_draft_async(workspace_id, draft_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Memory evolution draft not found")
+    return draft
+
+
+@router.post(
+    "/workspaces/{workspace_id}/memories/evolutions/{draft_id}:reject",
+    response_model=MemoryEvolutionDraft,
+)
+async def reject_memory_evolution_draft(
+    workspace_id: RequiredIdentifierStr = Path(),
+    draft_id: RequiredIdentifierStr = Path(),
+    body: RejectMemoryEvolutionDraftRequest | None = Body(default=None),
+    service: MemoryEvolutionService = Depends(get_memory_evolution_service),
+) -> MemoryEvolutionDraft:
+    payload = body or RejectMemoryEvolutionDraftRequest()
+    try:
+        draft = await service.reject_draft_async(workspace_id, draft_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Memory evolution draft not found")
+    return draft
 
 
 @router.get(

--- a/src/relay_teams/interfaces/server/routers/memories.py
+++ b/src/relay_teams/interfaces/server/routers/memories.py
@@ -31,7 +31,10 @@ from relay_teams.memory.models import (
     RejectMemoryEvolutionDraftRequest,
     UpdateMemoryEntryRequest,
 )
-from relay_teams.memory.evolution_service import MemoryEvolutionService
+from relay_teams.memory.evolution_service import (
+    MemoryEvolutionConflictError,
+    MemoryEvolutionService,
+)
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.validation import RequiredIdentifierStr
 
@@ -202,8 +205,10 @@ async def apply_memory_evolution_draft(
     payload = body or ApplyMemoryEvolutionDraftRequest()
     try:
         draft = await service.apply_draft_async(workspace_id, draft_id, payload)
-    except ValueError as exc:
+    except MemoryEvolutionConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if draft is None:
         raise HTTPException(status_code=404, detail="Memory evolution draft not found")
     return draft
@@ -222,8 +227,10 @@ async def reject_memory_evolution_draft(
     payload = body or RejectMemoryEvolutionDraftRequest()
     try:
         draft = await service.reject_draft_async(workspace_id, draft_id, payload)
-    except ValueError as exc:
+    except MemoryEvolutionConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if draft is None:
         raise HTTPException(status_code=404, detail="Memory evolution draft not found")
     return draft

--- a/src/relay_teams/memory/__init__.py
+++ b/src/relay_teams/memory/__init__.py
@@ -18,7 +18,9 @@ from relay_teams.memory.memory_defaults import (
 )
 from relay_teams.memory.models import (
     ConsolidationMode,
+    ApplyMemoryEvolutionDraftRequest,
     CreateMemoryEntryRequest,
+    CreateMemoryEvolutionDraftRequest,
     GlobalMemorySearchRequest,
     MemoryConsolidationRequest,
     MemoryConsolidationResult,
@@ -27,6 +29,11 @@ from relay_teams.memory.models import (
     MemoryEntryKind,
     MemoryEntryStatus,
     MemoryEntrySummary,
+    MemoryEvolutionDraft,
+    MemoryEvolutionDraftQuery,
+    MemoryEvolutionDraftQueryResult,
+    MemoryEvolutionStatus,
+    MemoryEvolutionTarget,
     MemoryQuery,
     MemoryQueryResult,
     MemoryScope,
@@ -35,16 +42,24 @@ from relay_teams.memory.models import (
     MemorySearchResult,
     MemorySourceKind,
     MemoryTier,
+    RejectMemoryEvolutionDraftRequest,
     UpdateMemoryEntryRequest,
 )
 from relay_teams.memory.event_handler import MemoryEventHandler
-from relay_teams.memory.repository import MemoryBankRepository, generate_memory_id
+from relay_teams.memory.evolution_service import MemoryEvolutionService
+from relay_teams.memory.repository import (
+    MemoryBankRepository,
+    generate_memory_evolution_draft_id,
+    generate_memory_id,
+)
 from relay_teams.memory.service import MemoryBankService
 
 __all__ = [
+    "ApplyMemoryEvolutionDraftRequest",
     "ConsolidationMode",
     "MemoryEventHandler",
     "CreateMemoryEntryRequest",
+    "CreateMemoryEvolutionDraftRequest",
     "GlobalMemorySearchRequest",
     "INJECTION_LIMIT",
     "INJECTION_MIN_CONFIDENCE",
@@ -65,6 +80,12 @@ __all__ = [
     "MemoryEntryKind",
     "MemoryEntryStatus",
     "MemoryEntrySummary",
+    "MemoryEvolutionDraft",
+    "MemoryEvolutionDraftQuery",
+    "MemoryEvolutionDraftQueryResult",
+    "MemoryEvolutionService",
+    "MemoryEvolutionStatus",
+    "MemoryEvolutionTarget",
     "MemoryQuery",
     "MemoryQueryResult",
     "MemoryScope",
@@ -74,8 +95,10 @@ __all__ = [
     "MemorySourceKind",
     "MemoryTier",
     "PERSISTENT_DECAY_FACTOR",
+    "RejectMemoryEvolutionDraftRequest",
     "UpdateMemoryEntryRequest",
     "WORKING_DECAY_FACTOR",
     "WORKING_TTL",
+    "generate_memory_evolution_draft_id",
     "generate_memory_id",
 ]

--- a/src/relay_teams/memory/evolution_service.py
+++ b/src/relay_teams/memory/evolution_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from datetime import datetime, timezone
 
 from relay_teams.logger import get_logger
@@ -169,7 +170,7 @@ class MemoryEvolutionService:
         updated = await self._complete_apply_claim_async(applied)
         try:
             await self._mark_source_memories_applied_async(updated)
-        except Exception:
+        except (RuntimeError, sqlite3.Error, ValueError):
             LOGGER.exception(
                 "Failed to tag source memories for Memory Bank evolution draft %s",
                 updated.draft_id,

--- a/src/relay_teams/memory/evolution_service.py
+++ b/src/relay_teams/memory/evolution_service.py
@@ -190,15 +190,16 @@ class MemoryEvolutionService:
             message = f"Memory evolution draft is not rejectable: {draft.status.value}"
             raise MemoryEvolutionConflictError(message)
         now = datetime.now(tz=timezone.utc)
-        rejected = draft.model_copy(
-            update={
-                "status": MemoryEvolutionStatus.REJECTED,
-                "rejection_reason": request.reason.strip(),
-                "updated_at": now,
-                "rejected_at": now,
-            }
+        rejected = await self._repo.claim_evolution_draft_reject_async(
+            draft_id=draft.draft_id,
+            rejection_reason=request.reason.strip(),
+            updated_at=now,
+            rejected_at=now,
         )
-        return await self._repo.update_evolution_draft_async(draft=rejected)
+        if rejected is None:
+            message = "Memory evolution draft is not rejectable: already claimed"
+            raise MemoryEvolutionConflictError(message)
+        return rejected
 
     async def _load_active_source_entries_async(
         self, request: CreateMemoryEvolutionDraftRequest

--- a/src/relay_teams/memory/evolution_service.py
+++ b/src/relay_teams/memory/evolution_service.py
@@ -154,6 +154,7 @@ class MemoryEvolutionService:
         except Exception:
             await self._release_apply_claim_async(draft, reason="save failed")
             raise
+        applied_at = datetime.now(tz=timezone.utc)
         applied_ref = saved.ref or runtime_name
         applied = draft.model_copy(
             update={
@@ -163,11 +164,15 @@ class MemoryEvolutionService:
                 "description": description,
                 "instructions": instructions,
                 "applied_skill_ref": applied_ref,
-                "updated_at": now,
-                "applied_at": now,
+                "updated_at": applied_at,
+                "applied_at": applied_at,
             }
         )
-        updated = await self._complete_apply_claim_async(applied)
+        try:
+            updated = await self._complete_apply_claim_async(applied)
+        except asyncio.CancelledError:
+            await self._finalize_apply_claim_after_cancellation_async(applied)
+            raise
         try:
             await self._mark_source_memories_applied_async(updated)
         except (RuntimeError, sqlite3.Error, ValueError):
@@ -249,7 +254,7 @@ class MemoryEvolutionService:
                 workspace_id=draft.workspace_id,
                 metadata_patch=metadata_patch,
                 metadata_limit=_MAX_MEMORY_METADATA_KEYS,
-                updated_at=draft.updated_at,
+                updated_at=datetime.now(tz=timezone.utc),
             )
             if not patched:
                 LOGGER.warning(
@@ -331,6 +336,18 @@ class MemoryEvolutionService:
             return updated
         message = "Memory evolution draft apply persistence did not complete"
         raise RuntimeError(message)
+
+    async def _finalize_apply_claim_after_cancellation_async(
+        self, draft: MemoryEvolutionDraft
+    ) -> None:
+        try:
+            await asyncio.shield(self._complete_apply_claim_async(draft))
+        except (MemoryEvolutionConflictError, RuntimeError, sqlite3.Error, ValueError):
+            LOGGER.exception(
+                "Failed to finalize Memory Bank evolution draft %s after "
+                "apply cancellation",
+                draft.draft_id,
+            )
 
 
 def _default_description(

--- a/src/relay_teams/memory/evolution_service.py
+++ b/src/relay_teams/memory/evolution_service.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 
 from relay_teams.logger import get_logger
@@ -40,6 +41,11 @@ class MemoryEvolutionService:
     async def create_draft_async(
         self, request: CreateMemoryEvolutionDraftRequest
     ) -> MemoryEvolutionDraft:
+        workspace_id = request.workspace_id.strip()
+        if not workspace_id:
+            message = "workspace_id is required when creating a memory evolution draft"
+            raise ValueError(message)
+        request = request.model_copy(update={"workspace_id": workspace_id})
         source_entries = await self._load_active_source_entries_async(request)
         now = datetime.now(tz=timezone.utc)
         description = request.description.strip() or _default_description(
@@ -56,12 +62,12 @@ class MemoryEvolutionService:
         )
         draft = MemoryEvolutionDraft(
             draft_id=generate_memory_evolution_draft_id(),
-            workspace_id=request.workspace_id,
+            workspace_id=workspace_id,
             source_memory_ids=request.source_memory_ids,
             target=request.target,
             status=MemoryEvolutionStatus.DRAFT,
-            skill_id=request.skill_id.strip(),
-            runtime_name=request.runtime_name.strip(),
+            skill_id=request.skill_id,
+            runtime_name=request.runtime_name,
             description=description,
             instructions=instructions,
             created_at=now,
@@ -116,7 +122,8 @@ class MemoryEvolutionService:
             )
             raise ValueError(message)
 
-        saved = self._skill_service.save_skill(
+        saved = await asyncio.to_thread(
+            self._skill_service.save_skill,
             skill_id,
             ClawHubSkillWriteRequest(
                 runtime_name=runtime_name,

--- a/src/relay_teams/memory/evolution_service.py
+++ b/src/relay_teams/memory/evolution_service.py
@@ -1,0 +1,381 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from relay_teams.logger import get_logger
+from relay_teams.memory.models import (
+    ApplyMemoryEvolutionDraftRequest,
+    CreateMemoryEvolutionDraftRequest,
+    MemoryEntry,
+    MemoryEntryStatus,
+    MemoryEvolutionDraft,
+    MemoryEvolutionDraftQuery,
+    MemoryEvolutionDraftQueryResult,
+    MemoryEvolutionStatus,
+    MemoryEvolutionTarget,
+    RejectMemoryEvolutionDraftRequest,
+)
+from relay_teams.memory.repository import (
+    MemoryBankRepository,
+    generate_memory_evolution_draft_id,
+)
+from relay_teams.skills.clawhub_models import ClawHubSkillWriteRequest
+from relay_teams.skills.clawhub_skill_service import ClawHubSkillService
+
+LOGGER = get_logger(__name__)
+_MAX_MEMORY_METADATA_KEYS = 20
+
+
+class MemoryEvolutionService:
+    def __init__(
+        self,
+        *,
+        repository: MemoryBankRepository,
+        skill_service: ClawHubSkillService,
+    ) -> None:
+        self._repo = repository
+        self._skill_service = skill_service
+
+    async def create_draft_async(
+        self, request: CreateMemoryEvolutionDraftRequest
+    ) -> MemoryEvolutionDraft:
+        source_entries = await self._load_active_source_entries_async(request)
+        now = datetime.now(tz=timezone.utc)
+        description = request.description.strip() or _default_description(
+            target=request.target,
+            runtime_name=request.runtime_name,
+            entries=source_entries,
+        )
+        instructions = _render_skill_instructions(
+            target=request.target,
+            runtime_name=request.runtime_name,
+            description=description,
+            objective=request.objective,
+            entries=source_entries,
+        )
+        draft = MemoryEvolutionDraft(
+            draft_id=generate_memory_evolution_draft_id(),
+            workspace_id=request.workspace_id,
+            source_memory_ids=request.source_memory_ids,
+            target=request.target,
+            status=MemoryEvolutionStatus.DRAFT,
+            skill_id=request.skill_id.strip(),
+            runtime_name=request.runtime_name.strip(),
+            description=description,
+            instructions=instructions,
+            created_at=now,
+            updated_at=now,
+        )
+        return await self._repo.create_evolution_draft_async(draft=draft)
+
+    async def get_draft_async(
+        self, workspace_id: str, draft_id: str
+    ) -> MemoryEvolutionDraft | None:
+        draft = await self._repo.get_evolution_draft_async(draft_id)
+        if draft is None or draft.workspace_id != workspace_id:
+            return None
+        return draft
+
+    async def list_drafts_async(
+        self, query: MemoryEvolutionDraftQuery
+    ) -> MemoryEvolutionDraftQueryResult:
+        return await self._repo.list_evolution_drafts_async(query)
+
+    async def apply_draft_async(
+        self,
+        workspace_id: str,
+        draft_id: str,
+        request: ApplyMemoryEvolutionDraftRequest,
+    ) -> MemoryEvolutionDraft | None:
+        draft = await self.get_draft_async(workspace_id, draft_id)
+        if draft is None:
+            return None
+        if draft.status != MemoryEvolutionStatus.DRAFT:
+            message = f"Memory evolution draft is not applicable: {draft.status.value}"
+            raise ValueError(message)
+
+        now = datetime.now(tz=timezone.utc)
+        skill_id = (request.skill_id or draft.skill_id).strip()
+        runtime_name = (request.runtime_name or draft.runtime_name).strip()
+        description = (
+            draft.description if request.description is None else request.description
+        ).strip()
+        instructions = (
+            draft.instructions if request.instructions is None else request.instructions
+        ).strip()
+        if not description:
+            description = _default_description(
+                target=draft.target,
+                runtime_name=runtime_name,
+                entries=await self._load_source_entries_by_id_async(draft),
+            )
+        if not instructions:
+            message = (
+                "instructions must be non-empty when applying a memory evolution draft"
+            )
+            raise ValueError(message)
+
+        saved = self._skill_service.save_skill(
+            skill_id,
+            ClawHubSkillWriteRequest(
+                runtime_name=runtime_name,
+                description=description,
+                instructions=instructions,
+                files=(),
+            ),
+        )
+        applied_ref = saved.ref or runtime_name
+        applied = draft.model_copy(
+            update={
+                "status": MemoryEvolutionStatus.APPLIED,
+                "skill_id": skill_id,
+                "runtime_name": runtime_name,
+                "description": description,
+                "instructions": instructions,
+                "applied_skill_ref": applied_ref,
+                "updated_at": now,
+                "applied_at": now,
+            }
+        )
+        updated = await self._repo.update_evolution_draft_async(draft=applied)
+        await self._mark_source_memories_applied_async(updated)
+        LOGGER.info(
+            "Applied Memory Bank evolution draft %s as skill %s",
+            updated.draft_id,
+            applied_ref,
+        )
+        return updated
+
+    async def reject_draft_async(
+        self,
+        workspace_id: str,
+        draft_id: str,
+        request: RejectMemoryEvolutionDraftRequest,
+    ) -> MemoryEvolutionDraft | None:
+        draft = await self.get_draft_async(workspace_id, draft_id)
+        if draft is None:
+            return None
+        if draft.status != MemoryEvolutionStatus.DRAFT:
+            message = f"Memory evolution draft is not rejectable: {draft.status.value}"
+            raise ValueError(message)
+        now = datetime.now(tz=timezone.utc)
+        rejected = draft.model_copy(
+            update={
+                "status": MemoryEvolutionStatus.REJECTED,
+                "rejection_reason": request.reason.strip(),
+                "updated_at": now,
+                "rejected_at": now,
+            }
+        )
+        return await self._repo.update_evolution_draft_async(draft=rejected)
+
+    async def _load_active_source_entries_async(
+        self, request: CreateMemoryEvolutionDraftRequest
+    ) -> tuple[MemoryEntry, ...]:
+        entries: list[MemoryEntry] = []
+        for memory_id in request.source_memory_ids:
+            entry = await self._repo.get_by_id_async(memory_id)
+            if entry is None:
+                message = f"Unknown source memory entry: {memory_id}"
+                raise ValueError(message)
+            if entry.workspace_id != request.workspace_id:
+                message = (
+                    f"Source memory entry belongs to a different workspace: {memory_id}"
+                )
+                raise ValueError(message)
+            if entry.status != MemoryEntryStatus.ACTIVE:
+                message = f"Source memory entry is not active: {memory_id}"
+                raise ValueError(message)
+            entries.append(entry)
+        return tuple(entries)
+
+    async def _load_source_entries_by_id_async(
+        self, draft: MemoryEvolutionDraft
+    ) -> tuple[MemoryEntry, ...]:
+        entries: list[MemoryEntry] = []
+        for memory_id in draft.source_memory_ids:
+            entry = await self._repo.get_by_id_async(memory_id)
+            if entry is not None and entry.workspace_id == draft.workspace_id:
+                entries.append(entry)
+        return tuple(entries)
+
+    async def _mark_source_memories_applied_async(
+        self, draft: MemoryEvolutionDraft
+    ) -> None:
+        for entry in await self._load_source_entries_by_id_async(draft):
+            metadata = _with_evolution_metadata(entry.metadata, draft)
+            updated_entry = entry.model_copy(
+                update={
+                    "metadata": metadata,
+                    "version": entry.version + 1,
+                    "updated_at": draft.updated_at,
+                }
+            )
+            await self._repo.update_entry_async(entry.id, entry=updated_entry)
+
+
+def _default_description(
+    *,
+    target: MemoryEvolutionTarget,
+    runtime_name: str,
+    entries: tuple[MemoryEntry, ...],
+) -> str:
+    if entries:
+        title = entries[0].content.title.strip()
+        if title:
+            return f"{_target_label(target)} distilled from Memory Bank: {title}"
+    return f"{_target_label(target)} distilled from Memory Bank for {runtime_name}"
+
+
+def _render_skill_instructions(
+    *,
+    target: MemoryEvolutionTarget,
+    runtime_name: str,
+    description: str,
+    objective: str,
+    entries: tuple[MemoryEntry, ...],
+) -> str:
+    if target == MemoryEvolutionTarget.SOP_SKILL:
+        return _render_sop_skill_instructions(
+            runtime_name=runtime_name,
+            description=description,
+            objective=objective,
+            entries=entries,
+        )
+    return _render_general_skill_instructions(
+        runtime_name=runtime_name,
+        description=description,
+        objective=objective,
+        entries=entries,
+    )
+
+
+def _render_general_skill_instructions(
+    *,
+    runtime_name: str,
+    description: str,
+    objective: str,
+    entries: tuple[MemoryEntry, ...],
+) -> str:
+    purpose = objective.strip() or description.strip()
+    return "\n".join(
+        (
+            f"# {runtime_name}",
+            "",
+            "## Purpose",
+            purpose,
+            "",
+            "## Source Memory",
+            _render_source_memory(entries),
+            "",
+            "## Operating Guidance",
+            "- Use this skill when the task matches the source memory context.",
+            "- Apply the captured constraints, decisions, and preferences directly.",
+            "- Prefer current repository evidence when it conflicts with older memory.",
+            "",
+            "## Verification",
+            "- Confirm the final result still satisfies the source memory constraints.",
+            "- Record any new durable lesson back into Memory Bank.",
+        )
+    )
+
+
+def _render_sop_skill_instructions(
+    *,
+    runtime_name: str,
+    description: str,
+    objective: str,
+    entries: tuple[MemoryEntry, ...],
+) -> str:
+    purpose = objective.strip() or description.strip()
+    return "\n".join(
+        (
+            f"# {runtime_name}",
+            "",
+            "## Purpose",
+            purpose,
+            "",
+            "## Preconditions",
+            "- Confirm the current task matches the source memory context.",
+            "- Inspect current repository state before applying remembered guidance.",
+            "- Treat source memory as guidance, not as a substitute for fresh evidence.",
+            "",
+            "## Procedure",
+            "1. Read the relevant task, repository files, and current constraints.",
+            "2. Compare current evidence with the source memory below.",
+            "3. Apply the remembered SOP only where it remains compatible.",
+            "4. Keep implementation changes scoped to the requested outcome.",
+            "5. Update Memory Bank when the SOP needs correction or extension.",
+            "",
+            "## Source Memory",
+            _render_source_memory(entries),
+            "",
+            "## Failure Modes",
+            _render_failure_modes(entries),
+            "",
+            "## Verification",
+            "- Run the smallest relevant checks for the affected behavior.",
+            "- Verify docs, APIs, UI, or runtime prompts are refreshed when contracts change.",
+            "- Report any source-memory conflicts in the final response.",
+        )
+    )
+
+
+def _render_source_memory(entries: tuple[MemoryEntry, ...]) -> str:
+    lines: list[str] = []
+    for index, entry in enumerate(entries, start=1):
+        lines.extend(
+            (
+                f"{index}. {entry.content.title}",
+                f"   - ID: {entry.id}",
+                f"   - Kind: {entry.kind.value}",
+                f"   - Confidence: {entry.confidence_score:.2f}",
+                f"   - Body: {_single_line(entry.content.body)}",
+            )
+        )
+        if entry.content.context:
+            lines.append(f"   - Context: {_single_line(entry.content.context)}")
+        if entry.content.outcome:
+            lines.append(f"   - Outcome: {_single_line(entry.content.outcome)}")
+    return "\n".join(lines) if lines else "- No source memory entries were provided."
+
+
+def _render_failure_modes(entries: tuple[MemoryEntry, ...]) -> str:
+    failure_entries = [
+        entry for entry in entries if entry.kind.value in {"failure_mode", "constraint"}
+    ]
+    if not failure_entries:
+        return "- Do not apply stale memory without checking current repository state."
+    return "\n".join(
+        f"- {_single_line(entry.content.body)}" for entry in failure_entries
+    )
+
+
+def _single_line(value: str) -> str:
+    return " ".join(value.strip().split())
+
+
+def _target_label(target: MemoryEvolutionTarget) -> str:
+    if target == MemoryEvolutionTarget.SOP_SKILL:
+        return "SOP skill"
+    return "Skill"
+
+
+def _with_evolution_metadata(
+    metadata: dict[str, str],
+    draft: MemoryEvolutionDraft,
+) -> dict[str, str]:
+    updated = dict(metadata)
+    updated["evolution_draft_id"] = draft.draft_id
+    updated["evolution_skill_ref"] = draft.applied_skill_ref or draft.runtime_name
+    while len(updated) > _MAX_MEMORY_METADATA_KEYS:
+        removable = sorted(
+            key
+            for key in updated
+            if key not in {"evolution_draft_id", "evolution_skill_ref"}
+        )
+        if not removable:
+            break
+        del updated[removable[0]]
+    return updated

--- a/src/relay_teams/memory/evolution_service.py
+++ b/src/relay_teams/memory/evolution_service.py
@@ -26,6 +26,7 @@ from relay_teams.skills.clawhub_skill_service import ClawHubSkillService
 
 LOGGER = get_logger(__name__)
 _MAX_MEMORY_METADATA_KEYS = 20
+_RECOVERY_ATTEMPTS = 3
 
 
 class MemoryEvolutionConflictError(ValueError):
@@ -146,14 +147,11 @@ class MemoryEvolutionService:
                     files=(),
                 ),
             )
+        except asyncio.CancelledError:
+            await self._release_apply_claim_async(draft, reason="cancelled")
+            raise
         except Exception:
-            reverted = draft.model_copy(
-                update={
-                    "status": MemoryEvolutionStatus.DRAFT,
-                    "updated_at": datetime.now(tz=timezone.utc),
-                }
-            )
-            await self._repo.update_evolution_draft_async(draft=reverted)
+            await self._release_apply_claim_async(draft, reason="save failed")
             raise
         applied_ref = saved.ref or runtime_name
         applied = draft.model_copy(
@@ -168,8 +166,14 @@ class MemoryEvolutionService:
                 "applied_at": now,
             }
         )
-        updated = await self._repo.update_evolution_draft_async(draft=applied)
-        await self._mark_source_memories_applied_async(updated)
+        updated = await self._complete_apply_claim_async(applied)
+        try:
+            await self._mark_source_memories_applied_async(updated)
+        except Exception:
+            LOGGER.exception(
+                "Failed to tag source memories for Memory Bank evolution draft %s",
+                updated.draft_id,
+            )
         LOGGER.info(
             "Applied Memory Bank evolution draft %s as skill %s",
             updated.draft_id,
@@ -234,16 +238,98 @@ class MemoryEvolutionService:
     async def _mark_source_memories_applied_async(
         self, draft: MemoryEvolutionDraft
     ) -> None:
-        for entry in await self._load_source_entries_by_id_async(draft):
-            metadata = _with_evolution_metadata(entry.metadata, draft)
-            updated_entry = entry.model_copy(
-                update={
-                    "metadata": metadata,
-                    "version": entry.version + 1,
-                    "updated_at": draft.updated_at,
-                }
+        metadata_patch = {
+            "evolution_draft_id": draft.draft_id,
+            "evolution_skill_ref": draft.applied_skill_ref or draft.runtime_name,
+        }
+        for memory_id in draft.source_memory_ids:
+            patched = await self._repo.patch_entry_metadata_async(
+                memory_id=memory_id,
+                workspace_id=draft.workspace_id,
+                metadata_patch=metadata_patch,
+                metadata_limit=_MAX_MEMORY_METADATA_KEYS,
+                updated_at=draft.updated_at,
             )
-            await self._repo.update_entry_async(entry.id, entry=updated_entry)
+            if not patched:
+                LOGGER.warning(
+                    "Skipped missing source memory %s while tagging "
+                    "Memory Bank evolution draft %s",
+                    memory_id,
+                    draft.draft_id,
+                )
+
+    async def _release_apply_claim_async(
+        self, draft: MemoryEvolutionDraft, *, reason: str
+    ) -> None:
+        for attempt in range(1, _RECOVERY_ATTEMPTS + 1):
+            try:
+                released = await asyncio.shield(
+                    self._repo.release_evolution_draft_apply_claim_async(
+                        draft_id=draft.draft_id,
+                        updated_at=datetime.now(tz=timezone.utc),
+                    )
+                )
+            except Exception as exc:
+                if attempt == _RECOVERY_ATTEMPTS:
+                    LOGGER.exception(
+                        "Failed to release Memory Bank evolution draft %s "
+                        "after %s attempts during %s",
+                        draft.draft_id,
+                        attempt,
+                        reason,
+                    )
+                    return
+                LOGGER.warning(
+                    "Retrying Memory Bank evolution draft %s claim release "
+                    "after %s failure: %s",
+                    draft.draft_id,
+                    reason,
+                    exc,
+                )
+                await asyncio.sleep(0)
+                continue
+            if not released:
+                LOGGER.warning(
+                    "Memory Bank evolution draft %s apply claim was already "
+                    "moved while handling %s",
+                    draft.draft_id,
+                    reason,
+                )
+            return
+
+    async def _complete_apply_claim_async(
+        self, draft: MemoryEvolutionDraft
+    ) -> MemoryEvolutionDraft:
+        for attempt in range(1, _RECOVERY_ATTEMPTS + 1):
+            try:
+                updated = await self._repo.complete_evolution_draft_apply_async(
+                    draft=draft
+                )
+            except Exception as exc:
+                if attempt == _RECOVERY_ATTEMPTS:
+                    LOGGER.exception(
+                        "Failed to persist applied Memory Bank evolution draft %s "
+                        "after %s attempts",
+                        draft.draft_id,
+                        attempt,
+                    )
+                    raise
+                LOGGER.warning(
+                    "Retrying applied Memory Bank evolution draft %s persistence "
+                    "after failure: %s",
+                    draft.draft_id,
+                    exc,
+                )
+                await asyncio.sleep(0)
+                continue
+            if updated is None:
+                message = (
+                    "Memory evolution draft is not applicable: apply claim was lost"
+                )
+                raise MemoryEvolutionConflictError(message)
+            return updated
+        message = "Memory evolution draft apply persistence did not complete"
+        raise RuntimeError(message)
 
 
 def _default_description(
@@ -391,22 +477,3 @@ def _target_label(target: MemoryEvolutionTarget) -> str:
     if target == MemoryEvolutionTarget.SOP_SKILL:
         return "SOP skill"
     return "Skill"
-
-
-def _with_evolution_metadata(
-    metadata: dict[str, str],
-    draft: MemoryEvolutionDraft,
-) -> dict[str, str]:
-    updated = dict(metadata)
-    updated["evolution_draft_id"] = draft.draft_id
-    updated["evolution_skill_ref"] = draft.applied_skill_ref or draft.runtime_name
-    while len(updated) > _MAX_MEMORY_METADATA_KEYS:
-        removable = sorted(
-            key
-            for key in updated
-            if key not in {"evolution_draft_id", "evolution_skill_ref"}
-        )
-        if not removable:
-            break
-        del updated[removable[0]]
-    return updated

--- a/src/relay_teams/memory/evolution_service.py
+++ b/src/relay_teams/memory/evolution_service.py
@@ -28,6 +28,10 @@ LOGGER = get_logger(__name__)
 _MAX_MEMORY_METADATA_KEYS = 20
 
 
+class MemoryEvolutionConflictError(ValueError):
+    pass
+
+
 class MemoryEvolutionService:
     def __init__(
         self,
@@ -99,9 +103,8 @@ class MemoryEvolutionService:
             return None
         if draft.status != MemoryEvolutionStatus.DRAFT:
             message = f"Memory evolution draft is not applicable: {draft.status.value}"
-            raise ValueError(message)
+            raise MemoryEvolutionConflictError(message)
 
-        now = datetime.now(tz=timezone.utc)
         skill_id = (request.skill_id or draft.skill_id).strip()
         runtime_name = (request.runtime_name or draft.runtime_name).strip()
         description = (
@@ -122,16 +125,36 @@ class MemoryEvolutionService:
             )
             raise ValueError(message)
 
-        saved = await asyncio.to_thread(
-            self._skill_service.save_skill,
-            skill_id,
-            ClawHubSkillWriteRequest(
-                runtime_name=runtime_name,
-                description=description,
-                instructions=instructions,
-                files=(),
-            ),
+        now = datetime.now(tz=timezone.utc)
+        claimed = await self._repo.claim_evolution_draft_apply_async(
+            draft_id=draft.draft_id,
+            updated_at=now,
         )
+        if claimed is None:
+            message = "Memory evolution draft is not applicable: already claimed"
+            raise MemoryEvolutionConflictError(message)
+        draft = claimed
+
+        try:
+            saved = await asyncio.to_thread(
+                self._skill_service.save_skill,
+                skill_id,
+                ClawHubSkillWriteRequest(
+                    runtime_name=runtime_name,
+                    description=description,
+                    instructions=instructions,
+                    files=(),
+                ),
+            )
+        except Exception:
+            reverted = draft.model_copy(
+                update={
+                    "status": MemoryEvolutionStatus.DRAFT,
+                    "updated_at": datetime.now(tz=timezone.utc),
+                }
+            )
+            await self._repo.update_evolution_draft_async(draft=reverted)
+            raise
         applied_ref = saved.ref or runtime_name
         applied = draft.model_copy(
             update={
@@ -165,7 +188,7 @@ class MemoryEvolutionService:
             return None
         if draft.status != MemoryEvolutionStatus.DRAFT:
             message = f"Memory evolution draft is not rejectable: {draft.status.value}"
-            raise ValueError(message)
+            raise MemoryEvolutionConflictError(message)
         now = datetime.now(tz=timezone.utc)
         rejected = draft.model_copy(
             update={

--- a/src/relay_teams/memory/models.py
+++ b/src/relay_teams/memory/models.py
@@ -407,3 +407,105 @@ class MemorySearchResult(BaseModel):
 
     items: tuple[MemorySearchHit, ...]
     total_count: int
+
+
+# ---------------------------------------------------------------------------
+# Evolution models
+# ---------------------------------------------------------------------------
+
+
+class MemoryEvolutionTarget(str, Enum):
+    SKILL = "skill"
+    SOP_SKILL = "sop_skill"
+
+
+class MemoryEvolutionStatus(str, Enum):
+    DRAFT = "draft"
+    APPLIED = "applied"
+    REJECTED = "rejected"
+    SUPERSEDED = "superseded"
+
+
+class CreateMemoryEvolutionDraftRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str = Field(min_length=1)
+    source_memory_ids: tuple[str, ...] = Field(min_length=1, max_length=50)
+    target: MemoryEvolutionTarget = MemoryEvolutionTarget.SOP_SKILL
+    skill_id: str = Field(min_length=1, max_length=128)
+    runtime_name: str = Field(min_length=1, max_length=128)
+    description: str = ""
+    objective: str = ""
+
+    @field_validator("source_memory_ids")
+    @classmethod
+    def _validate_source_memory_ids(
+        cls, source_memory_ids: tuple[str, ...]
+    ) -> tuple[str, ...]:
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for memory_id in source_memory_ids:
+            normalized = memory_id.strip()
+            if not normalized:
+                message = "source_memory_ids must contain non-empty values"
+                raise ValueError(message)
+            if normalized in seen:
+                message = f"Duplicate source memory id: {normalized}"
+                raise ValueError(message)
+            seen.add(normalized)
+            cleaned.append(normalized)
+        return tuple(cleaned)
+
+
+class ApplyMemoryEvolutionDraftRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    skill_id: str | None = Field(default=None, min_length=1, max_length=128)
+    runtime_name: str | None = Field(default=None, min_length=1, max_length=128)
+    description: str | None = None
+    instructions: str | None = None
+
+
+class RejectMemoryEvolutionDraftRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str = ""
+
+
+class MemoryEvolutionDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    draft_id: str = Field(min_length=1)
+    workspace_id: str = Field(min_length=1)
+    source_memory_ids: tuple[str, ...] = Field(min_length=1)
+    target: MemoryEvolutionTarget
+    status: MemoryEvolutionStatus = MemoryEvolutionStatus.DRAFT
+    skill_id: str = Field(min_length=1)
+    runtime_name: str = Field(min_length=1)
+    description: str = ""
+    instructions: str = Field(min_length=1)
+    applied_skill_ref: str | None = None
+    rejection_reason: str = ""
+    created_at: datetime
+    updated_at: datetime
+    applied_at: datetime | None = None
+    rejected_at: datetime | None = None
+
+
+class MemoryEvolutionDraftQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str = Field(min_length=1)
+    target: MemoryEvolutionTarget | None = None
+    status: MemoryEvolutionStatus | None = None
+    limit: int = Field(default=20, ge=1, le=100)
+    offset: int = Field(default=0, ge=0)
+
+
+class MemoryEvolutionDraftQueryResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: tuple[MemoryEvolutionDraft, ...]
+    total_count: int = Field(ge=0)
+    offset: int
+    limit: int

--- a/src/relay_teams/memory/models.py
+++ b/src/relay_teams/memory/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from enum import Enum
+import re
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -426,10 +427,24 @@ class MemoryEvolutionStatus(str, Enum):
     SUPERSEDED = "superseded"
 
 
+_CLAW_HUB_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _normalize_claw_hub_identifier(value: str, *, field_name: str) -> str:
+    normalized = value.strip()
+    if not _CLAW_HUB_IDENTIFIER_PATTERN.fullmatch(normalized):
+        message = (
+            f"{field_name} must start with an alphanumeric character and only use "
+            "letters, digits, dot, underscore, or hyphen"
+        )
+        raise ValueError(message)
+    return normalized
+
+
 class CreateMemoryEvolutionDraftRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(min_length=1)
+    workspace_id: str = ""
     source_memory_ids: tuple[str, ...] = Field(min_length=1, max_length=50)
     target: MemoryEvolutionTarget = MemoryEvolutionTarget.SOP_SKILL
     skill_id: str = Field(min_length=1, max_length=128)
@@ -456,6 +471,19 @@ class CreateMemoryEvolutionDraftRequest(BaseModel):
             cleaned.append(normalized)
         return tuple(cleaned)
 
+    @field_validator("skill_id")
+    @classmethod
+    def _validate_skill_id(cls, skill_id: str) -> str:
+        return _normalize_claw_hub_identifier(skill_id, field_name="skill_id")
+
+    @field_validator("runtime_name")
+    @classmethod
+    def _validate_runtime_name(cls, runtime_name: str) -> str:
+        return _normalize_claw_hub_identifier(
+            runtime_name,
+            field_name="runtime_name",
+        )
+
 
 class ApplyMemoryEvolutionDraftRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -464,6 +492,26 @@ class ApplyMemoryEvolutionDraftRequest(BaseModel):
     runtime_name: str | None = Field(default=None, min_length=1, max_length=128)
     description: str | None = None
     instructions: str | None = None
+
+    @field_validator("skill_id")
+    @classmethod
+    def _validate_optional_skill_id(cls, skill_id: str | None) -> str | None:
+        if skill_id is None:
+            return None
+        return _normalize_claw_hub_identifier(skill_id, field_name="skill_id")
+
+    @field_validator("runtime_name")
+    @classmethod
+    def _validate_optional_runtime_name(
+        cls,
+        runtime_name: str | None,
+    ) -> str | None:
+        if runtime_name is None:
+            return None
+        return _normalize_claw_hub_identifier(
+            runtime_name,
+            field_name="runtime_name",
+        )
 
 
 class RejectMemoryEvolutionDraftRequest(BaseModel):

--- a/src/relay_teams/memory/models.py
+++ b/src/relay_teams/memory/models.py
@@ -422,6 +422,7 @@ class MemoryEvolutionTarget(str, Enum):
 
 class MemoryEvolutionStatus(str, Enum):
     DRAFT = "draft"
+    APPLYING = "applying"
     APPLIED = "applied"
     REJECTED = "rejected"
     SUPERSEDED = "superseded"

--- a/src/relay_teams/memory/repository.py
+++ b/src/relay_teams/memory/repository.py
@@ -581,6 +581,75 @@ class MemoryBankRepository(SharedSqliteRepository):
             operation=op,
         )
 
+    async def release_evolution_draft_apply_claim_async(
+        self,
+        *,
+        draft_id: str,
+        updated_at: datetime,
+    ) -> bool:
+        async def op(conn: aiosqlite.Connection) -> bool:
+            cursor = await conn.execute(
+                """UPDATE memory_evolution_drafts
+                SET status=?, updated_at=?
+                WHERE draft_id=? AND status=?""",
+                (
+                    MemoryEvolutionStatus.DRAFT.value,
+                    updated_at.isoformat(),
+                    draft_id,
+                    MemoryEvolutionStatus.APPLYING.value,
+                ),
+            )
+            affected = cursor.rowcount
+            await cursor.close()
+            return affected > 0
+
+        return await self._run_async_write(
+            operation_name="release_memory_evolution_draft_apply_claim_async",
+            operation=op,
+        )
+
+    async def complete_evolution_draft_apply_async(
+        self,
+        *,
+        draft: MemoryEvolutionDraft,
+    ) -> MemoryEvolutionDraft | None:
+        async def op(conn: aiosqlite.Connection) -> MemoryEvolutionDraft | None:
+            cursor = await conn.execute(
+                """UPDATE memory_evolution_drafts SET
+                    status=?, skill_id=?, runtime_name=?, description=?,
+                    instructions=?, applied_skill_ref=?, updated_at=?, applied_at=?
+                WHERE draft_id=? AND status=?""",
+                (
+                    MemoryEvolutionStatus.APPLIED.value,
+                    draft.skill_id,
+                    draft.runtime_name,
+                    draft.description,
+                    draft.instructions,
+                    draft.applied_skill_ref,
+                    draft.updated_at.isoformat(),
+                    draft.applied_at.isoformat() if draft.applied_at else None,
+                    draft.draft_id,
+                    MemoryEvolutionStatus.APPLYING.value,
+                ),
+            )
+            affected = cursor.rowcount
+            await cursor.close()
+            if affected == 0:
+                return None
+            row = await async_fetchone(
+                conn,
+                "SELECT * FROM memory_evolution_drafts WHERE draft_id=?",
+                (draft.draft_id,),
+            )
+            if row is None:
+                return None
+            return _row_to_evolution_draft(row)
+
+        return await self._run_async_write(
+            operation_name="complete_memory_evolution_draft_apply_async",
+            operation=op,
+        )
+
     async def claim_evolution_draft_reject_async(
         self,
         *,
@@ -618,6 +687,54 @@ class MemoryBankRepository(SharedSqliteRepository):
 
         return await self._run_async_write(
             operation_name="claim_memory_evolution_draft_reject_async",
+            operation=op,
+        )
+
+    async def patch_entry_metadata_async(
+        self,
+        *,
+        memory_id: str,
+        workspace_id: str,
+        metadata_patch: dict[str, str],
+        metadata_limit: int,
+        updated_at: datetime,
+    ) -> bool:
+        async def op(conn: aiosqlite.Connection) -> bool:
+            row = await async_fetchone(
+                conn,
+                """SELECT metadata_json, version
+                FROM memory_entries
+                WHERE memory_id=? AND workspace_id=?""",
+                (memory_id, workspace_id),
+            )
+            if row is None:
+                return False
+            meta_raw = str(row["metadata_json"])
+            metadata: dict[str, str] = json.loads(meta_raw) if meta_raw else {}
+            metadata.update(metadata_patch)
+            while len(metadata) > metadata_limit:
+                removable = sorted(key for key in metadata if key not in metadata_patch)
+                if not removable:
+                    break
+                del metadata[removable[0]]
+            cursor = await conn.execute(
+                """UPDATE memory_entries
+                SET metadata_json=?, version=?, updated_at=?
+                WHERE memory_id=? AND workspace_id=?""",
+                (
+                    json.dumps(metadata, separators=(",", ":")),
+                    int(row["version"]) + 1,
+                    updated_at.isoformat(),
+                    memory_id,
+                    workspace_id,
+                ),
+            )
+            affected = cursor.rowcount
+            await cursor.close()
+            return affected > 0
+
+        return await self._run_async_write(
+            operation_name="patch_memory_entry_metadata_async",
             operation=op,
         )
 

--- a/src/relay_teams/memory/repository.py
+++ b/src/relay_teams/memory/repository.py
@@ -545,6 +545,42 @@ class MemoryBankRepository(SharedSqliteRepository):
         )
         return draft
 
+    async def claim_evolution_draft_apply_async(
+        self,
+        *,
+        draft_id: str,
+        updated_at: datetime,
+    ) -> MemoryEvolutionDraft | None:
+        async def op(conn: aiosqlite.Connection) -> MemoryEvolutionDraft | None:
+            cursor = await conn.execute(
+                """UPDATE memory_evolution_drafts
+                SET status=?, updated_at=?
+                WHERE draft_id=? AND status=?""",
+                (
+                    MemoryEvolutionStatus.APPLYING.value,
+                    updated_at.isoformat(),
+                    draft_id,
+                    MemoryEvolutionStatus.DRAFT.value,
+                ),
+            )
+            affected = cursor.rowcount
+            await cursor.close()
+            if affected == 0:
+                return None
+            row = await async_fetchone(
+                conn,
+                "SELECT * FROM memory_evolution_drafts WHERE draft_id=?",
+                (draft_id,),
+            )
+            if row is None:
+                return None
+            return _row_to_evolution_draft(row)
+
+        return await self._run_async_write(
+            operation_name="claim_memory_evolution_draft_apply_async",
+            operation=op,
+        )
+
     # ------------------------------------------------------------------
     # Read
     # ------------------------------------------------------------------

--- a/src/relay_teams/memory/repository.py
+++ b/src/relay_teams/memory/repository.py
@@ -16,6 +16,11 @@ from relay_teams.memory.memory_defaults import (
     PERSISTENT_DECAY_FACTOR,
 )
 from relay_teams.memory.models import (
+    MemoryEvolutionDraft,
+    MemoryEvolutionDraftQuery,
+    MemoryEvolutionDraftQueryResult,
+    MemoryEvolutionStatus,
+    MemoryEvolutionTarget,
     MemoryContent,
     MemoryEntry,
     MemoryEntryKind,
@@ -94,6 +99,30 @@ CREATE INDEX IF NOT EXISTS idx_memory_entries_expires
     """\
 CREATE INDEX IF NOT EXISTS idx_memory_entries_source_ref
     ON memory_entries(source_ref)""",
+    """\
+CREATE TABLE IF NOT EXISTS memory_evolution_drafts (
+    draft_id               TEXT PRIMARY KEY,
+    workspace_id           TEXT NOT NULL,
+    target                 TEXT NOT NULL,
+    status                 TEXT NOT NULL,
+    source_memory_ids_json TEXT NOT NULL,
+    skill_id               TEXT NOT NULL,
+    runtime_name           TEXT NOT NULL,
+    description            TEXT NOT NULL DEFAULT '',
+    instructions           TEXT NOT NULL,
+    applied_skill_ref      TEXT,
+    rejection_reason       TEXT NOT NULL DEFAULT '',
+    created_at             TEXT NOT NULL,
+    updated_at             TEXT NOT NULL,
+    applied_at             TEXT,
+    rejected_at            TEXT
+)""",
+    """\
+CREATE INDEX IF NOT EXISTS idx_memory_evolution_drafts_workspace_status
+    ON memory_evolution_drafts(workspace_id, status, updated_at DESC)""",
+    """\
+CREATE INDEX IF NOT EXISTS idx_memory_evolution_drafts_workspace_target
+    ON memory_evolution_drafts(workspace_id, target, updated_at DESC)""",
 ]
 
 
@@ -168,6 +197,35 @@ def _memory_source_from_db(value: object) -> MemorySourceKind:
 def _row_to_summary(row: sqlite3.Row) -> MemoryEntrySummary:
     entry = _row_to_entry(row)
     return _entry_to_summary(entry)
+
+
+def _row_to_evolution_draft(row: sqlite3.Row) -> MemoryEvolutionDraft:
+    source_memory_ids_raw: object = json.loads(str(row["source_memory_ids_json"]))
+    if isinstance(source_memory_ids_raw, list):
+        source_memory_ids = tuple(
+            str(memory_id).strip()
+            for memory_id in source_memory_ids_raw
+            if str(memory_id).strip()
+        )
+    else:
+        source_memory_ids = ()
+    return MemoryEvolutionDraft(
+        draft_id=str(row["draft_id"]),
+        workspace_id=str(row["workspace_id"]),
+        source_memory_ids=source_memory_ids,
+        target=MemoryEvolutionTarget(str(row["target"])),
+        status=MemoryEvolutionStatus(str(row["status"])),
+        skill_id=str(row["skill_id"]),
+        runtime_name=str(row["runtime_name"]),
+        description=str(row["description"]),
+        instructions=str(row["instructions"]),
+        applied_skill_ref=_nullable_str(row["applied_skill_ref"]),
+        rejection_reason=str(row["rejection_reason"]),
+        created_at=_parse_dt(row["created_at"]),
+        updated_at=_parse_dt(row["updated_at"]),
+        applied_at=_parse_dt_or_none(row["applied_at"]),
+        rejected_at=_parse_dt_or_none(row["rejected_at"]),
+    )
 
 
 class MemoryBankRepository(SharedSqliteRepository):
@@ -390,6 +448,102 @@ class MemoryBankRepository(SharedSqliteRepository):
             self._entry_to_params(entry),
         )
         await cursor.close()
+
+    # ------------------------------------------------------------------
+    # Evolution drafts
+    # ------------------------------------------------------------------
+
+    async def create_evolution_draft_async(
+        self, *, draft: MemoryEvolutionDraft
+    ) -> MemoryEvolutionDraft:
+        async def op(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                """INSERT INTO memory_evolution_drafts(
+                    draft_id, workspace_id, target, status, source_memory_ids_json,
+                    skill_id, runtime_name, description, instructions,
+                    applied_skill_ref, rejection_reason, created_at, updated_at,
+                    applied_at, rejected_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                self._evolution_draft_to_params(draft),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="create_memory_evolution_draft_async",
+            operation=op,
+        )
+        return draft
+
+    async def get_evolution_draft_async(
+        self, draft_id: str
+    ) -> MemoryEvolutionDraft | None:
+        async def op(conn: aiosqlite.Connection) -> MemoryEvolutionDraft | None:
+            row = await async_fetchone(
+                conn,
+                "SELECT * FROM memory_evolution_drafts WHERE draft_id=?",
+                (draft_id,),
+            )
+            if row is None:
+                return None
+            return _row_to_evolution_draft(row)
+
+        return await self._run_async_read(op)
+
+    async def list_evolution_drafts_async(
+        self, query: MemoryEvolutionDraftQuery
+    ) -> MemoryEvolutionDraftQueryResult:
+        clauses: list[str] = ["workspace_id = ?"]
+        params: list[object] = [query.workspace_id]
+        if query.target is not None:
+            clauses.append("target = ?")
+            params.append(query.target.value)
+        if query.status is not None:
+            clauses.append("status = ?")
+            params.append(query.status.value)
+        where_sql = "WHERE " + " AND ".join(clauses)
+
+        async def op(conn: aiosqlite.Connection) -> MemoryEvolutionDraftQueryResult:
+            count_row = await async_fetchone(
+                conn,
+                f"SELECT COUNT(*) as cnt FROM memory_evolution_drafts {where_sql}",
+                tuple(params),
+            )
+            total_count = int(count_row["cnt"]) if count_row is not None else 0
+            rows = await async_fetchall(
+                conn,
+                f"SELECT * FROM memory_evolution_drafts {where_sql} "
+                f"ORDER BY updated_at DESC LIMIT ? OFFSET ?",
+                tuple(params) + (query.limit, query.offset),
+            )
+            return MemoryEvolutionDraftQueryResult(
+                items=tuple(_row_to_evolution_draft(row) for row in rows),
+                total_count=total_count,
+                offset=query.offset,
+                limit=query.limit,
+            )
+
+        return await self._run_async_read(op)
+
+    async def update_evolution_draft_async(
+        self, *, draft: MemoryEvolutionDraft
+    ) -> MemoryEvolutionDraft:
+        async def op(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                """UPDATE memory_evolution_drafts SET
+                    workspace_id=?, target=?, status=?, source_memory_ids_json=?,
+                    skill_id=?, runtime_name=?, description=?, instructions=?,
+                    applied_skill_ref=?, rejection_reason=?, created_at=?,
+                    updated_at=?, applied_at=?, rejected_at=?
+                WHERE draft_id=?""",
+                (*self._evolution_draft_to_params(draft)[1:], draft.draft_id),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="update_memory_evolution_draft_async",
+            operation=op,
+        )
+        return draft
 
     # ------------------------------------------------------------------
     # Read
@@ -713,9 +867,36 @@ class MemoryBankRepository(SharedSqliteRepository):
             meta_json,
         )
 
+    @staticmethod
+    def _evolution_draft_to_params(
+        draft: MemoryEvolutionDraft,
+    ) -> tuple[object, ...]:
+        source_ids_json = json.dumps(draft.source_memory_ids, separators=(",", ":"))
+        return (
+            draft.draft_id,
+            draft.workspace_id,
+            draft.target.value,
+            draft.status.value,
+            source_ids_json,
+            draft.skill_id,
+            draft.runtime_name,
+            draft.description,
+            draft.instructions,
+            draft.applied_skill_ref,
+            draft.rejection_reason,
+            draft.created_at.isoformat(),
+            draft.updated_at.isoformat(),
+            draft.applied_at.isoformat() if draft.applied_at else None,
+            draft.rejected_at.isoformat() if draft.rejected_at else None,
+        )
+
 
 def generate_memory_id() -> str:
     return f"{MEMORY_ID_PREFIX}{uuid.uuid4().hex[:24]}"
+
+
+def generate_memory_evolution_draft_id() -> str:
+    return f"mem-evo-{uuid.uuid4().hex[:24]}"
 
 
 def _parse_dt_or_default(value: object) -> datetime:

--- a/src/relay_teams/memory/repository.py
+++ b/src/relay_teams/memory/repository.py
@@ -581,6 +581,46 @@ class MemoryBankRepository(SharedSqliteRepository):
             operation=op,
         )
 
+    async def claim_evolution_draft_reject_async(
+        self,
+        *,
+        draft_id: str,
+        rejection_reason: str,
+        updated_at: datetime,
+        rejected_at: datetime,
+    ) -> MemoryEvolutionDraft | None:
+        async def op(conn: aiosqlite.Connection) -> MemoryEvolutionDraft | None:
+            cursor = await conn.execute(
+                """UPDATE memory_evolution_drafts
+                SET status=?, rejection_reason=?, updated_at=?, rejected_at=?
+                WHERE draft_id=? AND status=?""",
+                (
+                    MemoryEvolutionStatus.REJECTED.value,
+                    rejection_reason,
+                    updated_at.isoformat(),
+                    rejected_at.isoformat(),
+                    draft_id,
+                    MemoryEvolutionStatus.DRAFT.value,
+                ),
+            )
+            affected = cursor.rowcount
+            await cursor.close()
+            if affected == 0:
+                return None
+            row = await async_fetchone(
+                conn,
+                "SELECT * FROM memory_evolution_drafts WHERE draft_id=?",
+                (draft_id,),
+            )
+            if row is None:
+                return None
+            return _row_to_evolution_draft(row)
+
+        return await self._run_async_write(
+            operation_name="claim_memory_evolution_draft_reject_async",
+            operation=op,
+        )
+
     # ------------------------------------------------------------------
     # Read
     # ------------------------------------------------------------------

--- a/src/relay_teams/memory/repository.py
+++ b/src/relay_teams/memory/repository.py
@@ -635,6 +635,21 @@ class MemoryBankRepository(SharedSqliteRepository):
             affected = cursor.rowcount
             await cursor.close()
             if affected == 0:
+                row = await async_fetchone(
+                    conn,
+                    "SELECT * FROM memory_evolution_drafts WHERE draft_id=?",
+                    (draft.draft_id,),
+                )
+                if row is None:
+                    return None
+                existing = _row_to_evolution_draft(row)
+                if (
+                    existing.status == MemoryEvolutionStatus.APPLIED
+                    and existing.skill_id == draft.skill_id
+                    and existing.runtime_name == draft.runtime_name
+                    and existing.applied_skill_ref == draft.applied_skill_ref
+                ):
+                    return existing
                 return None
             row = await async_fetchone(
                 conn,

--- a/tests/unit_tests/frontend/test_memory_view_ui.py
+++ b/tests/unit_tests/frontend/test_memory_view_ui.py
@@ -52,6 +52,23 @@ def test_memory_detail_exposes_lifecycle_fields() -> None:
     assert "function formatExpiry(value)" in source
 
 
+def test_memory_view_exposes_evolution_controls() -> None:
+    source = Path("frontend/dist/js/components/memoryView.js").read_text(
+        encoding="utf-8"
+    )
+    api_source = Path("frontend/dist/js/core/api/memories.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "createMemoryEvolutionDraft" in source
+    assert "applyMemoryEvolutionDraft" in source
+    assert 'data-memory-evolve-target="skill"' in source
+    assert 'data-memory-evolve-target="sop_skill"' in source
+    assert "data-memory-evolution-apply" in source
+    assert "/memories/evolutions" in api_source
+    assert ":apply" in api_source
+
+
 def test_memory_architecture_i18n_keys_exist() -> None:
     source = Path("frontend/dist/js/utils/i18n.js").read_text(encoding="utf-8")
 
@@ -68,6 +85,10 @@ def test_memory_architecture_i18n_keys_exist() -> None:
         "feature.memory.source",
         "feature.memory.expires",
         "feature.memory.no_expiry",
+        "feature.memory.evolution.create_skill",
+        "feature.memory.evolution.create_sop",
+        "feature.memory.evolution.apply",
+        "feature.memory.evolution.draft_status",
     ]:
         assert source.count(f"'{key}'") == 2
 

--- a/tests/unit_tests/frontend/test_memory_view_ui.py
+++ b/tests/unit_tests/frontend/test_memory_view_ui.py
@@ -69,6 +69,17 @@ def test_memory_view_exposes_evolution_controls() -> None:
     assert ":apply" in api_source
 
 
+def test_memory_evolution_ignores_stale_async_responses() -> None:
+    source = Path("frontend/dist/js/components/memoryView.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function isSelectedMemoryContext(workspaceId, memoryId)" in source
+    assert "function isSelectedDraftContext(workspaceId, memoryId, draftId)" in source
+    assert "if (!isSelectedMemoryContext(workspaceId, memoryId))" in source
+    assert "if (!isSelectedDraftContext(workspaceId, memoryId, draftId))" in source
+
+
 def test_memory_architecture_i18n_keys_exist() -> None:
     source = Path("frontend/dist/js/utils/i18n.js").read_text(encoding="utf-8")
 

--- a/tests/unit_tests/frontend/test_project_view_ui.py
+++ b/tests/unit_tests/frontend/test_project_view_ui.py
@@ -7559,6 +7559,40 @@ export async function getMemory() {
     };
 }
 
+export async function createMemoryEvolutionDraft() {
+    return {
+        draft_id: "mem-evo-1",
+        workspace_id: "alpha-project",
+        source_memory_ids: ["mem_1"],
+        target: "sop_skill",
+        status: "draft",
+        skill_id: "memory-entry-sop",
+        runtime_name: "memory-entry-sop",
+        description: "Memory entry",
+        instructions: "# memory-entry-sop",
+        created_at: "2026-05-10T08:00:00Z",
+        updated_at: "2026-05-10T08:00:00Z",
+    };
+}
+
+export async function applyMemoryEvolutionDraft() {
+    return {
+        draft_id: "mem-evo-1",
+        workspace_id: "alpha-project",
+        source_memory_ids: ["mem_1"],
+        target: "sop_skill",
+        status: "applied",
+        skill_id: "memory-entry-sop",
+        runtime_name: "memory-entry-sop",
+        description: "Memory entry",
+        instructions: "# memory-entry-sop",
+        applied_skill_ref: "memory-entry-sop",
+        created_at: "2026-05-10T08:00:00Z",
+        updated_at: "2026-05-10T08:00:00Z",
+        applied_at: "2026-05-10T08:00:01Z",
+    };
+}
+
 export async function fetchConfigStatus() {
     if (globalThis.__deferredConfigStatusPromise) {
         return await globalThis.__deferredConfigStatusPromise;

--- a/tests/unit_tests/interfaces/cli/test_memories_cli.py
+++ b/tests/unit_tests/interfaces/cli/test_memories_cli.py
@@ -51,6 +51,39 @@ class _FakeRequestJson:
         body: dict[str, object] | None,
     ) -> dict[str, object]:
         self.calls.append((base_url, method, path, body))
+        if "/memories/evolutions" in path:
+            if method == "GET" and path.endswith("/evolutions"):
+                return {
+                    "items": [
+                        {
+                            "draft_id": "mem-evo-001",
+                            "status": "draft",
+                            "target": "sop_skill",
+                            "runtime_name": "review-loop-sop",
+                            "skill_id": "review-loop-sop",
+                        }
+                    ],
+                    "total_count": 1,
+                    "offset": 0,
+                    "limit": 20,
+                }
+            status = "applied" if path.endswith(":apply") else "draft"
+            if path.endswith(":reject"):
+                status = "rejected"
+            return {
+                "draft_id": "mem-evo-001",
+                "workspace_id": "ws-1",
+                "source_memory_ids": ["mem-001"],
+                "target": "sop_skill",
+                "status": status,
+                "skill_id": "review-loop-sop",
+                "runtime_name": "review-loop-sop",
+                "description": "Review loop SOP",
+                "instructions": "# review-loop-sop",
+                "applied_skill_ref": "review-loop-sop" if status == "applied" else None,
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            }
         if method == "DELETE":
             return {"ok": True}
         if path.endswith("/consolidate"):
@@ -141,7 +174,15 @@ class TestCommandRegistration:
         result = runner.invoke(cli_app.app, ["memories", "--help"])
         assert result.exit_code == 0
         output = result.output.lower()
-        for cmd in ("list", "get", "create", "delete", "search", "consolidate"):
+        for cmd in (
+            "list",
+            "get",
+            "create",
+            "delete",
+            "search",
+            "consolidate",
+            "evolve",
+        ):
             assert cmd in output
 
     def test_memories_registered_in_main_app(self) -> None:
@@ -443,6 +484,92 @@ class TestConsolidateCommand:
         assert "2 entries created" in r.output
         assert "3 source entries examined" in r.output
         assert fake_req.calls[0][1] == "POST"
+
+
+# ---------------------------------------------------------------------------
+# evolve command
+# ---------------------------------------------------------------------------
+
+
+class TestEvolveCommand:
+    def test_evolve_create_output(self) -> None:
+        app_obj, fake_req, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            [
+                "evolve",
+                "create",
+                "--workspace-id",
+                "ws-1",
+                "--memory-id",
+                "mem-001",
+                "--skill-id",
+                "review-loop-sop",
+                "--runtime-name",
+                "review-loop-sop",
+            ],
+        )
+        assert r.exit_code == 0
+        assert "Created memory evolution draft" in r.output
+        _, method, path, body = fake_req.calls[0]
+        assert method == "POST"
+        assert path == "/api/workspaces/ws-1/memories/evolutions"
+        assert isinstance(body, dict)
+        assert body["source_memory_ids"] == ["mem-001"]
+
+    def test_evolve_list_json_output(self) -> None:
+        app_obj, _, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            ["evolve", "list", "--workspace-id", "ws-1", "--format", "json"],
+        )
+        assert r.exit_code == 0
+        data = json.loads(r.output)
+        assert data["total_count"] == 1
+
+    def test_evolve_apply_output(self) -> None:
+        app_obj, fake_req, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            [
+                "evolve",
+                "apply",
+                "--workspace-id",
+                "ws-1",
+                "--draft-id",
+                "mem-evo-001",
+            ],
+        )
+        assert r.exit_code == 0
+        assert "Applied memory evolution draft" in r.output
+        assert fake_req.calls[0][2].endswith("mem-evo-001:apply")
+
+    def test_evolve_reject_output(self) -> None:
+        app_obj, fake_req, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            [
+                "evolve",
+                "reject",
+                "--workspace-id",
+                "ws-1",
+                "--draft-id",
+                "mem-evo-001",
+                "--reason",
+                "duplicate",
+            ],
+        )
+        assert r.exit_code == 0
+        assert "Rejected memory evolution draft" in r.output
+        assert fake_req.calls[0][2].endswith("mem-evo-001:reject")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/interfaces/cli/test_memories_cli.py
+++ b/tests/unit_tests/interfaces/cli/test_memories_cli.py
@@ -52,8 +52,9 @@ class _FakeRequestJson:
         body: dict[str, object] | None,
     ) -> dict[str, object]:
         self.calls.append((base_url, method, path, body))
-        if "/memories/evolutions" in path:
-            if method == "GET" and path.endswith("/evolutions"):
+        normalized_path = path.split("?", maxsplit=1)[0]
+        if "/memories/evolutions" in normalized_path:
+            if method == "GET" and normalized_path.endswith("/evolutions"):
                 return {
                     "items": [
                         {
@@ -87,14 +88,14 @@ class _FakeRequestJson:
             }
         if method == "DELETE":
             return {"ok": True}
-        if path.endswith("/consolidate"):
+        if normalized_path.endswith("/consolidate"):
             return {
                 "source_entry_count": 3,
                 "consolidated_entry_count": 2,
                 "superseded_entry_ids": ("mem-a", "mem-b"),
                 "new_entry_ids": ("mem-c", "mem-d"),
             }
-        if method == "POST" and path.endswith("/memories"):
+        if method == "POST" and normalized_path.endswith("/memories"):
             # Create endpoint returns a single entry
             return {
                 "id": "mem-new01",
@@ -111,7 +112,11 @@ class _FakeRequestJson:
                 "tags": [],
                 "content": {"title": "Created", "body": "Created body"},
             }
-        if method == "GET" and "/memories/" in path and path.count("/") == 5:
+        if (
+            method == "GET"
+            and "/memories/" in normalized_path
+            and normalized_path.count("/") == 5
+        ):
             # Single-entry GET
             return {
                 "id": "mem-det01",
@@ -239,9 +244,11 @@ class TestListCommand:
             ],
         )
         assert r.exit_code == 0
-        _, _, _, body = fake_req.calls[0]
-        # request_json sends query params via the body dict for GET
-        assert body is not None
+        _, _, path, body = fake_req.calls[0]
+        assert body is None
+        assert "tier=persistent" in path
+        assert "scope=workspace" in path
+        assert "role_id=role-1" in path
 
 
 # ---------------------------------------------------------------------------
@@ -568,10 +575,10 @@ class TestEvolveCommand:
         assert "mem-evo-001" in r.output
         _, method, path, body = fake_req.calls[0]
         assert method == "GET"
-        assert path == "/api/workspaces/ws-1/memories/evolutions"
-        assert isinstance(body, dict)
-        assert body["target"] == "sop_skill"
-        assert body["status"] == "draft"
+        assert path.startswith("/api/workspaces/ws-1/memories/evolutions?")
+        assert body is None
+        assert "target=sop_skill" in path
+        assert "status=draft" in path
 
     def test_evolve_list_json_output(self) -> None:
         app_obj, _, _ = _build_app()

--- a/tests/unit_tests/interfaces/cli/test_memories_cli.py
+++ b/tests/unit_tests/interfaces/cli/test_memories_cli.py
@@ -11,6 +11,7 @@ from relay_teams.interfaces.cli import app as cli_app
 from relay_teams.interfaces.cli.memories_cli import (
     MemoriesOutputFormat,
     _render_entry_detail,
+    _render_evolution_table,
     _render_memories_table,
     _render_search_table,
     _require_object_response,
@@ -519,6 +520,59 @@ class TestEvolveCommand:
         assert isinstance(body, dict)
         assert body["source_memory_ids"] == ["mem-001"]
 
+    def test_evolve_create_json_output(self) -> None:
+        app_obj, _, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            [
+                "evolve",
+                "create",
+                "--workspace-id",
+                "ws-1",
+                "--memory-id",
+                "mem-001",
+                "--skill-id",
+                "review-loop-sop",
+                "--runtime-name",
+                "review-loop-sop",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert r.exit_code == 0
+        data = json.loads(r.output)
+        assert data["draft_id"] == "mem-evo-001"
+
+    def test_evolve_list_table_output_with_filters(self) -> None:
+        app_obj, fake_req, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            [
+                "evolve",
+                "list",
+                "--workspace-id",
+                "ws-1",
+                "--target",
+                "sop_skill",
+                "--status",
+                "draft",
+            ],
+        )
+
+        assert r.exit_code == 0
+        assert "mem-evo-001" in r.output
+        _, method, path, body = fake_req.calls[0]
+        assert method == "GET"
+        assert path == "/api/workspaces/ws-1/memories/evolutions"
+        assert isinstance(body, dict)
+        assert body["target"] == "sop_skill"
+        assert body["status"] == "draft"
+
     def test_evolve_list_json_output(self) -> None:
         app_obj, _, _ = _build_app()
         from typer.testing import CliRunner as _CR
@@ -550,6 +604,29 @@ class TestEvolveCommand:
         assert "Applied memory evolution draft" in r.output
         assert fake_req.calls[0][2].endswith("mem-evo-001:apply")
 
+    def test_evolve_apply_json_output(self) -> None:
+        app_obj, _, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            [
+                "evolve",
+                "apply",
+                "--workspace-id",
+                "ws-1",
+                "--draft-id",
+                "mem-evo-001",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert r.exit_code == 0
+        data = json.loads(r.output)
+        assert data["status"] == "applied"
+        assert data["applied_skill_ref"] == "review-loop-sop"
+
     def test_evolve_reject_output(self) -> None:
         app_obj, fake_req, _ = _build_app()
         from typer.testing import CliRunner as _CR
@@ -570,6 +647,28 @@ class TestEvolveCommand:
         assert r.exit_code == 0
         assert "Rejected memory evolution draft" in r.output
         assert fake_req.calls[0][2].endswith("mem-evo-001:reject")
+
+    def test_evolve_reject_json_output(self) -> None:
+        app_obj, _, _ = _build_app()
+        from typer.testing import CliRunner as _CR
+
+        r = _CR().invoke(
+            app_obj,
+            [
+                "evolve",
+                "reject",
+                "--workspace-id",
+                "ws-1",
+                "--draft-id",
+                "mem-evo-001",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert r.exit_code == 0
+        data = json.loads(r.output)
+        assert data["status"] == "rejected"
 
 
 # ---------------------------------------------------------------------------
@@ -680,6 +779,31 @@ class TestRenderSearchTable:
         assert "Fact about X" in result
         assert "A snippet of text" in result
         assert "Found 1 result" in result
+
+
+class TestRenderEvolutionTable:
+    def test_empty_drafts(self) -> None:
+        result = _render_evolution_table({"items": [], "total_count": 0})
+        assert "No memory evolution drafts found" in result
+
+    def test_with_drafts(self) -> None:
+        payload: dict[str, object] = {
+            "items": [
+                {
+                    "draft_id": "mem-evo-001",
+                    "status": "draft",
+                    "target": "sop_skill",
+                    "runtime_name": "review-loop-sop",
+                    "skill_id": "review-loop-sop",
+                },
+                "unexpected",
+            ],
+            "total_count": 1,
+        }
+        result = _render_evolution_table(payload)
+        assert "Total: 1" in result
+        assert "mem-evo-001" in result
+        assert "review-loop-sop" in result
 
 
 class TestRequireObjectResponse:

--- a/tests/unit_tests/interfaces/server/routers/test_memories.py
+++ b/tests/unit_tests/interfaces/server/routers/test_memories.py
@@ -397,6 +397,52 @@ class TestMemoryEvolutionDrafts:
         call_req = evolution_svc.create_draft_async.call_args[0][0]
         assert call_req.workspace_id == "ws-1"
 
+    def test_create_evolution_draft_allows_path_derived_workspace(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions",
+            json={
+                "source_memory_ids": ["mem-test001"],
+                "target": "sop_skill",
+                "skill_id": "test-sop",
+                "runtime_name": "test-sop",
+            },
+        )
+
+        assert response.status_code == 201
+        call_req = evolution_svc.create_draft_async.call_args[0][0]
+        assert call_req.workspace_id == "ws-1"
+
+    def test_create_evolution_draft_rejects_invalid_skill_id(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions",
+            json={
+                "source_memory_ids": ["mem-test001"],
+                "target": "sop_skill",
+                "skill_id": "   ",
+                "runtime_name": "test-sop",
+            },
+        )
+
+        assert response.status_code == 422
+        evolution_svc.create_draft_async.assert_not_awaited()
+
+    def test_create_evolution_draft_rejects_invalid_runtime_name(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions",
+            json={
+                "source_memory_ids": ["mem-test001"],
+                "target": "sop_skill",
+                "skill_id": "test-sop",
+                "runtime_name": "bad/runtime",
+            },
+        )
+
+        assert response.status_code == 422
+        evolution_svc.create_draft_async.assert_not_awaited()
+
     def test_create_evolution_draft_returns_400_for_service_error(self) -> None:
         client, _, evolution_svc = _client_with_evolution()
         evolution_svc.create_draft_async = AsyncMock(

--- a/tests/unit_tests/interfaces/server/routers/test_memories.py
+++ b/tests/unit_tests/interfaces/server/routers/test_memories.py
@@ -9,6 +9,7 @@ from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
 from relay_teams.interfaces.server.routers.memories import router
+from relay_teams.memory.evolution_service import MemoryEvolutionConflictError
 from relay_teams.memory.models import (
     MemoryContent,
     MemoryConsolidationResult,
@@ -519,7 +520,7 @@ class TestMemoryEvolutionDrafts:
     def test_apply_evolution_draft_returns_409_for_service_error(self) -> None:
         client, _, evolution_svc = _client_with_evolution()
         evolution_svc.apply_draft_async = AsyncMock(
-            side_effect=ValueError("not applicable")
+            side_effect=MemoryEvolutionConflictError("not applicable")
         )
 
         response = client.post(
@@ -529,6 +530,20 @@ class TestMemoryEvolutionDrafts:
 
         assert response.status_code == 409
         assert "not applicable" in response.json()["detail"]
+
+    def test_apply_evolution_draft_returns_400_for_invalid_payload(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.apply_draft_async = AsyncMock(
+            side_effect=ValueError("instructions must be non-empty")
+        )
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:apply",
+            json={},
+        )
+
+        assert response.status_code == 400
+        assert "instructions must be non-empty" in response.json()["detail"]
 
     def test_apply_evolution_draft_returns_404_when_missing(self) -> None:
         client, _, evolution_svc = _client_with_evolution()
@@ -565,7 +580,7 @@ class TestMemoryEvolutionDrafts:
     def test_reject_evolution_draft_returns_409_for_service_error(self) -> None:
         client, _, evolution_svc = _client_with_evolution()
         evolution_svc.reject_draft_async = AsyncMock(
-            side_effect=ValueError("not rejectable")
+            side_effect=MemoryEvolutionConflictError("not rejectable")
         )
 
         response = client.post(
@@ -575,6 +590,20 @@ class TestMemoryEvolutionDrafts:
 
         assert response.status_code == 409
         assert "not rejectable" in response.json()["detail"]
+
+    def test_reject_evolution_draft_returns_400_for_invalid_payload(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.reject_draft_async = AsyncMock(
+            side_effect=ValueError("invalid rejection")
+        )
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:reject",
+            json={},
+        )
+
+        assert response.status_code == 400
+        assert "invalid rejection" in response.json()["detail"]
 
     def test_reject_evolution_draft_returns_404_when_missing(self) -> None:
         client, _, evolution_svc = _client_with_evolution()

--- a/tests/unit_tests/interfaces/server/routers/test_memories.py
+++ b/tests/unit_tests/interfaces/server/routers/test_memories.py
@@ -15,6 +15,10 @@ from relay_teams.memory.models import (
     MemoryEntry,
     MemoryEntryKind,
     MemoryEntryStatus,
+    MemoryEvolutionDraft,
+    MemoryEvolutionDraftQueryResult,
+    MemoryEvolutionStatus,
+    MemoryEvolutionTarget,
     MemoryQueryResult,
     MemoryScope,
     MemorySearchResult,
@@ -57,15 +61,35 @@ def _build_client(service: MemoryBankService) -> TestClient:
     return TestClient(app)
 
 
+def _make_draft(**overrides: object) -> MemoryEvolutionDraft:
+    now = datetime.now(tz=timezone.utc)
+    draft = MemoryEvolutionDraft(
+        draft_id="mem-evo-test001",
+        workspace_id="ws-1",
+        source_memory_ids=("mem-test001",),
+        target=MemoryEvolutionTarget.SOP_SKILL,
+        status=MemoryEvolutionStatus.DRAFT,
+        skill_id="test-sop",
+        runtime_name="test-sop",
+        description="Test SOP",
+        instructions="# test-sop\n\n## Purpose\nTest",
+        created_at=now,
+        updated_at=now,
+    )
+    if overrides:
+        draft = draft.model_copy(update=overrides)
+    return draft
+
+
 # ---------------------------------------------------------------------------
 # Route registration
 # ---------------------------------------------------------------------------
 
 
 class TestRouteRegistration:
-    def test_router_has_nine_routes(self) -> None:
+    def test_router_has_fourteen_routes(self) -> None:
         routes = [r for r in router.routes if isinstance(r, APIRoute)]
-        assert len(routes) == 9
+        assert len(routes) == 14
 
     def test_router_paths_match_spec(self) -> None:
         paths = {r.path for r in router.routes if isinstance(r, APIRoute)}
@@ -73,6 +97,10 @@ class TestRouteRegistration:
         assert "/memories" in paths
         assert "/memories/search" in paths
         assert f"{wid}/memories" in paths
+        assert f"{wid}/memories/evolutions" in paths
+        assert f"{wid}/memories/evolutions/{{draft_id}}" in paths
+        assert f"{wid}/memories/evolutions/{{draft_id}}:apply" in paths
+        assert f"{wid}/memories/evolutions/{{draft_id}}:reject" in paths
         assert f"{wid}/memories/{{memory_id}}" in paths
         assert f"{wid}/memories/consolidate" in paths
         assert f"{wid}/memories/search" in paths
@@ -87,6 +115,15 @@ class TestRouteRegistration:
         assert "POST" in route_map.get("/memories/search", set())
         assert "GET" in route_map.get(f"{wid}/memories", set())
         assert "POST" in route_map.get(f"{wid}/memories", set())
+        assert "GET" in route_map.get(f"{wid}/memories/evolutions", set())
+        assert "POST" in route_map.get(f"{wid}/memories/evolutions", set())
+        assert "GET" in route_map.get(f"{wid}/memories/evolutions/{{draft_id}}", set())
+        assert "POST" in route_map.get(
+            f"{wid}/memories/evolutions/{{draft_id}}:apply", set()
+        )
+        assert "POST" in route_map.get(
+            f"{wid}/memories/evolutions/{{draft_id}}:reject", set()
+        )
         assert "GET" in route_map.get(f"{wid}/memories/{{memory_id}}", set())
         assert "PUT" in route_map.get(f"{wid}/memories/{{memory_id}}", set())
         assert "DELETE" in route_map.get(f"{wid}/memories/{{memory_id}}", set())
@@ -126,16 +163,58 @@ class _FakeMemoryBankService:
         )
 
 
+class _FakeMemoryEvolutionService:
+    def __init__(self) -> None:
+        draft = _make_draft()
+        self.create_draft_async: AsyncMock = AsyncMock(return_value=draft)
+        self.list_drafts_async: AsyncMock = AsyncMock(
+            return_value=MemoryEvolutionDraftQueryResult(
+                items=(draft,),
+                total_count=1,
+                offset=0,
+                limit=20,
+            )
+        )
+        self.get_draft_async: AsyncMock = AsyncMock(return_value=draft)
+        self.apply_draft_async: AsyncMock = AsyncMock(
+            return_value=draft.model_copy(
+                update={
+                    "status": MemoryEvolutionStatus.APPLIED,
+                    "applied_skill_ref": "test-sop",
+                }
+            )
+        )
+        self.reject_draft_async: AsyncMock = AsyncMock(
+            return_value=draft.model_copy(
+                update={"status": MemoryEvolutionStatus.REJECTED}
+            )
+        )
+
+
 def _client() -> tuple[TestClient, _FakeMemoryBankService]:
+    client, svc, _ = _client_with_evolution()
+    return client, svc
+
+
+def _client_with_evolution() -> tuple[
+    TestClient,
+    _FakeMemoryBankService,
+    _FakeMemoryEvolutionService,
+]:
     svc = _FakeMemoryBankService()
+    evolution_svc = _FakeMemoryEvolutionService()
     app = FastAPI()
     app.include_router(router, prefix="/api")
 
     # Override the DI dependency
-    from relay_teams.interfaces.server.deps import get_memory_bank_service
+    from relay_teams.interfaces.server.deps import (
+        get_memory_bank_service,
+        get_memory_evolution_service,
+    )
 
     app.dependency_overrides[get_memory_bank_service] = lambda: svc
-    return TestClient(app), svc
+    app.dependency_overrides[get_memory_evolution_service] = lambda: evolution_svc
+    return TestClient(app), svc, evolution_svc
 
 
 # ---------------------------------------------------------------------------
@@ -293,6 +372,72 @@ class TestCreateMemory:
             },
         )
         assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Memory evolution draft endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryEvolutionDrafts:
+    def test_create_evolution_draft_returns_201(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions",
+            json={
+                "workspace_id": "ws-original",
+                "source_memory_ids": ["mem-test001"],
+                "target": "sop_skill",
+                "skill_id": "test-sop",
+                "runtime_name": "test-sop",
+            },
+        )
+        assert response.status_code == 201
+        evolution_svc.create_draft_async.assert_awaited_once()
+        call_req = evolution_svc.create_draft_async.call_args[0][0]
+        assert call_req.workspace_id == "ws-1"
+
+    def test_list_evolution_drafts_returns_200(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.get(
+            "/api/workspaces/ws-1/memories/evolutions",
+            params={"status": "draft", "target": "sop_skill"},
+        )
+        assert response.status_code == 200
+        evolution_svc.list_drafts_async.assert_awaited_once()
+        call_req = evolution_svc.list_drafts_async.call_args[0][0]
+        assert call_req.status == MemoryEvolutionStatus.DRAFT
+        assert call_req.target == MemoryEvolutionTarget.SOP_SKILL
+
+    def test_get_evolution_draft_returns_200(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.get(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001"
+        )
+        assert response.status_code == 200
+        evolution_svc.get_draft_async.assert_awaited_once_with(
+            "ws-1", "mem-evo-test001"
+        )
+
+    def test_apply_evolution_draft_returns_200(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:apply",
+            json={},
+        )
+        assert response.status_code == 200
+        evolution_svc.apply_draft_async.assert_awaited_once()
+        assert response.json()["status"] == "applied"
+
+    def test_reject_evolution_draft_returns_200(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:reject",
+            json={"reason": "duplicate"},
+        )
+        assert response.status_code == 200
+        evolution_svc.reject_draft_async.assert_awaited_once()
+        assert response.json()["status"] == "rejected"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/interfaces/server/routers/test_memories.py
+++ b/tests/unit_tests/interfaces/server/routers/test_memories.py
@@ -397,6 +397,26 @@ class TestMemoryEvolutionDrafts:
         call_req = evolution_svc.create_draft_async.call_args[0][0]
         assert call_req.workspace_id == "ws-1"
 
+    def test_create_evolution_draft_returns_400_for_service_error(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.create_draft_async = AsyncMock(
+            side_effect=ValueError("Unknown source memory entry")
+        )
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions",
+            json={
+                "workspace_id": "ws-original",
+                "source_memory_ids": ["mem-missing"],
+                "target": "sop_skill",
+                "skill_id": "test-sop",
+                "runtime_name": "test-sop",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "Unknown source memory entry" in response.json()["detail"]
+
     def test_list_evolution_drafts_returns_200(self) -> None:
         client, _, evolution_svc = _client_with_evolution()
         response = client.get(
@@ -419,6 +439,16 @@ class TestMemoryEvolutionDrafts:
             "ws-1", "mem-evo-test001"
         )
 
+    def test_get_evolution_draft_returns_404_when_missing(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.get_draft_async = AsyncMock(return_value=None)
+
+        response = client.get(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-missing"
+        )
+
+        assert response.status_code == 404
+
     def test_apply_evolution_draft_returns_200(self) -> None:
         client, _, evolution_svc = _client_with_evolution()
         response = client.post(
@@ -429,6 +459,42 @@ class TestMemoryEvolutionDrafts:
         evolution_svc.apply_draft_async.assert_awaited_once()
         assert response.json()["status"] == "applied"
 
+    def test_apply_evolution_draft_accepts_empty_body(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:apply"
+        )
+
+        assert response.status_code == 200
+        call_req = evolution_svc.apply_draft_async.call_args[0][2]
+        assert call_req.skill_id is None
+
+    def test_apply_evolution_draft_returns_409_for_service_error(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.apply_draft_async = AsyncMock(
+            side_effect=ValueError("not applicable")
+        )
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:apply",
+            json={},
+        )
+
+        assert response.status_code == 409
+        assert "not applicable" in response.json()["detail"]
+
+    def test_apply_evolution_draft_returns_404_when_missing(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.apply_draft_async = AsyncMock(return_value=None)
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-missing:apply",
+            json={},
+        )
+
+        assert response.status_code == 404
+
     def test_reject_evolution_draft_returns_200(self) -> None:
         client, _, evolution_svc = _client_with_evolution()
         response = client.post(
@@ -438,6 +504,42 @@ class TestMemoryEvolutionDrafts:
         assert response.status_code == 200
         evolution_svc.reject_draft_async.assert_awaited_once()
         assert response.json()["status"] == "rejected"
+
+    def test_reject_evolution_draft_accepts_empty_body(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:reject"
+        )
+
+        assert response.status_code == 200
+        call_req = evolution_svc.reject_draft_async.call_args[0][2]
+        assert call_req.reason == ""
+
+    def test_reject_evolution_draft_returns_409_for_service_error(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.reject_draft_async = AsyncMock(
+            side_effect=ValueError("not rejectable")
+        )
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-test001:reject",
+            json={},
+        )
+
+        assert response.status_code == 409
+        assert "not rejectable" in response.json()["detail"]
+
+    def test_reject_evolution_draft_returns_404_when_missing(self) -> None:
+        client, _, evolution_svc = _client_with_evolution()
+        evolution_svc.reject_draft_async = AsyncMock(return_value=None)
+
+        response = client.post(
+            "/api/workspaces/ws-1/memories/evolutions/mem-evo-missing:reject",
+            json={},
+        )
+
+        assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/memory/test_memory_evolution.py
+++ b/tests/unit_tests/memory/test_memory_evolution.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from relay_teams.memory.evolution_service import MemoryEvolutionService
+from relay_teams.memory.models import (
+    ApplyMemoryEvolutionDraftRequest,
+    CreateMemoryEntryRequest,
+    CreateMemoryEvolutionDraftRequest,
+    MemoryContent,
+    MemoryEntryKind,
+    MemoryEntryStatus,
+    MemoryEvolutionDraftQuery,
+    MemoryEvolutionStatus,
+    MemoryEvolutionTarget,
+    MemoryScope,
+    MemorySourceKind,
+    MemoryTier,
+    RejectMemoryEvolutionDraftRequest,
+    UpdateMemoryEntryRequest,
+)
+from relay_teams.memory.repository import MemoryBankRepository
+from relay_teams.memory.service import MemoryBankService
+from relay_teams.persistence.sqlite_repository import async_fetchone
+from relay_teams.skills.clawhub_skill_service import ClawHubSkillService
+
+pytestmark = pytest.mark.asyncio
+
+
+class _ReloadRecorder:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(self) -> None:
+        self.count += 1
+
+
+async def _create_memory(
+    service: MemoryBankService,
+    *,
+    workspace_id: str = "ws-evo",
+    title: str = "Review loop SOP",
+) -> str:
+    entry = await service.create_entry_async(
+        CreateMemoryEntryRequest(
+            workspace_id=workspace_id,
+            tier=MemoryTier.PERSISTENT,
+            scope=MemoryScope.WORKSPACE,
+            kind=MemoryEntryKind.INSIGHT,
+            content=MemoryContent(
+                title=title,
+                body="Capture useful review feedback as a reusable SOP.",
+            ),
+            source=MemorySourceKind.MANUAL,
+        )
+    )
+    return entry.id
+
+
+def _build_services(
+    tmp_path: Path,
+) -> tuple[MemoryBankService, MemoryEvolutionService, _ReloadRecorder]:
+    repository = MemoryBankRepository(tmp_path / "memory_evolution.db")
+    memory_service = MemoryBankService(repository=repository)
+    reload_recorder = _ReloadRecorder()
+    evolution_service = MemoryEvolutionService(
+        repository=repository,
+        skill_service=ClawHubSkillService(
+            config_dir=tmp_path / "config",
+            on_skill_mutated=reload_recorder,
+        ),
+    )
+    return memory_service, evolution_service, reload_recorder
+
+
+class TestMemoryEvolutionRepository:
+    async def test_schema_is_created(self, tmp_path: Path) -> None:
+        repository = MemoryBankRepository(tmp_path / "schema.db")
+
+        row = await repository._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='memory_evolution_drafts'",
+            )
+        )
+
+        assert row is not None
+
+
+class TestMemoryEvolutionService:
+    async def test_create_draft_from_active_memory(self, tmp_path: Path) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SOP_SKILL,
+                skill_id="review-loop-sop",
+                runtime_name="review-loop-sop",
+            )
+        )
+
+        assert draft.status == MemoryEvolutionStatus.DRAFT
+        assert draft.source_memory_ids == (memory_id,)
+        assert "## Procedure" in draft.instructions
+        assert "## Source Memory" in draft.instructions
+
+        result = await evolution_service.list_drafts_async(
+            MemoryEvolutionDraftQuery(workspace_id="ws-evo")
+        )
+        assert result.total_count == 1
+        assert result.items[0].draft_id == draft.draft_id
+
+    async def test_create_rejects_cross_workspace_memory(self, tmp_path: Path) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service, workspace_id="ws-other")
+
+        with pytest.raises(ValueError, match="different workspace"):
+            await evolution_service.create_draft_async(
+                CreateMemoryEvolutionDraftRequest(
+                    workspace_id="ws-evo",
+                    source_memory_ids=(memory_id,),
+                    target=MemoryEvolutionTarget.SKILL,
+                    skill_id="bad-skill",
+                    runtime_name="bad-skill",
+                )
+            )
+
+    async def test_create_rejects_inactive_memory(self, tmp_path: Path) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        await memory_service.update_entry_async(
+            memory_id,
+            UpdateMemoryEntryRequest(status=MemoryEntryStatus.EXPIRED),
+        )
+
+        with pytest.raises(ValueError, match="not active"):
+            await evolution_service.create_draft_async(
+                CreateMemoryEvolutionDraftRequest(
+                    workspace_id="ws-evo",
+                    source_memory_ids=(memory_id,),
+                    target=MemoryEvolutionTarget.SKILL,
+                    skill_id="expired-skill",
+                    runtime_name="expired-skill",
+                )
+            )
+
+    async def test_apply_draft_writes_skill_and_marks_source_memory(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, reload_recorder = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SOP_SKILL,
+                skill_id="review-loop-sop",
+                runtime_name="review-loop-sop",
+            )
+        )
+
+        applied = await evolution_service.apply_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            ApplyMemoryEvolutionDraftRequest(),
+        )
+
+        assert applied is not None
+        assert applied.status == MemoryEvolutionStatus.APPLIED
+        assert applied.applied_skill_ref == "review-loop-sop"
+        assert reload_recorder.count == 1
+        skill_path = tmp_path / "config" / "skills" / "review-loop-sop" / "SKILL.md"
+        assert skill_path.exists()
+        assert "review-loop-sop" in skill_path.read_text(encoding="utf-8")
+
+        source = await memory_service.get_entry_async(memory_id)
+        assert source is not None
+        assert source.metadata["evolution_draft_id"] == draft.draft_id
+        assert source.metadata["evolution_skill_ref"] == "review-loop-sop"
+
+    async def test_reject_draft_blocks_later_apply(self, tmp_path: Path) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="rejected-skill",
+                runtime_name="rejected-skill",
+            )
+        )
+
+        rejected = await evolution_service.reject_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            RejectMemoryEvolutionDraftRequest(reason="Not useful enough"),
+        )
+
+        assert rejected is not None
+        assert rejected.status == MemoryEvolutionStatus.REJECTED
+        assert rejected.rejection_reason == "Not useful enough"
+        with pytest.raises(ValueError, match="not applicable"):
+            await evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(),
+            )

--- a/tests/unit_tests/memory/test_memory_evolution.py
+++ b/tests/unit_tests/memory/test_memory_evolution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from relay_teams.memory.evolution_service import MemoryEvolutionService
 from relay_teams.memory.models import (
@@ -43,18 +44,26 @@ async def _create_memory(
     *,
     workspace_id: str = "ws-evo",
     title: str = "Review loop SOP",
+    body: str = "Capture useful review feedback as a reusable SOP.",
+    kind: MemoryEntryKind = MemoryEntryKind.INSIGHT,
+    context: str = "",
+    outcome: str = "",
+    metadata: dict[str, str] | None = None,
 ) -> str:
     entry = await service.create_entry_async(
         CreateMemoryEntryRequest(
             workspace_id=workspace_id,
             tier=MemoryTier.PERSISTENT,
             scope=MemoryScope.WORKSPACE,
-            kind=MemoryEntryKind.INSIGHT,
+            kind=kind,
             content=MemoryContent(
                 title=title,
-                body="Capture useful review feedback as a reusable SOP.",
+                body=body,
+                context=context,
+                outcome=outcome,
             ),
             source=MemorySourceKind.MANUAL,
+            metadata=metadata or {},
         )
     )
     return entry.id
@@ -90,6 +99,33 @@ class TestMemoryEvolutionRepository:
 
         assert row is not None
 
+    async def test_get_missing_draft_returns_none(self, tmp_path: Path) -> None:
+        repository = MemoryBankRepository(tmp_path / "missing.db")
+
+        draft = await repository.get_evolution_draft_async("mem-evo-missing")
+
+        assert draft is None
+
+
+class TestMemoryEvolutionModels:
+    async def test_source_memory_ids_reject_blank_values(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty"):
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(" ",),
+                skill_id="review-loop-sop",
+                runtime_name="review-loop-sop",
+            )
+
+    async def test_source_memory_ids_reject_duplicates_after_trim(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate source memory id"):
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=("mem-1", " mem-1 "),
+                skill_id="review-loop-sop",
+                runtime_name="review-loop-sop",
+            )
+
 
 class TestMemoryEvolutionService:
     async def test_create_draft_from_active_memory(self, tmp_path: Path) -> None:
@@ -117,6 +153,55 @@ class TestMemoryEvolutionService:
         assert result.total_count == 1
         assert result.items[0].draft_id == draft.draft_id
 
+    async def test_create_general_skill_includes_context_and_outcome(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(
+            memory_service,
+            title="Testing convention",
+            body="Use focused unit coverage for changed behavior.",
+            context="Memory Bank evolution PR",
+            outcome="CI changed-line coverage stayed above the threshold.",
+        )
+
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="coverage-skill",
+                runtime_name="coverage-skill",
+                objective="Preserve changed-line coverage.",
+            )
+        )
+
+        assert "## Operating Guidance" in draft.instructions
+        assert "Memory Bank evolution PR" in draft.instructions
+        assert "CI changed-line coverage" in draft.instructions
+
+    async def test_create_sop_lists_failure_modes(self, tmp_path: Path) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(
+            memory_service,
+            title="Coverage failure",
+            body="Changed-line coverage can fail after broad API additions.",
+            kind=MemoryEntryKind.FAILURE_MODE,
+        )
+
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SOP_SKILL,
+                skill_id="coverage-failure-sop",
+                runtime_name="coverage-failure-sop",
+            )
+        )
+
+        assert "## Failure Modes" in draft.instructions
+        assert "- Changed-line coverage can fail" in draft.instructions
+
     async def test_create_rejects_cross_workspace_memory(self, tmp_path: Path) -> None:
         memory_service, evolution_service, _ = _build_services(tmp_path)
         memory_id = await _create_memory(memory_service, workspace_id="ws-other")
@@ -129,6 +214,20 @@ class TestMemoryEvolutionService:
                     target=MemoryEvolutionTarget.SKILL,
                     skill_id="bad-skill",
                     runtime_name="bad-skill",
+                )
+            )
+
+    async def test_create_rejects_unknown_memory(self, tmp_path: Path) -> None:
+        _, evolution_service, _ = _build_services(tmp_path)
+
+        with pytest.raises(ValueError, match="Unknown source memory entry"):
+            await evolution_service.create_draft_async(
+                CreateMemoryEvolutionDraftRequest(
+                    workspace_id="ws-evo",
+                    source_memory_ids=("mem-missing",),
+                    target=MemoryEvolutionTarget.SKILL,
+                    skill_id="missing-skill",
+                    runtime_name="missing-skill",
                 )
             )
 
@@ -150,6 +249,76 @@ class TestMemoryEvolutionService:
                     runtime_name="expired-skill",
                 )
             )
+
+    async def test_list_drafts_filters_by_target_and_status(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        sop_draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SOP_SKILL,
+                skill_id="filtered-sop",
+                runtime_name="filtered-sop",
+            )
+        )
+        skill_draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="filtered-skill",
+                runtime_name="filtered-skill",
+            )
+        )
+        await evolution_service.reject_draft_async(
+            "ws-evo",
+            skill_draft.draft_id,
+            RejectMemoryEvolutionDraftRequest(reason="duplicate"),
+        )
+
+        result = await evolution_service.list_drafts_async(
+            MemoryEvolutionDraftQuery(
+                workspace_id="ws-evo",
+                target=MemoryEvolutionTarget.SOP_SKILL,
+                status=MemoryEvolutionStatus.DRAFT,
+            )
+        )
+
+        assert result.total_count == 1
+        assert result.items[0].draft_id == sop_draft.draft_id
+
+    async def test_get_draft_returns_none_for_wrong_workspace(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="workspace-skill",
+                runtime_name="workspace-skill",
+            )
+        )
+
+        assert (
+            await evolution_service.get_draft_async("ws-other", draft.draft_id) is None
+        )
+
+    async def test_apply_returns_none_for_missing_draft(self, tmp_path: Path) -> None:
+        _, evolution_service, _ = _build_services(tmp_path)
+
+        result = await evolution_service.apply_draft_async(
+            "ws-evo",
+            "mem-evo-missing",
+            ApplyMemoryEvolutionDraftRequest(),
+        )
+
+        assert result is None
 
     async def test_apply_draft_writes_skill_and_marks_source_memory(
         self, tmp_path: Path
@@ -185,6 +354,73 @@ class TestMemoryEvolutionService:
         assert source.metadata["evolution_draft_id"] == draft.draft_id
         assert source.metadata["evolution_skill_ref"] == "review-loop-sop"
 
+    async def test_apply_draft_can_default_description_and_trim_source_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        metadata = {f"k{index:02d}": f"v{index:02d}" for index in range(20)}
+        memory_id = await _create_memory(
+            memory_service,
+            metadata=metadata,
+            title="Metadata-heavy SOP",
+        )
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SOP_SKILL,
+                skill_id="metadata-sop",
+                runtime_name="metadata-sop",
+            )
+        )
+
+        applied = await evolution_service.apply_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            ApplyMemoryEvolutionDraftRequest(description=""),
+        )
+
+        assert applied is not None
+        assert applied.description == (
+            "SOP skill distilled from Memory Bank: Metadata-heavy SOP"
+        )
+        source = await memory_service.get_entry_async(memory_id)
+        assert source is not None
+        assert len(source.metadata) == 20
+        assert source.metadata["evolution_draft_id"] == draft.draft_id
+        assert source.metadata["evolution_skill_ref"] == "metadata-sop"
+
+    async def test_apply_draft_rejects_blank_instructions(self, tmp_path: Path) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="blank-instructions",
+                runtime_name="blank-instructions",
+            )
+        )
+
+        with pytest.raises(ValueError, match="instructions must be non-empty"):
+            await evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(instructions=" "),
+            )
+
+    async def test_reject_returns_none_for_missing_draft(self, tmp_path: Path) -> None:
+        _, evolution_service, _ = _build_services(tmp_path)
+
+        result = await evolution_service.reject_draft_async(
+            "ws-evo",
+            "mem-evo-missing",
+            RejectMemoryEvolutionDraftRequest(reason="missing"),
+        )
+
+        assert result is None
+
     async def test_reject_draft_blocks_later_apply(self, tmp_path: Path) -> None:
         memory_service, evolution_service, _ = _build_services(tmp_path)
         memory_id = await _create_memory(memory_service)
@@ -212,4 +448,31 @@ class TestMemoryEvolutionService:
                 "ws-evo",
                 draft.draft_id,
                 ApplyMemoryEvolutionDraftRequest(),
+            )
+
+    async def test_reject_draft_blocks_already_applied_draft(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="applied-skill",
+                runtime_name="applied-skill",
+            )
+        )
+        await evolution_service.apply_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            ApplyMemoryEvolutionDraftRequest(),
+        )
+
+        with pytest.raises(ValueError, match="not rejectable"):
+            await evolution_service.reject_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                RejectMemoryEvolutionDraftRequest(reason="too late"),
             )

--- a/tests/unit_tests/memory/test_memory_evolution.py
+++ b/tests/unit_tests/memory/test_memory_evolution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
+import time
 
 import pytest
 from pydantic import ValidationError
@@ -712,6 +713,95 @@ class TestMemoryEvolutionService:
         assert applied is not None
         assert applied.status == MemoryEvolutionStatus.APPLIED
 
+    async def test_apply_draft_uses_post_save_applied_timestamp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="post-save-time",
+                runtime_name="post-save-time",
+            )
+        )
+        original_save = evolution_service._skill_service.save_skill
+        save_finished_at: datetime | None = None
+
+        def slow_save(
+            skill_id: str, request: ClawHubSkillWriteRequest
+        ) -> ClawHubSkillDetail:
+            nonlocal save_finished_at
+            time.sleep(0.02)
+            saved = original_save(skill_id, request)
+            save_finished_at = datetime.now(tz=timezone.utc)
+            return saved
+
+        monkeypatch.setattr(
+            evolution_service._skill_service,
+            "save_skill",
+            slow_save,
+        )
+
+        applied = await evolution_service.apply_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            ApplyMemoryEvolutionDraftRequest(),
+        )
+
+        assert save_finished_at is not None
+        assert applied is not None
+        assert applied.applied_at is not None
+        assert applied.applied_at >= save_finished_at
+        assert applied.updated_at == applied.applied_at
+
+    async def test_apply_draft_finalizes_claim_when_completion_is_cancelled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="cancelled-complete",
+                runtime_name="cancelled-complete",
+            )
+        )
+        repository = evolution_service._repo
+        original_complete = repository.complete_evolution_draft_apply_async
+        complete_attempts = 0
+
+        async def cancel_first_complete(
+            *, draft: MemoryEvolutionDraft
+        ) -> MemoryEvolutionDraft | None:
+            nonlocal complete_attempts
+            complete_attempts += 1
+            if complete_attempts == 1:
+                raise asyncio.CancelledError
+            return await original_complete(draft=draft)
+
+        monkeypatch.setattr(
+            repository,
+            "complete_evolution_draft_apply_async",
+            cancel_first_complete,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(),
+            )
+
+        reloaded = await evolution_service.get_draft_async("ws-evo", draft.draft_id)
+        assert complete_attempts == 2
+        assert reloaded is not None
+        assert reloaded.status == MemoryEvolutionStatus.APPLIED
+
     async def test_apply_draft_returns_applied_when_source_tagging_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -757,6 +847,60 @@ class TestMemoryEvolutionService:
         assert reloaded.status == MemoryEvolutionStatus.APPLIED
         assert source is not None
         assert "evolution_draft_id" not in source.metadata
+
+    async def test_apply_draft_uses_fresh_source_tag_timestamp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="fresh-tag-time",
+                runtime_name="fresh-tag-time",
+            )
+        )
+        repository = evolution_service._repo
+        original_patch = repository.patch_entry_metadata_async
+        patch_times: list[datetime] = []
+
+        async def record_patch_metadata(
+            *,
+            memory_id: str,
+            workspace_id: str,
+            metadata_patch: dict[str, str],
+            metadata_limit: int,
+            updated_at: datetime,
+        ) -> bool:
+            patch_times.append(updated_at)
+            return await original_patch(
+                memory_id=memory_id,
+                workspace_id=workspace_id,
+                metadata_patch=metadata_patch,
+                metadata_limit=metadata_limit,
+                updated_at=updated_at,
+            )
+
+        monkeypatch.setattr(
+            repository,
+            "patch_entry_metadata_async",
+            record_patch_metadata,
+        )
+
+        applied = await evolution_service.apply_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            ApplyMemoryEvolutionDraftRequest(),
+        )
+
+        source = await memory_service.get_entry_async(memory_id)
+        assert applied is not None
+        assert patch_times
+        assert patch_times[0] > applied.updated_at
+        assert source is not None
+        assert source.updated_at == patch_times[0]
 
     async def test_apply_draft_rejects_blank_instructions(self, tmp_path: Path) -> None:
         memory_service, evolution_service, _ = _build_services(tmp_path)

--- a/tests/unit_tests/memory/test_memory_evolution.py
+++ b/tests/unit_tests/memory/test_memory_evolution.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,10 @@ from relay_teams.memory.models import (
 from relay_teams.memory.repository import MemoryBankRepository
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence.sqlite_repository import async_fetchone
+from relay_teams.skills.clawhub_models import (
+    ClawHubSkillDetail,
+    ClawHubSkillWriteRequest,
+)
 from relay_teams.skills.clawhub_skill_service import ClawHubSkillService
 
 pytestmark = pytest.mark.asyncio
@@ -110,6 +115,42 @@ class TestMemoryEvolutionRepository:
         draft = await repository.get_evolution_draft_async("mem-evo-missing")
 
         assert draft is None
+
+    async def test_patch_entry_metadata_preserves_other_fields(
+        self, tmp_path: Path
+    ) -> None:
+        repository = MemoryBankRepository(tmp_path / "metadata_patch.db")
+        service = MemoryBankService(repository=repository)
+        memory_id = await _create_memory(
+            service,
+            title="Original title",
+            body="Original body",
+            metadata={f"key-{index:02d}": str(index) for index in range(20)},
+        )
+        before = await service.get_entry_async(memory_id)
+        assert before is not None
+
+        patched = await repository.patch_entry_metadata_async(
+            memory_id=memory_id,
+            workspace_id="ws-evo",
+            metadata_patch={
+                "evolution_draft_id": "mem-evo-patched",
+                "evolution_skill_ref": "patched-skill",
+            },
+            metadata_limit=20,
+            updated_at=datetime.now(tz=timezone.utc),
+        )
+
+        after = await service.get_entry_async(memory_id)
+        assert patched is True
+        assert after is not None
+        assert after.content == before.content
+        assert after.tags == before.tags
+        assert after.status == before.status
+        assert after.version == before.version + 1
+        assert len(after.metadata) == 20
+        assert after.metadata["evolution_draft_id"] == "mem-evo-patched"
+        assert after.metadata["evolution_skill_ref"] == "patched-skill"
 
 
 class TestMemoryEvolutionModels:
@@ -537,6 +578,185 @@ class TestMemoryEvolutionService:
             assert reload_recorder.count == 0
         else:
             assert reload_recorder.count == 1
+
+    async def test_apply_draft_releases_claim_when_save_is_cancelled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="cancelled-apply",
+                runtime_name="cancelled-apply",
+            )
+        )
+
+        def cancel_save(
+            skill_id: str, request: ClawHubSkillWriteRequest
+        ) -> ClawHubSkillDetail:
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(
+            evolution_service._skill_service,
+            "save_skill",
+            cancel_save,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(),
+            )
+
+        reloaded = await evolution_service.get_draft_async("ws-evo", draft.draft_id)
+        assert reloaded is not None
+        assert reloaded.status == MemoryEvolutionStatus.DRAFT
+
+    async def test_apply_draft_retries_release_when_save_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="failing-apply",
+                runtime_name="failing-apply",
+            )
+        )
+        repository = evolution_service._repo
+        original_release = repository.release_evolution_draft_apply_claim_async
+        release_attempts = 0
+
+        def fail_save(
+            skill_id: str, request: ClawHubSkillWriteRequest
+        ) -> ClawHubSkillDetail:
+            raise RuntimeError("skill write failed")
+
+        async def flaky_release(*, draft_id: str, updated_at: datetime) -> bool:
+            nonlocal release_attempts
+            release_attempts += 1
+            if release_attempts == 1:
+                raise RuntimeError("database locked")
+            return await original_release(draft_id=draft_id, updated_at=updated_at)
+
+        monkeypatch.setattr(
+            evolution_service._skill_service,
+            "save_skill",
+            fail_save,
+        )
+        monkeypatch.setattr(
+            repository,
+            "release_evolution_draft_apply_claim_async",
+            flaky_release,
+        )
+
+        with pytest.raises(RuntimeError, match="skill write failed"):
+            await evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(),
+            )
+
+        reloaded = await evolution_service.get_draft_async("ws-evo", draft.draft_id)
+        assert release_attempts == 2
+        assert reloaded is not None
+        assert reloaded.status == MemoryEvolutionStatus.DRAFT
+
+    async def test_apply_draft_retries_applied_state_persistence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="retry-apply-complete",
+                runtime_name="retry-apply-complete",
+            )
+        )
+        repository = evolution_service._repo
+        original_complete = repository.complete_evolution_draft_apply_async
+        complete_attempts = 0
+
+        async def flaky_complete(
+            *, draft: MemoryEvolutionDraft
+        ) -> MemoryEvolutionDraft | None:
+            nonlocal complete_attempts
+            complete_attempts += 1
+            if complete_attempts == 1:
+                raise RuntimeError("database locked")
+            return await original_complete(draft=draft)
+
+        monkeypatch.setattr(
+            repository,
+            "complete_evolution_draft_apply_async",
+            flaky_complete,
+        )
+
+        applied = await evolution_service.apply_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            ApplyMemoryEvolutionDraftRequest(),
+        )
+
+        assert complete_attempts == 2
+        assert applied is not None
+        assert applied.status == MemoryEvolutionStatus.APPLIED
+
+    async def test_apply_draft_returns_applied_when_source_tagging_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="tagging-failure",
+                runtime_name="tagging-failure",
+            )
+        )
+
+        async def fail_patch_metadata(
+            *,
+            memory_id: str,
+            workspace_id: str,
+            metadata_patch: dict[str, str],
+            metadata_limit: int,
+            updated_at: datetime,
+        ) -> bool:
+            raise RuntimeError("metadata write failed")
+
+        monkeypatch.setattr(
+            evolution_service._repo,
+            "patch_entry_metadata_async",
+            fail_patch_metadata,
+        )
+
+        applied = await evolution_service.apply_draft_async(
+            "ws-evo",
+            draft.draft_id,
+            ApplyMemoryEvolutionDraftRequest(),
+        )
+
+        reloaded = await evolution_service.get_draft_async("ws-evo", draft.draft_id)
+        source = await memory_service.get_entry_async(memory_id)
+        assert applied is not None
+        assert applied.status == MemoryEvolutionStatus.APPLIED
+        assert reloaded is not None
+        assert reloaded.status == MemoryEvolutionStatus.APPLIED
+        assert source is not None
+        assert "evolution_draft_id" not in source.metadata
 
     async def test_apply_draft_rejects_blank_instructions(self, tmp_path: Path) -> None:
         memory_service, evolution_service, _ = _build_services(tmp_path)

--- a/tests/unit_tests/memory/test_memory_evolution.py
+++ b/tests/unit_tests/memory/test_memory_evolution.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
-from relay_teams.memory.evolution_service import MemoryEvolutionService
+from relay_teams.memory.evolution_service import (
+    MemoryEvolutionConflictError,
+    MemoryEvolutionService,
+)
 from relay_teams.memory.models import (
     ApplyMemoryEvolutionDraftRequest,
     CreateMemoryEntryRequest,
@@ -14,6 +18,7 @@ from relay_teams.memory.models import (
     MemoryContent,
     MemoryEntryKind,
     MemoryEntryStatus,
+    MemoryEvolutionDraft,
     MemoryEvolutionDraftQuery,
     MemoryEvolutionStatus,
     MemoryEvolutionTarget,
@@ -436,6 +441,52 @@ class TestMemoryEvolutionService:
         assert len(source.metadata) == 20
         assert source.metadata["evolution_draft_id"] == draft.draft_id
         assert source.metadata["evolution_skill_ref"] == "metadata-sop"
+
+    async def test_apply_draft_allows_only_one_concurrent_claim(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, reload_recorder = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="concurrent-apply",
+                runtime_name="concurrent-apply",
+            )
+        )
+
+        results = await asyncio.gather(
+            evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(),
+            ),
+            evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(
+                    skill_id="concurrent-apply-other",
+                    runtime_name="concurrent-apply-other",
+                ),
+            ),
+            return_exceptions=True,
+        )
+
+        applied: list[MemoryEvolutionDraft] = []
+        conflicts: list[MemoryEvolutionConflictError] = []
+        for result in results:
+            if isinstance(result, MemoryEvolutionConflictError):
+                conflicts.append(result)
+            elif isinstance(result, BaseException):
+                raise result
+            elif result is not None:
+                applied.append(result)
+        assert len(applied) == 1
+        assert len(conflicts) == 1
+        assert applied[0].status == MemoryEvolutionStatus.APPLIED
+        assert reload_recorder.count == 1
 
     async def test_apply_draft_rejects_blank_instructions(self, tmp_path: Path) -> None:
         memory_service, evolution_service, _ = _build_services(tmp_path)

--- a/tests/unit_tests/memory/test_memory_evolution.py
+++ b/tests/unit_tests/memory/test_memory_evolution.py
@@ -108,6 +108,15 @@ class TestMemoryEvolutionRepository:
 
 
 class TestMemoryEvolutionModels:
+    async def test_workspace_id_can_be_path_derived(self) -> None:
+        request = CreateMemoryEvolutionDraftRequest(
+            source_memory_ids=("mem-1",),
+            skill_id="review-loop-sop",
+            runtime_name="review-loop-sop",
+        )
+
+        assert request.workspace_id == ""
+
     async def test_source_memory_ids_reject_blank_values(self) -> None:
         with pytest.raises(ValidationError, match="non-empty"):
             CreateMemoryEvolutionDraftRequest(
@@ -116,6 +125,28 @@ class TestMemoryEvolutionModels:
                 skill_id="review-loop-sop",
                 runtime_name="review-loop-sop",
             )
+
+    async def test_skill_ids_are_stripped_and_validated(self) -> None:
+        request = CreateMemoryEvolutionDraftRequest(
+            workspace_id="ws-evo",
+            source_memory_ids=("mem-1",),
+            skill_id=" review-loop-sop ",
+            runtime_name=" review-loop-sop ",
+        )
+
+        assert request.skill_id == "review-loop-sop"
+        assert request.runtime_name == "review-loop-sop"
+
+        with pytest.raises(ValidationError, match="skill_id must start"):
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=("mem-1",),
+                skill_id="bad/skill",
+                runtime_name="review-loop-sop",
+            )
+
+        with pytest.raises(ValidationError, match="runtime_name must start"):
+            ApplyMemoryEvolutionDraftRequest(runtime_name=" ")
 
     async def test_source_memory_ids_reject_duplicates_after_trim(self) -> None:
         with pytest.raises(ValidationError, match="Duplicate source memory id"):
@@ -228,6 +259,22 @@ class TestMemoryEvolutionService:
                     target=MemoryEvolutionTarget.SKILL,
                     skill_id="missing-skill",
                     runtime_name="missing-skill",
+                )
+            )
+
+    async def test_create_requires_workspace_id_in_service(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, _ = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+
+        with pytest.raises(ValueError, match="workspace_id is required"):
+            await evolution_service.create_draft_async(
+                CreateMemoryEvolutionDraftRequest(
+                    source_memory_ids=(memory_id,),
+                    target=MemoryEvolutionTarget.SKILL,
+                    skill_id="missing-workspace-skill",
+                    runtime_name="missing-workspace-skill",
                 )
             )
 

--- a/tests/unit_tests/memory/test_memory_evolution.py
+++ b/tests/unit_tests/memory/test_memory_evolution.py
@@ -488,6 +488,56 @@ class TestMemoryEvolutionService:
         assert applied[0].status == MemoryEvolutionStatus.APPLIED
         assert reload_recorder.count == 1
 
+    async def test_apply_and_reject_cannot_both_claim_draft(
+        self, tmp_path: Path
+    ) -> None:
+        memory_service, evolution_service, reload_recorder = _build_services(tmp_path)
+        memory_id = await _create_memory(memory_service)
+        draft = await evolution_service.create_draft_async(
+            CreateMemoryEvolutionDraftRequest(
+                workspace_id="ws-evo",
+                source_memory_ids=(memory_id,),
+                target=MemoryEvolutionTarget.SKILL,
+                skill_id="apply-reject-race",
+                runtime_name="apply-reject-race",
+            )
+        )
+
+        results = await asyncio.gather(
+            evolution_service.apply_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                ApplyMemoryEvolutionDraftRequest(),
+            ),
+            evolution_service.reject_draft_async(
+                "ws-evo",
+                draft.draft_id,
+                RejectMemoryEvolutionDraftRequest(reason="not reusable"),
+            ),
+            return_exceptions=True,
+        )
+
+        completed: list[MemoryEvolutionDraft] = []
+        conflicts: list[MemoryEvolutionConflictError] = []
+        for result in results:
+            if isinstance(result, MemoryEvolutionConflictError):
+                conflicts.append(result)
+            elif isinstance(result, BaseException):
+                raise result
+            elif result is not None:
+                completed.append(result)
+        assert len(completed) == 1
+        assert len(conflicts) == 1
+        assert completed[0].status in {
+            MemoryEvolutionStatus.APPLIED,
+            MemoryEvolutionStatus.REJECTED,
+        }
+        assert reload_recorder.count in {0, 1}
+        if completed[0].status == MemoryEvolutionStatus.REJECTED:
+            assert reload_recorder.count == 0
+        else:
+            assert reload_recorder.count == 1
+
     async def test_apply_draft_rejects_blank_instructions(self, tmp_path: Path) -> None:
         memory_service, evolution_service, _ = _build_services(tmp_path)
         memory_id = await _create_memory(memory_service)


### PR DESCRIPTION
## Summary
- add review-first Memory Bank evolution drafts for skill and SOP-skill promotion
- persist draft lifecycle state and apply drafts through the existing ClawHub skill service/reload path
- expose API, CLI, and Memory UI controls for creating/applying drafts
- refresh Memory Bank API/schema/design docs

## Verification
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests
- Browser E2E: temp server on 127.0.0.1:8765, created memory entry, generated SOP draft from Memory UI, applied draft, verified generated SKILL.md under temp config dir

Fixes #836