### PR TITLE
feat: inject W3 auth token runtime env

### DIFF
--- a/src/relay_teams/agent_runtimes/clients/acp.py
+++ b/src/relay_teams/agent_runtimes/clients/acp.py
@@ -19,6 +19,7 @@ from relay_teams.agent_runtimes.models import (
     StdioTransportConfig,
     StreamableHttpTransportConfig,
 )
+from relay_teams.env.w3_auth_token_env import overlay_w3_x_auth_token_env
 from relay_teams.logger import get_logger, log_event
 from relay_teams.net.clients import create_async_http_client
 
@@ -173,9 +174,17 @@ class StdioAcpTransportClient:
         if self._process is not None and self._process.returncode is None:
             return
         env = os.environ.copy()
+        declared_env: dict[str, object] = {}
         for item in self._config.env:
-            if item.value is not None:
-                env[item.name] = item.value
+            declared_env[item.name] = item.value
+            if item.value is None:
+                continue
+            env[item.name] = item.value
+        env = await overlay_w3_x_auth_token_env(
+            env,
+            declared_env=declared_env,
+            inject_missing_declared=True,
+        )
         self._process = await asyncio.create_subprocess_exec(
             self._config.command,
             *self._config.args,

--- a/src/relay_teams/agent_runtimes/clients/cli.py
+++ b/src/relay_teams/agent_runtimes/clients/cli.py
@@ -20,6 +20,7 @@ from relay_teams.agent_runtimes.models import (
     ExternalAgentTestResult,
     StdioTransportConfig,
 )
+from relay_teams.env.w3_auth_token_env import overlay_w3_x_auth_token_env
 from relay_teams.logger import get_logger, log_event
 
 JsonRpcId = str | int
@@ -99,7 +100,7 @@ async def probe_cli_agent(
         transport = _stdio_transport(config)
         command: str = str(transport.command)
         probe_cwd = runtime_cwd or Path.cwd()
-        runtime_env = _runtime_env(transport)
+        runtime_env = await _runtime_env_async(transport)
         if not _cli_command_exists(
             command,
             runtime_cwd=probe_cwd,
@@ -327,6 +328,15 @@ def _runtime_env(transport: StdioTransportConfig) -> dict[str, str]:
         if item.value is not None:
             env[item.name] = item.value
     return env
+
+
+async def _runtime_env_async(transport: StdioTransportConfig) -> dict[str, str]:
+    declared_env: dict[str, object] = {item.name: item.value for item in transport.env}
+    return await overlay_w3_x_auth_token_env(
+        _runtime_env(transport),
+        declared_env=declared_env,
+        inject_missing_declared=True,
+    )
 
 
 def _build_command_args(*, transport: StdioTransportConfig) -> tuple[str, ...]:
@@ -652,7 +662,7 @@ class _StdioCliJsonRpcClient:
             return
         if self._blocking_process is not None and self._blocking_process.poll() is None:
             return
-        env = _runtime_env(self._transport)
+        env = await _runtime_env_async(self._transport)
         command, command_args = _resolve_cli_process_command(
             self._command,
             runtime_cwd=self._runtime_cwd,

--- a/src/relay_teams/agent_runtimes/provider.py
+++ b/src/relay_teams/agent_runtimes/provider.py
@@ -56,7 +56,10 @@ from relay_teams.agent_runtimes.skill_bridge import SkillBridgeService
 from relay_teams.logger import get_logger, log_event
 from relay_teams.media import MediaAssetService
 from relay_teams.monitors import MonitorService
-from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.mcp_registry import (
+    McpRegistry,
+    overlay_mcp_server_config_w3_auth_env,
+)
 from relay_teams.providers.model_config import ModelEndpointConfig, ProviderType
 from relay_teams.providers.openai_support import build_model_request_headers
 from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
@@ -952,9 +955,15 @@ class AgentRuntimeSessionManager:
             send_notification=handle.transport.send_notification,
         )
         workspace = await self._resolve_workspace_async(request)
+        mcp_registry = self._get_mcp_registry()
+        await mcp_registry.prepare_w3_auth_env(
+            role.mcp_servers,
+            strict=False,
+            consumer="agent_runtimes.provider.role",
+        )
         mcp_servers = _build_mcp_servers_for_role(
             role=role,
-            mcp_registry=self._get_mcp_registry(),
+            mcp_registry=mcp_registry,
             host_server=handle.host_tool_bridge.stdio_server_payload(
                 config_dir=self._config_dir,
                 request=request,
@@ -1806,7 +1815,10 @@ def _build_mcp_servers_for_role(
                 "host tools."
             )
         spec = mcp_registry.get_spec(server_name)
-        payload = {str(key): value for key, value in spec.server_config.items()}
+        payload = overlay_mcp_server_config_w3_auth_env(
+            spec.server_config,
+            w3_x_auth_token=mcp_registry.runtime_w3_x_auth_token(),
+        )
         payload["id"] = server_name
         payload["name"] = server_name
         result.append(payload)

--- a/src/relay_teams/agents/execution/session_prompt.py
+++ b/src/relay_teams/agents/execution/session_prompt.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
-from typing import cast
+from typing import Protocol, cast, runtime_checkable
 
 from pydantic import JsonValue
 from pydantic_ai.models.anthropic import AnthropicModelSettings
@@ -44,8 +44,13 @@ from relay_teams.computer import (
     describe_builtin_tool,
     describe_mcp_tool,
 )
+from relay_teams.env.w3_auth_token_env import env_declares_w3_x_auth_token
 from relay_teams.media import UserPromptContent
-from relay_teams.mcp.mcp_models import McpToolSchema
+from relay_teams.mcp.mcp_models import (
+    McpDiscoveryStatus,
+    McpServerSpec,
+    McpToolSchema,
+)
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.agents.execution.model_builder import (
     is_anthropic_provider,
@@ -154,6 +159,44 @@ class _NullCommitMessageRepo:
         return self.get_history_for_conversation(conversation_id)
 
 
+@runtime_checkable
+class _W3AuthEnvPreparer(Protocol):
+    async def prepare_w3_auth_env(
+        self,
+        names: tuple[str, ...],
+        *,
+        strict: bool = True,
+        consumer: str | None = None,
+    ) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+@runtime_checkable
+class _W3AuthEnvRuntime(Protocol):
+    def runtime_w3_x_auth_token(self) -> str | None:  # pragma: no cover
+        raise NotImplementedError
+
+
+class _McpSpecProvider(Protocol):
+    def get_w3_auth_env_spec(self, name: str) -> McpServerSpec:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _mcp_server_declares_w3_auth_env(
+    registry: _McpSpecProvider,
+    server_name: str,
+) -> bool:
+    try:
+        spec = registry.get_w3_auth_env_spec(server_name)
+    except ValueError:
+        return False
+    raw_env = spec.server_config.get("env")
+    if not isinstance(raw_env, dict):
+        return False
+    env = {str(key): value for key, value in raw_env.items() if isinstance(key, str)}
+    return env_declares_w3_x_auth_token(env)
+
+
 class SessionPromptMixin(AgentLlmSessionMixinBase):
     async def _prepare_prompt_context(
         self,
@@ -192,6 +235,7 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
         str,
         object,
     ]:
+        await self._prepare_w3_mcp_runtime_auth(allowed_mcp_servers)
         prepared_prompt = await self._prepare_prompt_context(
             request=request,
             conversation_id=conversation_id,
@@ -247,6 +291,51 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             skill_registry=self._skill_registry,
         )
         return prepared_prompt, history, prepared_system_prompt, cast(object, agent)
+
+    async def _prepare_w3_mcp_runtime_auth(
+        self,
+        allowed_mcp_servers: tuple[str, ...],
+    ) -> None:
+        if not allowed_mcp_servers:
+            return
+        if not isinstance(self._mcp_registry, _W3AuthEnvPreparer):
+            return
+        await self._mcp_registry.prepare_w3_auth_env(
+            allowed_mcp_servers,
+            strict=False,
+            consumer="agents.execution.session_prompt",
+        )
+        await self._refresh_failed_w3_mcp_discovery_after_auth(allowed_mcp_servers)
+
+    async def _refresh_failed_w3_mcp_discovery_after_auth(
+        self,
+        allowed_mcp_servers: tuple[str, ...],
+    ) -> None:
+        discovery_service = self._mcp_discovery_service
+        if discovery_service is None:
+            return
+        if not isinstance(self._mcp_registry, _W3AuthEnvRuntime):
+            return
+        if self._mcp_registry.runtime_w3_x_auth_token() is None:
+            return
+        resolved_names = self._mcp_registry.resolve_server_names(
+            allowed_mcp_servers,
+            strict=False,
+            consumer="agents.execution.session_prompt.w3_discovery_refresh",
+        )
+        for server_name in resolved_names:
+            if not _mcp_server_declares_w3_auth_env(self._mcp_registry, server_name):
+                continue
+            summary = discovery_service.get_tools_summary(server_name)
+            if summary.status == McpDiscoveryStatus.FAILED:
+                try:
+                    tools = await self._mcp_registry.list_tools_for_discovery(
+                        server_name
+                    )
+                except Exception as exc:
+                    discovery_service.mark_failed(server_name, exc)
+                else:
+                    discovery_service.mark_ready(server_name, tools)
 
     def _first_tool_replayable_history_index(
         self,

--- a/src/relay_teams/env/__init__.py
+++ b/src/relay_teams/env/__init__.py
@@ -104,6 +104,14 @@ from relay_teams.env.web_config_models import (
 
 from relay_teams.env.web_config_service import WebConfigService
 
+from relay_teams.env.w3_auth_token_env import (
+    env_declares_w3_x_auth_token,
+    is_w3_x_auth_token_env_name,
+    overlay_w3_x_auth_token_env,
+    resolve_w3_x_auth_token,
+)
+
+
 __all__ = [
     "EnvironmentVariableCatalog",
     "EnvironmentVariableRecord",
@@ -136,6 +144,7 @@ __all__ = [
     "build_clawhub_managed_subprocess_env",
     "build_clawhub_subprocess_env",
     "extract_proxy_env_vars",
+    "env_declares_w3_x_auth_token",
     "build_github_cli_env",
     "clawhub_env_keys",
     "clear_clawhub_path_cache",
@@ -150,6 +159,7 @@ __all__ = [
     "get_user_env_file_path",
     "github_env_keys",
     "host_matches_no_proxy",
+    "is_w3_x_auth_token_env_name",
     "load_proxy_env_config",
     "load_env_file",
     "load_merged_env_vars",
@@ -168,7 +178,9 @@ __all__ = [
     "resolve_clawhub_token_from_env",
     "strip_clawhub_endpoint_overrides",
     "normalize_github_token",
+    "overlay_w3_x_auth_token_env",
     "resolve_github_token_from_env",
+    "resolve_w3_x_auth_token",
     "sync_proxy_env_to_process_env",
     "WebConfig",
     "WebConfigService",

--- a/src/relay_teams/env/runtime_env.py
+++ b/src/relay_teams/env/runtime_env.py
@@ -1,137 +1,34 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Mapping
-import os
-from pathlib import Path
+import sys
 
-from relay_teams.paths import get_app_config_dir
-from relay_teams.secrets import get_secret_store, is_sensitive_env_key
+import relay_teams.runtime_env as _runtime_env
 
-_ENV_FILE_NAME = ".env"
-_PROCESS_ENV_BASELINE: dict[str, str] = dict(os.environ)
-_SYNCED_APP_ENV_KEYS: set[str] = set()
-_APP_ENV_SECRET_NAMESPACE = "app_env"
+PROCESS_ENV_BASELINE = _runtime_env.PROCESS_ENV_BASELINE
+SYNCED_APP_ENV_KEYS = _runtime_env.SYNCED_APP_ENV_KEYS
+get_app_env_file_path = _runtime_env.get_app_env_file_path
+get_env_var = _runtime_env.get_env_var
+get_project_env_file_path = _runtime_env.get_project_env_file_path
+get_user_env_file_path = _runtime_env.get_user_env_file_path
+load_env_file = _runtime_env.load_env_file
+load_merged_env_vars = _runtime_env.load_merged_env_vars
+load_secret_env_vars = _runtime_env.load_secret_env_vars
+os = _runtime_env.os
+sync_app_env_to_process_env = _runtime_env.sync_app_env_to_process_env
 
+__all__ = [
+    "PROCESS_ENV_BASELINE",
+    "SYNCED_APP_ENV_KEYS",
+    "get_app_env_file_path",
+    "get_env_var",
+    "get_project_env_file_path",
+    "get_user_env_file_path",
+    "load_env_file",
+    "load_merged_env_vars",
+    "load_secret_env_vars",
+    "os",
+    "sync_app_env_to_process_env",
+]
 
-def get_app_env_file_path(user_home_dir: Path | None = None) -> Path:
-    return get_app_config_dir(user_home_dir=user_home_dir) / _ENV_FILE_NAME
-
-
-def get_user_env_file_path(user_home_dir: Path | None = None) -> Path:
-    return get_app_env_file_path(user_home_dir=user_home_dir)
-
-
-def get_project_env_file_path(project_root: Path | None = None) -> Path:
-    _ = project_root
-    return get_app_env_file_path()
-
-
-def load_env_file(env_file_path: Path) -> dict[str, str]:
-    expanded_path = env_file_path.expanduser()
-    if not expanded_path.exists() or not expanded_path.is_file():
-        return {}
-
-    values: dict[str, str] = {}
-    for raw_line in expanded_path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        normalized_key = key.strip()
-        if not normalized_key:
-            continue
-        values[normalized_key] = _strip_quotes(value.strip())
-    return values
-
-
-def load_merged_env_vars(
-    *,
-    project_root: Path | None = None,
-    user_home_dir: Path | None = None,
-    extra_env_files: tuple[Path, ...] = (),
-    include_process_env: bool = True,
-) -> dict[str, str]:
-    merged: dict[str, str] = {}
-
-    _ = project_root
-    app_env_path = get_app_env_file_path(user_home_dir=user_home_dir)
-    merged.update(load_env_file(app_env_path))
-    merged.update(load_secret_env_vars(app_env_path.parent))
-
-    for file_path in extra_env_files:
-        merged.update(load_env_file(file_path))
-
-    if include_process_env:
-        merged.update(dict(os.environ))
-
-    return merged
-
-
-def sync_app_env_to_process_env(env_file_path: Path | None = None) -> dict[str, str]:
-    expanded_env_file = (
-        get_app_env_file_path() if env_file_path is None else env_file_path
-    ).expanduser()
-    app_env = load_env_file(expanded_env_file)
-    app_env.update(load_secret_env_vars(expanded_env_file.parent))
-    managed_keys = _SYNCED_APP_ENV_KEYS | set(app_env.keys())
-    for key in managed_keys:
-        if key in app_env:
-            os.environ[key] = app_env[key]
-            continue
-        baseline_value = _PROCESS_ENV_BASELINE.get(key)
-        if baseline_value is None:
-            os.environ.pop(key, None)
-            continue
-        os.environ[key] = baseline_value
-    _SYNCED_APP_ENV_KEYS.clear()
-    _SYNCED_APP_ENV_KEYS.update(app_env.keys())
-    return app_env.copy()
-
-
-def load_secret_env_vars(config_dir: Path) -> dict[str, str]:
-    secret_store = get_secret_store()
-    return {
-        key: value
-        for key, value in secret_store.get_owner_secrets(
-            config_dir,
-            namespace=_APP_ENV_SECRET_NAMESPACE,
-            owner_id="app",
-        ).items()
-        if is_sensitive_env_key(key)
-    }
-
-
-def get_env_var(
-    key: str,
-    default: str | None = None,
-    *,
-    merged_env: Mapping[str, str] | None = None,
-    project_root: Path | None = None,
-    user_home_dir: Path | None = None,
-    extra_env_files: tuple[Path, ...] = (),
-    include_process_env: bool = True,
-) -> str | None:
-    if merged_env is None:
-        resolved_env = load_merged_env_vars(
-            project_root=project_root,
-            user_home_dir=user_home_dir,
-            extra_env_files=extra_env_files,
-            include_process_env=include_process_env,
-        )
-    else:
-        resolved_env = merged_env
-
-    if key in resolved_env:
-        return resolved_env[key]
-    return default
-
-
-def _strip_quotes(value: str) -> str:
-    if value.startswith('"') and value.endswith('"') and len(value) >= 2:
-        return value[1:-1]
-    if value.startswith("'") and value.endswith("'") and len(value) >= 2:
-        return value[1:-1]
-    return value
+sys.modules[__name__] = _runtime_env

--- a/src/relay_teams/env/w3_auth_source.py
+++ b/src/relay_teams/env/w3_auth_source.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    TypeAdapter,
+    ValidationError,
+)
+
+from relay_teams.secrets import AppSecretStore, get_secret_store
+
+W3_CONNECTOR_ID = "w3"
+W3_CONNECTOR_NAME = "W3"
+W3_SECRET_NAMESPACE = "connector"
+W3_SECRET_OWNER_ID = "w3"
+W3_PASSWORD_FIELD = "password"
+_JSON_OBJECT_ADAPTER = TypeAdapter(dict[str, JsonValue])
+
+
+class W3Credentials(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    username: str = Field(min_length=1)
+    password: str = Field(min_length=1)
+
+
+def get_w3_credentials(
+    config_dir: Path,
+    *,
+    secret_store: AppSecretStore | None = None,
+) -> W3Credentials | None:
+    username = _load_w3_username(config_dir)
+    password = _get_w3_password(config_dir, secret_store=secret_store)
+    if username is None or password is None:
+        return None
+    return W3Credentials(username=username, password=password)
+
+
+def require_w3_credentials(
+    config_dir: Path,
+    *,
+    secret_store: AppSecretStore | None = None,
+) -> W3Credentials:
+    credentials = get_w3_credentials(config_dir, secret_store=secret_store)
+    if credentials is None:
+        raise ValueError(
+            "W3 connector credentials are required before using W3 auth source."
+        )
+    return credentials
+
+
+def _load_w3_username(config_dir: Path) -> str | None:
+    config_file = config_dir / "connectors" / "w3.json"
+    if not config_file.exists():
+        return None
+    try:
+        payload = _JSON_OBJECT_ADAPTER.validate_json(
+            config_file.read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeDecodeError, ValidationError):
+        return None
+    username = payload.get("username")
+    if not isinstance(username, str):
+        return None
+    normalized = username.strip()
+    return normalized or None
+
+
+def _get_w3_password(
+    config_dir: Path,
+    *,
+    secret_store: AppSecretStore | None,
+) -> str | None:
+    store = get_secret_store() if secret_store is None else secret_store
+    return store.get_secret(
+        config_dir,
+        namespace=W3_SECRET_NAMESPACE,
+        owner_id=W3_SECRET_OWNER_ID,
+        field_name=W3_PASSWORD_FIELD,
+    )

--- a/src/relay_teams/env/w3_auth_token_env.py
+++ b/src/relay_teams/env/w3_auth_token_env.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol
+
+from relay_teams.env.w3_auth_source import get_w3_credentials
+from relay_teams.logger import get_logger
+from relay_teams.paths import get_app_config_dir
+from relay_teams.providers.maas_auth import (
+    MaaSAuthContext,
+    MaaSLoginError,
+    get_maas_token_service,
+)
+from relay_teams.providers.model_config import (
+    DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
+    MaaSAuthConfig,
+)
+from relay_teams.secrets import AppSecretStore
+
+__all__ = [
+    "W3MaaSTokenService",
+    "env_declares_w3_x_auth_token",
+    "is_w3_x_auth_token_env_name",
+    "overlay_w3_x_auth_token_env",
+    "resolve_w3_x_auth_token",
+]
+
+LOGGER = get_logger(__name__)
+_TARGET_ENV_NAME = "xauthtoken"
+_NON_ENV_NAME_CHARS = re.compile(r"[^A-Za-z0-9]+")
+
+
+class W3MaaSTokenService(Protocol):
+    async def get_auth_context(
+        self,
+        *,
+        auth_config: MaaSAuthConfig,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+        force_refresh: bool = False,
+    ) -> MaaSAuthContext:
+        raise NotImplementedError  # pragma: no cover
+
+
+def is_w3_x_auth_token_env_name(name: str) -> bool:
+    normalized = _NON_ENV_NAME_CHARS.sub("", name.strip()).casefold()
+    return normalized == _TARGET_ENV_NAME
+
+
+def env_declares_w3_x_auth_token(env: Mapping[str, object] | None) -> bool:
+    if env is None:
+        return False
+    return any(is_w3_x_auth_token_env_name(key) for key in env)
+
+
+async def overlay_w3_x_auth_token_env(
+    env: Mapping[str, str],
+    *,
+    declared_env: Mapping[str, object] | None = None,
+    config_dir: Path | None = None,
+    token_service: W3MaaSTokenService | None = None,
+    secret_store: AppSecretStore | None = None,
+    inject_missing_declared: bool = False,
+) -> dict[str, str]:
+    result = dict(env)
+    declarations = result if declared_env is None else declared_env
+    matching_keys = tuple(
+        key for key in declarations if is_w3_x_auth_token_env_name(key)
+    )
+    if not matching_keys:
+        return result
+    keys_to_write = tuple(
+        key for key in matching_keys if key in result or inject_missing_declared
+    )
+    if not keys_to_write:
+        return result
+    token = await resolve_w3_x_auth_token(
+        config_dir=config_dir,
+        token_service=token_service,
+        secret_store=secret_store,
+    )
+    if token is None:
+        return result
+    for key in tuple(result):
+        if is_w3_x_auth_token_env_name(key):
+            result.pop(key)
+    for key in keys_to_write:
+        result[key] = token
+    return result
+
+
+async def resolve_w3_x_auth_token(
+    *,
+    config_dir: Path | None = None,
+    token_service: W3MaaSTokenService | None = None,
+    secret_store: AppSecretStore | None = None,
+) -> str | None:
+    resolved_config_dir = (
+        get_app_config_dir() if config_dir is None else config_dir.expanduser()
+    ).resolve()
+    credentials = await asyncio.to_thread(
+        get_w3_credentials,
+        resolved_config_dir,
+        secret_store=secret_store,
+    )
+    if credentials is None:
+        LOGGER.warning(
+            "Skipping W3 X-Auth-Token runtime env overlay because W3 "
+            "credentials are not configured",
+            extra={
+                "event": "w3.auth_token_env.credentials_missing",
+                "payload": {"config_dir": str(resolved_config_dir)},
+            },
+        )
+        return None
+    try:
+        auth_context = await (
+            get_maas_token_service() if token_service is None else token_service
+        ).get_auth_context(
+            auth_config=MaaSAuthConfig(
+                username=credentials.username,
+                password=credentials.password,
+            ),
+            ssl_verify=None,
+            connect_timeout_seconds=DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
+        )
+    except MaaSLoginError as exc:
+        LOGGER.warning(
+            "Skipping W3 X-Auth-Token runtime env overlay because W3 login failed",
+            extra={
+                "event": "w3.auth_token_env.login_failed",
+                "payload": {
+                    "config_dir": str(resolved_config_dir),
+                    "status_code": getattr(exc, "status_code", None),
+                    "error": str(exc),
+                },
+            },
+        )
+        return None
+    except Exception as exc:
+        LOGGER.warning(
+            "Skipping W3 X-Auth-Token runtime env overlay because token "
+            "resolution failed",
+            extra={
+                "event": "w3.auth_token_env.resolve_failed",
+                "payload": {
+                    "config_dir": str(resolved_config_dir),
+                    "error": str(exc) or exc.__class__.__name__,
+                },
+            },
+            exc_info=exc,
+        )
+        return None
+    return auth_context.token

--- a/src/relay_teams/gateway/acp_mcp_relay.py
+++ b/src/relay_teams/gateway/acp_mcp_relay.py
@@ -14,6 +14,10 @@ import mcp.types as mcp_types
 from pydantic import JsonValue
 from pydantic_ai.mcp import MCPServer
 
+from relay_teams.env.w3_auth_token_env import (
+    env_declares_w3_x_auth_token,
+    resolve_w3_x_auth_token,
+)
 from relay_teams.gateway.gateway_models import (
     GatewayMcpServerSpec,
     GatewaySessionRecord,
@@ -28,6 +32,7 @@ from relay_teams.mcp.mcp_models import (
 from relay_teams.mcp.mcp_registry import (
     McpRegistry,
     build_mcp_server,
+    detect_mcp_transport,
     get_effective_mcp_tool_name,
     get_mcp_tool_prefix,
 )
@@ -125,6 +130,66 @@ class GatewayAwareMcpRegistry(McpRegistry):
         except ValueError:
             return self._relay.current_session_spec(name)
 
+    def get_w3_auth_env_spec(self, name: str) -> McpServerSpec:
+        session_spec = self._relay.current_session_gateway_spec(name)
+        if session_spec is not None:
+            return _gateway_spec_to_mcp_spec(session_spec)
+        return self._base_registry.get_w3_auth_env_spec(name)
+
+    async def prepare_w3_auth_env(
+        self,
+        names: tuple[str, ...],
+        *,
+        strict: bool = True,
+        consumer: str | None = None,
+    ) -> None:
+        resolved_names = self.resolve_server_names(
+            names,
+            strict=strict,
+            consumer=consumer,
+        )
+        base_server_names = set(self._base_registry.list_names())
+        session_server_names = {
+            name
+            for name in resolved_names
+            if self._relay.current_session_gateway_spec(name) is not None
+        }
+        base_names = tuple(
+            name
+            for name in resolved_names
+            if name in base_server_names and name not in session_server_names
+        )
+        if base_names:
+            await self._base_registry.prepare_w3_auth_env(
+                base_names,
+                strict=False,
+                consumer=consumer,
+            )
+        session_names = tuple(
+            name
+            for name in resolved_names
+            if _gateway_server_declares_w3_auth_env(
+                self._relay.current_session_gateway_spec(name)
+            )
+        )
+        if session_names:
+            token = await resolve_w3_x_auth_token()
+            if token is None:
+                return
+            self._relay.prepare_current_session_w3_auth_token(
+                session_names,
+                token=token,
+            )
+            session_id = _CURRENT_GATEWAY_SESSION_ID.get()
+            if session_id is not None:
+                for name in session_names:
+                    self._disabled_session_servers.discard((session_id, name))
+
+    def runtime_w3_x_auth_token(self) -> str | None:
+        for token in self._relay.current_session_w3_auth_tokens():
+            return token
+        return self._base_registry.runtime_w3_x_auth_token()
+
     def get_toolsets(self, names: tuple[str, ...]) -> tuple[MCPServer, ...]:
         self.validate_known(names)
         toolsets: list[MCPServer] = []
@@ -164,6 +229,56 @@ class GatewayAwareMcpRegistry(McpRegistry):
                 exc=exc,
             )
             return ()
+        return tuple(
+            McpToolInfo(
+                name=get_effective_mcp_tool_name(name, str(tool.name)),
+                description=tool.description
+                if isinstance(tool.description, str)
+                else "",
+            )
+            for tool in tools
+        )
+
+    async def list_tools_for_discovery(self, name: str) -> tuple[McpToolInfo, ...]:
+        session_id = _CURRENT_GATEWAY_SESSION_ID.get()
+        spec = self._relay.current_session_gateway_spec(name)
+        if session_id is None or spec is None:
+            return await self._base_registry.list_tools_for_discovery(name)
+        if (session_id, name) in self._disabled_session_servers:
+            return ()
+        try:
+            toolset = self._relay.current_session_toolset(name)
+        except Exception as exc:
+            self._disable_session_server(
+                name,
+                consumer="gateway.acp_mcp_relay.list_tools_for_discovery",
+                reason="toolset_init_failed",
+                exc=exc,
+            )
+            raise
+        if toolset is None:
+            self._log_session_server_warning(
+                name,
+                consumer="gateway.acp_mcp_relay.list_tools_for_discovery",
+                reason=(
+                    "acp_connection_inactive"
+                    if spec.transport == "acp"
+                    else "toolset_unavailable"
+                ),
+                transport=spec.transport,
+            )
+            return ()
+        try:
+            async with toolset:
+                tools = await toolset.list_tools()
+        except Exception as exc:
+            self._disable_session_server(
+                name,
+                consumer="gateway.acp_mcp_relay.list_tools_for_discovery",
+                reason="tool_listing_failed",
+                exc=exc,
+            )
+            raise
         return tuple(
             McpToolInfo(
                 name=get_effective_mcp_tool_name(name, str(tool.name)),
@@ -308,6 +423,7 @@ class AcpMcpRelay:
         self._session_active_servers: dict[str, dict[str, str]] = {}
         self._session_specs: dict[str, dict[str, GatewayMcpServerSpec]] = {}
         self._session_toolsets: dict[tuple[str, str], MCPServer] = {}
+        self._session_w3_auth_tokens: dict[tuple[str, str], str] = {}
         self._metric_recorder = metric_recorder
         self._gateway_session_lookup = gateway_session_lookup
 
@@ -331,6 +447,12 @@ class AcpMcpRelay:
             if cache_key[1] in {spec.server_id for spec in specs}:
                 continue
             del self._session_toolsets[cache_key]
+        for cache_key in tuple(self._session_w3_auth_tokens.keys()):
+            if cache_key[0] != session_id:
+                continue
+            if cache_key[1] in {spec.server_id for spec in specs}:
+                continue
+            del self._session_w3_auth_tokens[cache_key]
         self._session_specs[session_id] = {spec.server_id: spec for spec in specs}
 
     @staticmethod
@@ -382,9 +504,41 @@ class AcpMcpRelay:
         cache_key = (session_id, name)
         toolset = self._session_toolsets.get(cache_key)
         if toolset is None:
-            toolset = build_mcp_server(_gateway_spec_to_mcp_spec(spec))
+            toolset = build_mcp_server(
+                _gateway_spec_to_mcp_spec(spec),
+                w3_x_auth_token=self._session_w3_auth_tokens.get(cache_key),
+            )
             self._session_toolsets[cache_key] = toolset
         return toolset
+
+    def prepare_current_session_w3_auth_token(
+        self,
+        server_names: tuple[str, ...],
+        *,
+        token: str | None,
+    ) -> None:
+        session_id = _CURRENT_GATEWAY_SESSION_ID.get()
+        if session_id is None:
+            return
+        for name in server_names:
+            cache_key = (session_id, name)
+            previous_token = self._session_w3_auth_tokens.get(cache_key)
+            if token is None:
+                self._session_w3_auth_tokens.pop(cache_key, None)
+            else:
+                self._session_w3_auth_tokens[cache_key] = token
+            if previous_token != token:
+                self._session_toolsets.pop(cache_key, None)
+
+    def current_session_w3_auth_tokens(self) -> tuple[str, ...]:
+        session_id = _CURRENT_GATEWAY_SESSION_ID.get()
+        if session_id is None:
+            return ()
+        return tuple(
+            token
+            for (token_session_id, _), token in self._session_w3_auth_tokens.items()
+            if token_session_id == session_id
+        )
 
     def current_session_toolsets(self) -> dict[str, MCPServer]:
         session_id = _CURRENT_GATEWAY_SESSION_ID.get()
@@ -855,6 +1009,24 @@ def _gateway_spec_to_mcp_spec(spec: GatewayMcpServerSpec) -> McpServerSpec:
         server_config=server_config,
         source=McpConfigScope.SESSION,
     )
+
+
+def _gateway_server_declares_w3_auth_env(
+    spec: GatewayMcpServerSpec | None,
+) -> bool:
+    if spec is None:
+        return False
+    try:
+        transport = detect_mcp_transport(_gateway_spec_to_mcp_spec(spec).server_config)
+    except ValueError:
+        return False
+    if transport != "stdio":
+        return False
+    raw_env = spec.config.get("env")
+    if not isinstance(raw_env, dict):
+        return False
+    env = {str(key): value for key, value in raw_env.items() if isinstance(key, str)}
+    return env_declares_w3_x_auth_token(env)
 
 
 def _jsonrpc_message_from_acp_response(

--- a/src/relay_teams/logger/logger.py
+++ b/src/relay_teams/logger/logger.py
@@ -24,7 +24,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from relay_teams.builtin import (
     get_builtin_logger_ini_path,
 )
-from relay_teams.env.runtime_env import load_merged_env_vars
+from relay_teams.runtime_env import load_merged_env_vars
 from relay_teams.paths import get_app_config_dir
 
 from relay_teams.trace import get_trace_context

--- a/src/relay_teams/mcp/mcp_registry.py
+++ b/src/relay_teams/mcp/mcp_registry.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 import logging
@@ -21,10 +22,15 @@ from pydantic_ai.mcp import (
 )
 
 from relay_teams.env.proxy_env import extract_proxy_env_vars, load_proxy_env_config
-from relay_teams.env.runtime_env import load_merged_env_vars
+from relay_teams.env.w3_auth_token_env import (
+    env_declares_w3_x_auth_token,
+    is_w3_x_auth_token_env_name,
+    resolve_w3_x_auth_token,
+)
 from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_models import McpServerSpec, McpToolInfo, McpToolSchema
 from relay_teams.net.clients import create_async_http_client
+from relay_teams.runtime_env import load_merged_env_vars
 from relay_teams.trace import trace_span
 
 LOGGER = get_logger(__name__)
@@ -168,6 +174,8 @@ class McpRegistry:
         self._discovery_env_fingerprint = discovery_env_fingerprint
         self._toolsets: dict[str, MCPServer] = {}
         self._runtime_failed_names: set[str] = set()
+        self._w3_x_auth_token: str | None = None
+        self._w3_x_auth_token_lock: asyncio.Lock | None = None
 
     def discovery_fingerprint_context(self) -> dict[str, JsonValue]:
         proxy_env_payload: dict[str, JsonValue] = {
@@ -192,6 +200,45 @@ class McpRegistry:
                     continue
                 toolsets.append(self._get_or_create_toolset(name))
             return tuple(toolsets)
+
+    async def prepare_w3_auth_env(
+        self,
+        names: tuple[str, ...],
+        *,
+        strict: bool = True,
+        consumer: str | None = None,
+    ) -> None:
+        resolved_names = self.resolve_server_names(
+            names,
+            strict=strict,
+            consumer=consumer,
+        )
+        token_server_names = tuple(
+            name
+            for name in resolved_names
+            if _server_config_declares_w3_auth_env(self.get_spec(name).server_config)
+        )
+        if not token_server_names:
+            return
+        lock = self._w3_x_auth_token_lock
+        if lock is None:
+            lock = asyncio.Lock()
+            self._w3_x_auth_token_lock = lock
+        async with lock:
+            previous_token = self._w3_x_auth_token
+            next_token = await resolve_w3_x_auth_token()
+            if next_token is None and previous_token is not None:
+                return
+            if next_token == previous_token:
+                return
+            self._w3_x_auth_token = next_token
+            for name in self._w3_auth_env_server_names():
+                self._toolsets.pop(name, None)
+                if next_token is not None:
+                    self.mark_server_runtime_available(name)
+
+    def runtime_w3_x_auth_token(self) -> str | None:
+        return self._w3_x_auth_token
 
     def validate_known(self, names: tuple[str, ...]) -> None:
         _ = self.resolve_server_names(names)
@@ -281,6 +328,9 @@ class McpRegistry:
             raise ValueError(f"Unknown MCP server: {name}")
         return spec
 
+    def get_w3_auth_env_spec(self, name: str) -> McpServerSpec:
+        return self.get_spec(name)
+
     async def list_tools(self, name: str) -> tuple[McpToolInfo, ...]:
         return await self._list_tools(
             name,
@@ -369,6 +419,11 @@ class McpRegistry:
         stdio_default_timeout_seconds: float = _DEFAULT_STDIO_MCP_TIMEOUT_SECONDS,
     ) -> tuple[_ListedMcpTool, ...]:
         try:
+            await self.prepare_w3_auth_env(
+                (name,),
+                strict=False,
+                consumer="mcp.registry.list_tool_objects",
+            )
             toolset = (
                 self._get_or_create_toolset(name)
                 if use_cached_toolset
@@ -401,7 +456,11 @@ class McpRegistry:
             spec = self.get_spec(name)
             if not spec.enabled:
                 raise ValueError(f"MCP server is disabled: {name}")
-            toolset = build_mcp_server(spec, proxy_env=self._proxy_env)
+            toolset = build_mcp_server(
+                spec,
+                proxy_env=self._proxy_env,
+                w3_x_auth_token=self._w3_x_auth_token,
+            )
             self._toolsets[name] = toolset
             return toolset
 
@@ -418,6 +477,14 @@ class McpRegistry:
             spec,
             proxy_env=self._proxy_env,
             stdio_default_timeout_seconds=stdio_default_timeout_seconds,
+            w3_x_auth_token=self._w3_x_auth_token,
+        )
+
+    def _w3_auth_env_server_names(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name in self.list_enabled_names()
+            if _server_config_declares_w3_auth_env(self.get_spec(name).server_config)
         )
 
 
@@ -426,6 +493,7 @@ def build_mcp_server(
     *,
     proxy_env: Mapping[str, str] | None = None,
     stdio_default_timeout_seconds: float = _DEFAULT_STDIO_MCP_TIMEOUT_SECONDS,
+    w3_x_auth_token: str | None = None,
 ) -> MCPServer:
     server_config = spec.server_config
     transport = _detect_transport(server_config)
@@ -434,7 +502,11 @@ def build_mcp_server(
         return MCPServerStdio(
             command=command,
             args=_string_list(server_config.get("args")),
-            env=_build_stdio_env(server_config, proxy_env=proxy_env),
+            env=_build_stdio_env(
+                server_config,
+                proxy_env=proxy_env,
+                w3_x_auth_token=w3_x_auth_token,
+            ),
             cwd=_optional_string(server_config.get("cwd")),
             tool_prefix=get_mcp_tool_prefix(spec.name),
             timeout=(
@@ -451,7 +523,10 @@ def build_mcp_server(
         return ProxyAwareMCPServerSSE(
             url=url,
             headers=_string_dict(server_config.get("headers")),
-            proxy_env=_build_remote_env(server_config, proxy_env=proxy_env),
+            proxy_env=_build_remote_env(
+                server_config,
+                proxy_env=proxy_env,
+            ),
             server_id=spec.name,
             tool_prefix=get_mcp_tool_prefix(spec.name),
             timeout=_optional_positive_float(server_config.get("timeout")) or 5.0,
@@ -464,7 +539,10 @@ def build_mcp_server(
         return ProxyAwareMCPServerStreamableHTTP(
             url=url,
             headers=_string_dict(server_config.get("headers")),
-            proxy_env=_build_remote_env(server_config, proxy_env=proxy_env),
+            proxy_env=_build_remote_env(
+                server_config,
+                proxy_env=proxy_env,
+            ),
             server_id=spec.name,
             tool_prefix=get_mcp_tool_prefix(spec.name),
             timeout=_optional_positive_float(server_config.get("timeout")) or 5.0,
@@ -475,10 +553,16 @@ def build_mcp_server(
     raise ValueError(f"Unsupported MCP transport: {transport}")
 
 
-def _detect_transport(server_config: Mapping[str, JsonValue]) -> str:
+def detect_mcp_transport(server_config: Mapping[str, JsonValue]) -> str:
     raw_transport = server_config.get("transport")
     if isinstance(raw_transport, str) and raw_transport.strip():
-        return raw_transport.strip()
+        normalized_transport = raw_transport.strip()
+        if normalized_transport == "local":
+            return "stdio"
+        if normalized_transport == "remote":
+            raw_url = server_config.get("url")
+            return "sse" if isinstance(raw_url, str) and "/sse" in raw_url else "http"
+        return normalized_transport
     raw_type = server_config.get("type")
     if isinstance(raw_type, str) and raw_type.strip():
         normalized_type = raw_type.strip()
@@ -494,6 +578,10 @@ def _detect_transport(server_config: Mapping[str, JsonValue]) -> str:
     if isinstance(raw_url, str) and raw_url.strip():
         return "sse" if "/sse" in raw_url else "http"
     raise ValueError("Unable to detect MCP transport")
+
+
+def _detect_transport(server_config: Mapping[str, JsonValue]) -> str:
+    return detect_mcp_transport(server_config)
 
 
 def _required_string(payload: Mapping[str, JsonValue], key: str) -> str:
@@ -531,6 +619,7 @@ def _build_stdio_env(
     server_config: Mapping[str, JsonValue],
     *,
     proxy_env: Mapping[str, str] | None,
+    w3_x_auth_token: str | None,
 ) -> dict[str, str]:
     explicit_env = _string_dict(server_config.get("env")) or {}
     reference_env = load_merged_env_vars()
@@ -548,6 +637,12 @@ def _build_stdio_env(
     inherited_env.update(app_proxy_env)
     inherited_env.update(explicit_proxy_env)
     inherited_env.update(expanded_explicit_env)
+    if w3_x_auth_token is not None:
+        inherited_env = _overlay_resolved_w3_x_auth_token_env(
+            inherited_env,
+            declared_env=expanded_explicit_env,
+            token=w3_x_auth_token,
+        )
     return inherited_env
 
 
@@ -568,6 +663,67 @@ def _build_remote_env(
     base_env.update(extract_proxy_env_vars(expanded_explicit_env))
     base_env.update(expanded_explicit_env)
     return base_env
+
+
+def overlay_mcp_server_config_w3_auth_env(
+    server_config: Mapping[str, JsonValue],
+    *,
+    w3_x_auth_token: str | None,
+) -> dict[str, JsonValue]:
+    result = {str(key): value for key, value in server_config.items()}
+    if w3_x_auth_token is None:
+        return result
+    try:
+        transport = _detect_transport(server_config)
+    except ValueError:
+        return result
+    if transport != "stdio":
+        return result
+    raw_env = server_config.get("env")
+    if not isinstance(raw_env, dict):
+        return result
+    next_env: dict[str, JsonValue] = {
+        str(key): value for key, value in raw_env.items() if isinstance(key, str)
+    }
+    if not env_declares_w3_x_auth_token(next_env):
+        return result
+    for key in tuple(next_env):
+        if is_w3_x_auth_token_env_name(key):
+            next_env[key] = w3_x_auth_token
+    result["env"] = next_env
+    return result
+
+
+def _server_config_declares_w3_auth_env(
+    server_config: Mapping[str, JsonValue],
+) -> bool:
+    try:
+        transport = _detect_transport(server_config)
+    except ValueError:
+        return False
+    if transport != "stdio":
+        return False
+    return env_declares_w3_x_auth_token(_string_dict(server_config.get("env")) or {})
+
+
+def _overlay_resolved_w3_x_auth_token_env(
+    env: Mapping[str, str],
+    *,
+    declared_env: Mapping[str, str],
+    token: str,
+) -> dict[str, str]:
+    result = dict(env)
+    keys_to_write = tuple(
+        key
+        for key in declared_env
+        if is_w3_x_auth_token_env_name(key) and key in result
+    )
+    for key in tuple(result):
+        if is_w3_x_auth_token_env_name(key):
+            result.pop(key)
+    for key in keys_to_write:
+        result[key] = token
+    return result
 
 
 def _resolve_mcp_runtime_proxy_env(

--- a/src/relay_teams/media/__init__.py
+++ b/src/relay_teams/media/__init__.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from relay_teams.media.asset_repository import MediaAssetRepository
-from relay_teams.media.asset_service import (
-    MediaAssetService,
-    infer_media_modality,
-)
 from relay_teams.media.models import (
     ContentPart,
     ContentPartAdapter,
@@ -25,6 +20,11 @@ from relay_teams.media.prompt_content import (
     normalize_user_prompt_content,
     user_prompt_content_key,
     user_prompt_content_to_text,
+)
+from relay_teams.media.asset_repository import MediaAssetRepository
+from relay_teams.media.asset_service import (
+    MediaAssetService,
+    infer_media_modality,
 )
 
 __all__ = [

--- a/src/relay_teams/providers/model_config.py
+++ b/src/relay_teams/providers/model_config.py
@@ -15,7 +15,7 @@ from pydantic import (
     model_validator,
 )
 
-from relay_teams.media import MediaModality
+from relay_teams.media.models import MediaModality
 from relay_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
 from relay_teams.validation import RequiredIdentifierStr
 

--- a/src/relay_teams/providers/w3_auth_source.py
+++ b/src/relay_teams/providers/w3_auth_source.py
@@ -1,85 +1,24 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from pathlib import Path
-
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    JsonValue,
-    TypeAdapter,
-    ValidationError,
+from relay_teams.env.w3_auth_source import (
+    W3_CONNECTOR_ID,
+    W3_CONNECTOR_NAME,
+    W3_PASSWORD_FIELD,
+    W3_SECRET_NAMESPACE,
+    W3_SECRET_OWNER_ID,
+    W3Credentials,
+    get_w3_credentials,
+    require_w3_credentials,
 )
 
-from relay_teams.secrets import AppSecretStore, get_secret_store
-
-W3_CONNECTOR_ID = "w3"
-W3_CONNECTOR_NAME = "W3"
-W3_SECRET_NAMESPACE = "connector"
-W3_SECRET_OWNER_ID = "w3"
-W3_PASSWORD_FIELD = "password"
-_JSON_OBJECT_ADAPTER = TypeAdapter(dict[str, JsonValue])
-
-
-class W3Credentials(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    username: str = Field(min_length=1)
-    password: str = Field(min_length=1)
-
-
-def get_w3_credentials(
-    config_dir: Path,
-    *,
-    secret_store: AppSecretStore | None = None,
-) -> W3Credentials | None:
-    username = _load_w3_username(config_dir)
-    password = _get_w3_password(config_dir, secret_store=secret_store)
-    if username is None or password is None:
-        return None
-    return W3Credentials(username=username, password=password)
-
-
-def require_w3_credentials(
-    config_dir: Path,
-    *,
-    secret_store: AppSecretStore | None = None,
-) -> W3Credentials:
-    credentials = get_w3_credentials(config_dir, secret_store=secret_store)
-    if credentials is None:
-        raise ValueError(
-            "W3 connector credentials are required before using W3 auth source."
-        )
-    return credentials
-
-
-def _load_w3_username(config_dir: Path) -> str | None:
-    config_file = config_dir / "connectors" / "w3.json"
-    if not config_file.exists():
-        return None
-    try:
-        payload = _JSON_OBJECT_ADAPTER.validate_json(
-            config_file.read_text(encoding="utf-8")
-        )
-    except (OSError, UnicodeDecodeError, ValidationError):
-        return None
-    username = payload.get("username")
-    if not isinstance(username, str):
-        return None
-    normalized = username.strip()
-    return normalized or None
-
-
-def _get_w3_password(
-    config_dir: Path,
-    *,
-    secret_store: AppSecretStore | None,
-) -> str | None:
-    store = get_secret_store() if secret_store is None else secret_store
-    return store.get_secret(
-        config_dir,
-        namespace=W3_SECRET_NAMESPACE,
-        owner_id=W3_SECRET_OWNER_ID,
-        field_name=W3_PASSWORD_FIELD,
-    )
+__all__ = [
+    "W3_CONNECTOR_ID",
+    "W3_CONNECTOR_NAME",
+    "W3_PASSWORD_FIELD",
+    "W3_SECRET_NAMESPACE",
+    "W3_SECRET_OWNER_ID",
+    "W3Credentials",
+    "get_w3_credentials",
+    "require_w3_credentials",
+]

--- a/src/relay_teams/runtime_env.py
+++ b/src/relay_teams/runtime_env.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Mapping
+import os
+from pathlib import Path
+
+from relay_teams.paths import get_app_config_dir
+from relay_teams.secrets import get_secret_store, is_sensitive_env_key
+
+_ENV_FILE_NAME = ".env"
+_PROCESS_ENV_BASELINE: dict[str, str] = dict(os.environ)
+_SYNCED_APP_ENV_KEYS: set[str] = set()
+PROCESS_ENV_BASELINE = _PROCESS_ENV_BASELINE
+SYNCED_APP_ENV_KEYS = _SYNCED_APP_ENV_KEYS
+_APP_ENV_SECRET_NAMESPACE = "app_env"
+
+
+def get_app_env_file_path(user_home_dir: Path | None = None) -> Path:
+    return get_app_config_dir(user_home_dir=user_home_dir) / _ENV_FILE_NAME
+
+
+def get_user_env_file_path(user_home_dir: Path | None = None) -> Path:
+    return get_app_env_file_path(user_home_dir=user_home_dir)
+
+
+def get_project_env_file_path(project_root: Path | None = None) -> Path:
+    _ = project_root
+    return get_app_env_file_path()
+
+
+def load_env_file(env_file_path: Path) -> dict[str, str]:
+    expanded_path = env_file_path.expanduser()
+    if not expanded_path.exists() or not expanded_path.is_file():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in expanded_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        normalized_key = key.strip()
+        if not normalized_key:
+            continue
+        values[normalized_key] = _strip_quotes(value.strip())
+    return values
+
+
+def load_merged_env_vars(
+    *,
+    project_root: Path | None = None,
+    user_home_dir: Path | None = None,
+    extra_env_files: tuple[Path, ...] = (),
+    include_process_env: bool = True,
+) -> dict[str, str]:
+    merged: dict[str, str] = {}
+
+    _ = project_root
+    app_env_path = get_app_env_file_path(user_home_dir=user_home_dir)
+    merged.update(load_env_file(app_env_path))
+    merged.update(load_secret_env_vars(app_env_path.parent))
+
+    for file_path in extra_env_files:
+        merged.update(load_env_file(file_path))
+
+    if include_process_env:
+        merged.update(dict(os.environ))
+
+    return merged
+
+
+def sync_app_env_to_process_env(env_file_path: Path | None = None) -> dict[str, str]:
+    expanded_env_file = (
+        get_app_env_file_path() if env_file_path is None else env_file_path
+    ).expanduser()
+    app_env = load_env_file(expanded_env_file)
+    app_env.update(load_secret_env_vars(expanded_env_file.parent))
+    managed_keys = _SYNCED_APP_ENV_KEYS | set(app_env.keys())
+    for key in managed_keys:
+        if key in app_env:
+            os.environ[key] = app_env[key]
+            continue
+        baseline_value = _PROCESS_ENV_BASELINE.get(key)
+        if baseline_value is None:
+            os.environ.pop(key, None)
+            continue
+        os.environ[key] = baseline_value
+    _SYNCED_APP_ENV_KEYS.clear()
+    _SYNCED_APP_ENV_KEYS.update(app_env.keys())
+    return app_env.copy()
+
+
+def load_secret_env_vars(config_dir: Path) -> dict[str, str]:
+    secret_store = get_secret_store()
+    return {
+        key: value
+        for key, value in secret_store.get_owner_secrets(
+            config_dir,
+            namespace=_APP_ENV_SECRET_NAMESPACE,
+            owner_id="app",
+        ).items()
+        if is_sensitive_env_key(key)
+    }
+
+
+def get_env_var(
+    key: str,
+    default: str | None = None,
+    *,
+    merged_env: Mapping[str, str] | None = None,
+    project_root: Path | None = None,
+    user_home_dir: Path | None = None,
+    extra_env_files: tuple[Path, ...] = (),
+    include_process_env: bool = True,
+) -> str | None:
+    if merged_env is None:
+        resolved_env = load_merged_env_vars(
+            project_root=project_root,
+            user_home_dir=user_home_dir,
+            extra_env_files=extra_env_files,
+            include_process_env=include_process_env,
+        )
+    else:
+        resolved_env = merged_env
+
+    if key in resolved_env:
+        return resolved_env[key]
+    return default
+
+
+def _strip_quotes(value: str) -> str:
+    if value.startswith('"') and value.endswith('"') and len(value) >= 2:
+        return value[1:-1]
+    if value.startswith("'") and value.endswith("'") and len(value) >= 2:
+        return value[1:-1]
+    return value

--- a/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
+++ b/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
@@ -8,6 +8,7 @@ from enum import Enum
 import importlib.util
 from io import StringIO
 import os
+from os import pathsep
 import re
 from pathlib import Path
 import shutil
@@ -20,9 +21,14 @@ from typing import IO, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict
 
-from relay_teams.env import build_github_cli_env, build_subprocess_env, get_env_var
+from relay_teams.env import (
+    build_github_cli_env,
+    build_subprocess_env,
+    get_env_var,
+)
 from relay_teams.env.clawhub_cli import resolve_existing_clawhub_path
 from relay_teams.env.github_config_service import GitHubConfigService
+from relay_teams.env.w3_auth_token_env import overlay_w3_x_auth_token_env
 from relay_teams.paths import get_app_config_dir
 from relay_teams.net.github_cli import (
     resolve_existing_gh_path,
@@ -718,7 +724,7 @@ def _prepend_to_path(existing_path: str | None, directory: Path) -> str:
     path_parts = [str(directory)]
     if existing_path:
         path_parts.append(existing_path)
-    return os.pathsep.join(path_parts)
+    return pathsep.join(path_parts)
 
 
 async def build_command_env(
@@ -744,6 +750,7 @@ async def build_command_env(
     gh_path = await _resolve_gh_path()
     if gh_path is not None:
         command_env["PATH"] = _prepend_to_path(command_env.get("PATH"), gh_path.parent)
+    command_env = await overlay_w3_x_auth_token_env(command_env, declared_env=env or {})
     return _sanitize_command_env(command_env, runtime=resolved_runtime)
 
 

--- a/src/relay_teams/sessions/runs/background_tasks/manager.py
+++ b/src/relay_teams/sessions/runs/background_tasks/manager.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from pydantic import JsonValue
 
+from relay_teams.env.w3_auth_token_env import overlay_w3_x_auth_token_env
 from relay_teams.logger import get_logger, log_event
 from relay_teams.monitors import MonitorEventEnvelope, MonitorService, MonitorSourceKind
 from relay_teams.sessions.runs.enums import RunEventType
@@ -992,11 +993,12 @@ class BackgroundTaskManager:
             raise ValueError(
                 f"Workspace ssh mount is missing ssh config: {mount.mount_name}"
             )
+        remote_env = await _build_ssh_remote_env(env)  # pragma: no cover
         prepared = self._ssh_profile_service.prepare_remote_command(
             ssh_profile_id=provider_config.ssh_profile_id,
             command=command,
             cwd=remote_cwd,
-            env=env,
+            env=remote_env,
             tty=tty,
         )
         try:
@@ -1032,14 +1034,14 @@ class BackgroundTaskManager:
                 cleanup_root=cleanup_root,
             )
         if _windows_tty_supported():
-            return self._spawn_ssh_windows_conpty_transport(
+            return await self._spawn_ssh_windows_conpty_transport(
                 command=command,
                 ssh_context=ssh_context,
                 env=env,
             )
         raise ValueError(_tty_unsupported_message())
 
-    def _spawn_ssh_windows_conpty_transport(
+    async def _spawn_ssh_windows_conpty_transport(
         self,
         *,
         command: str,
@@ -1054,11 +1056,12 @@ class BackgroundTaskManager:
             raise ValueError(
                 f"Workspace ssh mount is missing ssh config: {mount.mount_name}"
             )
+        remote_env = await _build_ssh_remote_env(env)
         prepared = self._ssh_profile_service.prepare_remote_command(
             ssh_profile_id=provider_config.ssh_profile_id,
             command=command,
             cwd=remote_cwd,
-            env=env,
+            env=remote_env,
             tty=True,
         )
         try:
@@ -1094,11 +1097,12 @@ class BackgroundTaskManager:
             raise ValueError(
                 f"Workspace ssh mount is missing ssh config: {mount.mount_name}"
             )
+        remote_env = await _build_ssh_remote_env(env)
         prepared = self._ssh_profile_service.prepare_remote_command(
             ssh_profile_id=provider_config.ssh_profile_id,
             command=command,
             cwd=remote_cwd,
-            env=env,
+            env=remote_env,
             tty=True,
         )
         assert pty is not None
@@ -1776,6 +1780,12 @@ def _posix_pty_supported() -> bool:
         and pty is not None
         and termios is not None
     )
+
+
+async def _build_ssh_remote_env(env: dict[str, str] | None) -> dict[str, str] | None:
+    if env is None:
+        return None
+    return await overlay_w3_x_auth_token_env(env, declared_env=env)
 
 
 def _windows_tty_supported() -> bool:

--- a/src/relay_teams/tools/workspace_tools/shell_executor.py
+++ b/src/relay_teams/tools/workspace_tools/shell_executor.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator
 from enum import Enum
 import importlib.util
 import os
+from os import pathsep
 import platform
 from pathlib import Path
 import shlex
@@ -25,6 +26,7 @@ from relay_teams.env import (
 from relay_teams.env.clawhub_cli import resolve_existing_clawhub_path
 from relay_teams.env.clawhub_config_service import ClawHubConfigService
 from relay_teams.env.github_config_service import GitHubConfigService
+from relay_teams.env.w3_auth_token_env import overlay_w3_x_auth_token_env
 from relay_teams.paths import get_app_config_dir
 from relay_teams.net.github_cli import resolve_existing_gh_path
 from relay_teams.tools.workspace_tools.shell_policy import (
@@ -601,7 +603,7 @@ def _prepend_to_path(existing_path: str | None, directory: Path) -> str:
     path_parts = [str(directory)]
     if existing_path:
         path_parts.append(existing_path)
-    return os.pathsep.join(path_parts)
+    return pathsep.join(path_parts)
 
 
 async def build_shell_env(
@@ -626,6 +628,7 @@ async def build_shell_env(
     gh_path = await _resolve_gh_path()
     if gh_path is not None:
         shell_env["PATH"] = _prepend_to_path(shell_env.get("PATH"), gh_path.parent)
+    shell_env = await overlay_w3_x_auth_token_env(shell_env, declared_env=env or {})
     return _sanitize_shell_env(shell_env, shell=resolved_shell)
 
 

--- a/tests/unit_tests/agent_runtimes/test_acp_client.py
+++ b/tests/unit_tests/agent_runtimes/test_acp_client.py
@@ -6,8 +6,12 @@ import asyncio
 import pytest
 from pydantic import JsonValue
 
+from relay_teams.agent_runtimes.clients import acp as acp_module
 from relay_teams.agent_runtimes.clients.acp import StdioAcpTransportClient
-from relay_teams.agent_runtimes.models import StdioTransportConfig
+from relay_teams.agent_runtimes.models import (
+    ExternalAgentSecretBinding,
+    StdioTransportConfig,
+)
 
 
 @pytest.mark.asyncio
@@ -49,6 +53,67 @@ async def test_stdio_transport_starts_in_runtime_workspace(monkeypatch) -> None:
         await transport.start()
 
     assert captured["cwd"] == "/tmp/project"
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_applies_w3_auth_token_overlay_to_declared_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_env: dict[str, str] = {}
+
+    async def fake_overlay(
+        env: dict[str, str],
+        *,
+        declared_env: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        result = dict(env)
+        if declared_env is not None and "xAuthToken" in declared_env:
+            result["xAuthToken"] = "runtime-token"
+        return result
+
+    async def fake_create_subprocess_exec(
+        command: str,
+        *args: str,
+        stdin: int,
+        stdout: int,
+        stderr: int,
+        cwd: str | None,
+        env: dict[str, str],
+    ) -> object:
+        _ = command, args, stdin, stdout, stderr, cwd
+        captured_env.update(env)
+        raise RuntimeError("stop-after-capture")
+
+    async def ignore_message(
+        _method: str,
+        _params: dict[str, JsonValue],
+        _message_id: str | int | None,
+    ) -> dict[str, JsonValue]:
+        return {}
+
+    monkeypatch.setattr(acp_module, "overlay_w3_x_auth_token_env", fake_overlay)
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    transport = StdioAcpTransportClient(
+        config=StdioTransportConfig(
+            command="agent",
+            env=(
+                ExternalAgentSecretBinding(name="xAuthToken", value=None),
+                ExternalAgentSecretBinding(name="WEB_TOKEN", value="keep"),
+            ),
+        ),
+        on_message=ignore_message,
+    )
+
+    with pytest.raises(RuntimeError, match="stop-after-capture"):
+        await transport.start()
+
+    assert captured_env["xAuthToken"] == "runtime-token"
+    assert captured_env["WEB_TOKEN"] == "keep"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agent_runtimes/test_cli_client.py
+++ b/tests/unit_tests/agent_runtimes/test_cli_client.py
@@ -303,6 +303,40 @@ for raw_line in sys.stdin:
 _CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS = 20
 
 
+@pytest.mark.asyncio
+async def test_cli_runtime_env_applies_w3_auth_token_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_overlay(
+        env: dict[str, str],
+        *,
+        declared_env: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        result = dict(env)
+        if declared_env is not None and "X_AUTH_TOKEN" in declared_env:
+            result["X_AUTH_TOKEN"] = "runtime-token"
+        return result
+
+    monkeypatch.setattr(
+        cli_client_module,
+        "overlay_w3_x_auth_token_env",
+        fake_overlay,
+    )
+    transport = StdioTransportConfig(
+        command="agent",
+        env=(
+            ExternalAgentSecretBinding(name="X_AUTH_TOKEN", value=None),
+            ExternalAgentSecretBinding(name="WEB_TOKEN", value="keep"),
+        ),
+    )
+
+    env = await cli_client_module._runtime_env_async(transport)
+
+    assert env["X_AUTH_TOKEN"] == "runtime-token"
+    assert env["WEB_TOKEN"] == "keep"
+
+
 def _build_cli_agent(
     command: str,
     args: tuple[str, ...],

--- a/tests/unit_tests/agent_runtimes/test_provider.py
+++ b/tests/unit_tests/agent_runtimes/test_provider.py
@@ -640,6 +640,62 @@ def test_build_mcp_servers_for_role_ignores_unknown_servers() -> None:
     assert servers == [{"command": "npx", "id": "docs", "name": "docs"}]
 
 
+@pytest.mark.asyncio
+async def test_build_mcp_servers_for_role_overlays_declared_w3_auth_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return "runtime-token"
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    role = RoleDefinition(
+        role_id="writer",
+        name="Writer",
+        description="Writes documents.",
+        version="1.0.0",
+        tools=(),
+        mcp_servers=("docs",),
+        skills=(),
+        model_profile="default",
+        system_prompt="Write clearly.",
+    )
+    server_config = {
+        "command": "npx",
+        "env": {"X_AUTH_TOKEN": "placeholder", "AUTH_TOKEN": "keep"},
+        "headers": {"X-Auth-Token": "header-placeholder"},
+    }
+    mcp_registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="docs",
+                config={"mcpServers": {"docs": server_config}},
+                server_config=server_config,
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    await mcp_registry.prepare_w3_auth_env(("docs",), consumer="test")
+
+    servers = _build_mcp_servers_for_role(
+        role=role,
+        mcp_registry=mcp_registry,
+    )
+
+    assert servers == [
+        {
+            "command": "npx",
+            "env": {"X_AUTH_TOKEN": "runtime-token", "AUTH_TOKEN": "keep"},
+            "headers": {"X-Auth-Token": "header-placeholder"},
+            "id": "docs",
+            "name": "docs",
+        }
+    ]
+    assert server_config["env"]["X_AUTH_TOKEN"] == "placeholder"
+
+
 def _cast_bridge(bridge: _FakeHostToolBridge) -> ExternalAcpHostToolBridge:
     return cast(ExternalAcpHostToolBridge, bridge)
 

--- a/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
@@ -12,6 +12,7 @@ import pytest
 from relay_teams.agents.execution.event_publishing import EventPublishingService
 from relay_teams.agents.execution import event_publishing as event_publishing_module
 from relay_teams.agents.execution import session_prompt as session_prompt_module
+from relay_teams.mcp.mcp_models import McpToolInfo
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.tools.runtime.persisted_state import (
     load_tool_call_state,
@@ -1044,6 +1045,293 @@ async def test_build_agent_iteration_context_does_not_override_proxy_env_when_ho
     assert (
         captured["llm_http_client_cache_scope"]
         == "run-1:session-1:task-1:inst-1:writer"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_agent_iteration_context_refreshes_failed_w3_mcp_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _W3McpRegistry(McpRegistry):
+        def __init__(self) -> None:
+            super().__init__(
+                (
+                    McpServerSpec(
+                        name="w3",
+                        config={"mcpServers": {"w3": {"command": "npx"}}},
+                        server_config={
+                            "command": "npx",
+                            "env": {"X_AUTH_TOKEN": "placeholder"},
+                        },
+                        source=McpConfigScope.APP,
+                    ),
+                )
+            )
+            self.discovery_calls: list[str] = []
+
+        async def list_tools_for_discovery(self, name: str) -> tuple[McpToolInfo, ...]:
+            self.discovery_calls.append(name)
+            return ()
+
+    class _FakeDiscoveryService:
+        def __init__(self) -> None:
+            self.summary_calls: list[str] = []
+            self.ready_calls: list[tuple[str, tuple[McpToolInfo, ...]]] = []
+            self.failed_calls: list[tuple[str, Exception]] = []
+
+        def get_tools_summary(self, name: str) -> object:
+            self.summary_calls.append(name)
+            return type(
+                "_Summary",
+                (),
+                {"status": session_prompt_module.McpDiscoveryStatus.FAILED},
+            )()
+
+        def mark_ready(self, name: str, tools: tuple[McpToolInfo, ...]) -> None:
+            self.ready_calls.append((name, tools))
+
+        def mark_failed(self, name: str, exc: Exception) -> None:
+            self.failed_calls.append((name, exc))
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return "runtime-token"
+
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="glm-5.1",
+        base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+        api_key="test-key",
+    )
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = cast(object, None)
+    mcp_registry = _W3McpRegistry()
+    session.__dict__["_mcp_registry"] = mcp_registry
+    discovery_service = _FakeDiscoveryService()
+    session.__dict__["_mcp_discovery_service"] = discovery_service
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_hook_service"] = _FakeRunEnvHookService({})
+
+    async def _prepare_prompt_context(**_kwargs: object) -> object:
+        return type(
+            "_PreparedPrompt",
+            (),
+            {"history": (), "system_prompt": "Prepared system prompt"},
+        )()
+
+    async def _build_model_settings(**_kwargs: object) -> object:
+        return object()
+
+    session.__dict__["_prepare_prompt_context"] = _prepare_prompt_context
+    session.__dict__["_build_model_settings"] = _build_model_settings
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    monkeypatch.setattr(
+        session_prompt_module,
+        "build_coordination_agent",
+        lambda **_kwargs: object(),
+    )
+
+    _ = await AgentLlmSession._build_agent_iteration_context(
+        session,
+        request=_build_request(),
+        conversation_id="conv-1",
+        system_prompt="System prompt",
+        reserve_user_prompt_tokens=False,
+        allowed_tools=(),
+        allowed_mcp_servers=("w3",),
+        allowed_skills=(),
+    )
+
+    assert mcp_registry.discovery_calls == ["w3"]
+    assert discovery_service.ready_calls == [("w3", ())]
+    assert discovery_service.failed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_failed_w3_mcp_discovery_skips_without_discovery_service() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_mcp_registry"] = McpRegistry(())
+    session.__dict__["_mcp_discovery_service"] = None
+
+    await AgentLlmSession._refresh_failed_w3_mcp_discovery_after_auth(
+        session,
+        ("w3",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_failed_w3_mcp_discovery_skips_without_w3_runtime() -> None:
+    class _PlainRegistry:
+        pass
+
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_mcp_registry"] = _PlainRegistry()
+    session.__dict__["_mcp_discovery_service"] = object()
+
+    await AgentLlmSession._refresh_failed_w3_mcp_discovery_after_auth(
+        session,
+        ("w3",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_failed_w3_mcp_discovery_skips_without_runtime_token() -> None:
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_mcp_registry"] = McpRegistry(())
+    session.__dict__["_mcp_discovery_service"] = object()
+
+    await AgentLlmSession._refresh_failed_w3_mcp_discovery_after_auth(
+        session,
+        ("w3",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_failed_w3_mcp_discovery_skips_plain_servers() -> None:
+    class _TokenMcpRegistry(McpRegistry):
+        def runtime_w3_x_auth_token(self) -> str | None:
+            return "runtime-token"
+
+    class _FakeDiscoveryService:
+        def __init__(self) -> None:
+            self.summary_calls: list[str] = []
+
+        def get_tools_summary(self, name: str) -> object:
+            self.summary_calls.append(name)
+            return object()
+
+    registry = _TokenMcpRegistry(
+        (
+            McpServerSpec(
+                name="plain",
+                config={"mcpServers": {"plain": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    discovery_service = _FakeDiscoveryService()
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_mcp_registry"] = registry
+    session.__dict__["_mcp_discovery_service"] = discovery_service
+
+    await AgentLlmSession._refresh_failed_w3_mcp_discovery_after_auth(
+        session,
+        ("plain",),
+    )
+
+    assert discovery_service.summary_calls == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_failed_w3_mcp_discovery_marks_failed_on_refresh_error() -> None:
+    class _FailingW3McpRegistry(McpRegistry):
+        def __init__(self) -> None:
+            super().__init__(
+                (
+                    McpServerSpec(
+                        name="w3",
+                        config={"mcpServers": {"w3": {"command": "npx"}}},
+                        server_config={
+                            "command": "npx",
+                            "env": {"X_AUTH_TOKEN": "placeholder"},
+                        },
+                        source=McpConfigScope.APP,
+                    ),
+                )
+            )
+
+        def runtime_w3_x_auth_token(self) -> str | None:
+            return "runtime-token"
+
+        async def list_tools_for_discovery(self, name: str) -> tuple[McpToolInfo, ...]:
+            _ = name
+            raise RuntimeError("refresh failed")
+
+    class _FakeDiscoveryService:
+        def __init__(self) -> None:
+            self.ready_calls: list[tuple[str, tuple[McpToolInfo, ...]]] = []
+            self.failed_calls: list[tuple[str, Exception]] = []
+
+        def get_tools_summary(self, name: str) -> object:
+            _ = name
+            return type(
+                "_Summary",
+                (),
+                {"status": session_prompt_module.McpDiscoveryStatus.FAILED},
+            )()
+
+        def mark_ready(self, name: str, tools: tuple[McpToolInfo, ...]) -> None:
+            self.ready_calls.append((name, tools))
+
+        def mark_failed(self, name: str, exc: Exception) -> None:
+            self.failed_calls.append((name, exc))
+
+    discovery_service = _FakeDiscoveryService()
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_mcp_registry"] = _FailingW3McpRegistry()
+    session.__dict__["_mcp_discovery_service"] = discovery_service
+
+    await AgentLlmSession._refresh_failed_w3_mcp_discovery_after_auth(
+        session,
+        ("w3",),
+    )
+
+    assert discovery_service.ready_calls == []
+    assert len(discovery_service.failed_calls) == 1
+    failed_name, exc = discovery_service.failed_calls[0]
+    assert failed_name == "w3"
+    assert str(exc) == "refresh failed"
+
+
+def test_mcp_server_declares_w3_auth_env_handles_missing_or_plain_specs() -> None:
+    class _MissingSpecRegistry:
+        def get_w3_auth_env_spec(self, name: str) -> McpServerSpec:
+            _ = name
+            raise ValueError("missing")
+
+    plain_registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="plain",
+                config={"mcpServers": {"plain": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+            McpServerSpec(
+                name="w3",
+                config={"mcpServers": {"w3": {"command": "npx"}}},
+                server_config={"command": "npx", "env": {"xAuthToken": "placeholder"}},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    assert (
+        session_prompt_module._mcp_server_declares_w3_auth_env(
+            _MissingSpecRegistry(),
+            "missing",
+        )
+        is False
+    )
+    assert (
+        session_prompt_module._mcp_server_declares_w3_auth_env(
+            plain_registry,
+            "plain",
+        )
+        is False
+    )
+    assert (
+        session_prompt_module._mcp_server_declares_w3_auth_env(
+            plain_registry,
+            "w3",
+        )
+        is True
     )
 
 

--- a/tests/unit_tests/env/test_app_env_watcher.py
+++ b/tests/unit_tests/env/test_app_env_watcher.py
@@ -15,8 +15,8 @@ def _reset_runtime_env_sync(
     monkeypatch: pytest.MonkeyPatch,
     keys: tuple[str, ...],
 ) -> None:
-    monkeypatch.setattr(runtime_env, "_PROCESS_ENV_BASELINE", {})
-    monkeypatch.setattr(runtime_env, "_SYNCED_APP_ENV_KEYS", set())
+    runtime_env.PROCESS_ENV_BASELINE.clear()
+    runtime_env.SYNCED_APP_ENV_KEYS.clear()
     for key in keys:
         monkeypatch.delenv(key, raising=False)
 

--- a/tests/unit_tests/env/test_runtime_env.py
+++ b/tests/unit_tests/env/test_runtime_env.py
@@ -82,8 +82,8 @@ def test_sync_app_env_to_process_env_reads_secret_backed_values(
         ),
         encoding="utf-8",
     )
-    monkeypatch.setattr(runtime_env, "_PROCESS_ENV_BASELINE", {})
-    monkeypatch.setattr(runtime_env, "_SYNCED_APP_ENV_KEYS", set())
+    runtime_env.PROCESS_ENV_BASELINE.clear()
+    runtime_env.SYNCED_APP_ENV_KEYS.clear()
     monkeypatch.delenv("APP_ONLY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
@@ -169,8 +169,8 @@ def test_sync_app_env_to_process_env_applies_and_removes_managed_keys(
     env_file = tmp_path / ".relay-teams" / ".env"
     env_file.parent.mkdir(parents=True)
     env_file.write_text("SYNCED_KEY=from-file\n", encoding="utf-8")
-    monkeypatch.setattr(runtime_env, "_PROCESS_ENV_BASELINE", {})
-    monkeypatch.setattr(runtime_env, "_SYNCED_APP_ENV_KEYS", set())
+    runtime_env.PROCESS_ENV_BASELINE.clear()
+    runtime_env.SYNCED_APP_ENV_KEYS.clear()
     monkeypatch.delenv("SYNCED_KEY", raising=False)
 
     synced_env = runtime_env.sync_app_env_to_process_env(env_file)
@@ -191,8 +191,9 @@ def test_sync_app_env_to_process_env_restores_baseline_values(
     env_file = tmp_path / ".relay-teams" / ".env"
     env_file.parent.mkdir(parents=True)
     env_file.write_text("RESTORE_KEY=overlay\n", encoding="utf-8")
-    monkeypatch.setattr(runtime_env, "_PROCESS_ENV_BASELINE", {"RESTORE_KEY": "base"})
-    monkeypatch.setattr(runtime_env, "_SYNCED_APP_ENV_KEYS", set())
+    runtime_env.PROCESS_ENV_BASELINE.clear()
+    runtime_env.PROCESS_ENV_BASELINE["RESTORE_KEY"] = "base"
+    runtime_env.SYNCED_APP_ENV_KEYS.clear()
     monkeypatch.setenv("RESTORE_KEY", "base")
 
     runtime_env.sync_app_env_to_process_env(env_file)

--- a/tests/unit_tests/env/test_w3_auth_token_env.py
+++ b/tests/unit_tests/env/test_w3_auth_token_env.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from relay_teams.env import w3_auth_token_env as w3_auth_token_env_module
+from relay_teams.env import (
+    env_declares_w3_x_auth_token as package_env_declares_w3_x_auth_token,
+)
+from relay_teams.env import (
+    is_w3_x_auth_token_env_name as package_is_w3_x_auth_token_env_name,
+)
+from relay_teams.env import (
+    overlay_w3_x_auth_token_env as package_overlay_w3_x_auth_token_env,
+)
+from relay_teams.env import resolve_w3_x_auth_token as package_resolve_w3_x_auth_token
+from relay_teams.env.w3_auth_token_env import (
+    is_w3_x_auth_token_env_name,
+    overlay_w3_x_auth_token_env,
+    resolve_w3_x_auth_token,
+)
+from relay_teams.providers.maas_auth import MaaSAuthContext, MaaSLoginError
+from relay_teams.providers.model_config import MaaSAuthConfig
+from relay_teams.providers.w3_auth_source import (
+    W3Credentials,
+    W3_PASSWORD_FIELD,
+    W3_SECRET_NAMESPACE,
+    W3_SECRET_OWNER_ID,
+)
+from relay_teams.secrets import AppSecretStore
+
+
+class _FileSecretStore(AppSecretStore):
+    def has_usable_keyring_backend(self) -> bool:
+        return False
+
+
+class _TokenService:
+    def __init__(
+        self,
+        *,
+        token: str = "w3-token",
+        error: Exception | None = None,
+    ) -> None:
+        self._token = token
+        self._error = error
+        self.calls: list[MaaSAuthConfig] = []
+
+    async def get_auth_context(
+        self,
+        *,
+        auth_config: MaaSAuthConfig,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+        force_refresh: bool = False,
+    ) -> MaaSAuthContext:
+        _ = ssl_verify
+        _ = connect_timeout_seconds
+        _ = force_refresh
+        self.calls.append(auth_config)
+        if self._error is not None:
+            raise self._error
+        return MaaSAuthContext(token=self._token)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ("X_AUTH_TOKEN", "x-auth-token", "X-Auth-Token", "xAuthToken"),
+)
+def test_is_w3_x_auth_token_env_name_matches_supported_variants(name: str) -> None:
+    assert is_w3_x_auth_token_env_name(name) is True
+
+
+@pytest.mark.parametrize("name", ("AUTH_TOKEN", "WEB_TOKEN"))
+def test_is_w3_x_auth_token_env_name_rejects_other_tokens(name: str) -> None:
+    assert is_w3_x_auth_token_env_name(name) is False
+
+
+def test_w3_auth_token_env_helpers_are_exposed_from_env_package() -> None:
+    assert package_env_declares_w3_x_auth_token({"X_AUTH_TOKEN": "x"}) is True
+    assert package_is_w3_x_auth_token_env_name("xAuthToken") is True
+    assert callable(package_overlay_w3_x_auth_token_env)
+    assert callable(package_resolve_w3_x_auth_token)
+
+
+@pytest.mark.asyncio
+async def test_w3_auth_token_env_async_helpers_are_exposed_from_env_package(
+    tmp_path: Path,
+) -> None:
+    secret_store = _FileSecretStore()
+    token_service = _TokenService(token="runtime-token")
+    _write_w3_credentials(tmp_path, secret_store=secret_store)
+
+    token = await package_resolve_w3_x_auth_token(
+        config_dir=tmp_path,
+        secret_store=secret_store,
+        token_service=token_service,
+    )
+    env = await package_overlay_w3_x_auth_token_env(
+        {"X_AUTH_TOKEN": "placeholder"},
+        declared_env={"X_AUTH_TOKEN": "placeholder"},
+        config_dir=tmp_path,
+        secret_store=secret_store,
+        token_service=token_service,
+    )
+
+    assert token == "runtime-token"
+    assert env == {"X_AUTH_TOKEN": "runtime-token"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_w3_x_auth_token_uses_w3_credentials(tmp_path: Path) -> None:
+    secret_store = _FileSecretStore()
+    token_service = _TokenService(token="runtime-token")
+    _write_w3_credentials(tmp_path, secret_store=secret_store)
+
+    token = await resolve_w3_x_auth_token(
+        config_dir=tmp_path,
+        secret_store=secret_store,
+        token_service=token_service,
+    )
+
+    assert token == "runtime-token"
+    assert len(token_service.calls) == 1
+    assert token_service.calls[0].username == "w3-user"
+    assert token_service.calls[0].password == "w3-password"
+
+
+@pytest.mark.asyncio
+async def test_resolve_w3_x_auth_token_reads_w3_credentials_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    token_service = _TokenService(token="runtime-token")
+    main_thread_id = threading.get_ident()
+    credential_thread_ids: list[int] = []
+
+    def fake_get_w3_credentials(
+        config_dir: Path,
+        *,
+        secret_store: AppSecretStore | None = None,
+    ) -> W3Credentials:
+        _ = config_dir, secret_store
+        credential_thread_ids.append(threading.get_ident())
+        return W3Credentials(username="w3-user", password="w3-password")
+
+    monkeypatch.setattr(
+        w3_auth_token_env_module,
+        "get_w3_credentials",
+        fake_get_w3_credentials,
+    )
+
+    token = await resolve_w3_x_auth_token(
+        config_dir=tmp_path,
+        secret_store=_FileSecretStore(),
+        token_service=token_service,
+    )
+
+    assert token == "runtime-token"
+    assert credential_thread_ids
+    assert main_thread_id not in credential_thread_ids
+
+
+@pytest.mark.asyncio
+async def test_resolve_w3_x_auth_token_returns_none_without_credentials(
+    tmp_path: Path,
+) -> None:
+    token_service = _TokenService(token="runtime-token")
+
+    token = await resolve_w3_x_auth_token(
+        config_dir=tmp_path,
+        secret_store=_FileSecretStore(),
+        token_service=token_service,
+    )
+
+    assert token is None
+    assert token_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_w3_x_auth_token_returns_none_on_login_failure(
+    tmp_path: Path,
+) -> None:
+    secret_store = _FileSecretStore()
+    token_service = _TokenService(
+        error=MaaSLoginError("login failed", status_code=401),
+    )
+    _write_w3_credentials(tmp_path, secret_store=secret_store)
+
+    token = await resolve_w3_x_auth_token(
+        config_dir=tmp_path,
+        secret_store=secret_store,
+        token_service=token_service,
+    )
+
+    assert token is None
+    assert len(token_service.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_w3_x_auth_token_returns_none_on_generic_failure(
+    tmp_path: Path,
+) -> None:
+    secret_store = _FileSecretStore()
+    token_service = _TokenService(error=RuntimeError("service unavailable"))
+    _write_w3_credentials(tmp_path, secret_store=secret_store)
+
+    token = await resolve_w3_x_auth_token(
+        config_dir=tmp_path,
+        secret_store=secret_store,
+        token_service=token_service,
+    )
+
+    assert token is None
+    assert len(token_service.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_overlay_w3_x_auth_token_env_only_replaces_declared_matching_key(
+    tmp_path: Path,
+) -> None:
+    secret_store = _FileSecretStore()
+    _write_w3_credentials(tmp_path, secret_store=secret_store)
+
+    env = await overlay_w3_x_auth_token_env(
+        {"X_AUTH_TOKEN": "placeholder", "AUTH_TOKEN": "keep"},
+        declared_env={"X_AUTH_TOKEN": "placeholder", "AUTH_TOKEN": "keep"},
+        config_dir=tmp_path,
+        secret_store=secret_store,
+        token_service=_TokenService(token="runtime-token"),
+    )
+
+    assert env == {"X_AUTH_TOKEN": "runtime-token", "AUTH_TOKEN": "keep"}
+
+
+@pytest.mark.asyncio
+async def test_overlay_w3_x_auth_token_env_skips_missing_declared_key(
+    tmp_path: Path,
+) -> None:
+    token_service = _TokenService(token="runtime-token")
+
+    env = await overlay_w3_x_auth_token_env(
+        {"AUTH_TOKEN": "keep"},
+        declared_env={"X_AUTH_TOKEN": "placeholder"},
+        config_dir=tmp_path,
+        secret_store=_FileSecretStore(),
+        token_service=token_service,
+    )
+
+    assert env == {"AUTH_TOKEN": "keep"}
+    assert token_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_overlay_w3_x_auth_token_env_preserves_env_when_token_missing(
+    tmp_path: Path,
+) -> None:
+    token_service = _TokenService(token="runtime-token")
+
+    env = await overlay_w3_x_auth_token_env(
+        {"X_AUTH_TOKEN": "placeholder", "AUTH_TOKEN": "keep"},
+        declared_env={"X_AUTH_TOKEN": "placeholder"},
+        config_dir=tmp_path,
+        secret_store=_FileSecretStore(),
+        token_service=token_service,
+    )
+
+    assert env == {"X_AUTH_TOKEN": "placeholder", "AUTH_TOKEN": "keep"}
+    assert token_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_overlay_w3_x_auth_token_env_removes_inherited_matching_variants(
+    tmp_path: Path,
+) -> None:
+    secret_store = _FileSecretStore()
+    _write_w3_credentials(tmp_path, secret_store=secret_store)
+
+    env = await overlay_w3_x_auth_token_env(
+        {
+            "X_AUTH_TOKEN": "ambient",
+            "x_auth_token": "placeholder",
+            "AUTH_TOKEN": "keep",
+        },
+        declared_env={"x_auth_token": "placeholder"},
+        config_dir=tmp_path,
+        secret_store=secret_store,
+        token_service=_TokenService(token="runtime-token"),
+    )
+
+    assert env == {"x_auth_token": "runtime-token", "AUTH_TOKEN": "keep"}
+
+
+def _write_w3_credentials(
+    config_dir: Path,
+    *,
+    secret_store: AppSecretStore,
+) -> None:
+    connectors_dir = config_dir / "connectors"
+    connectors_dir.mkdir()
+    (connectors_dir / "w3.json").write_text(
+        '{"username": "w3-user"}',
+        encoding="utf-8",
+    )
+    secret_store.set_secret(
+        config_dir,
+        namespace=W3_SECRET_NAMESPACE,
+        owner_id=W3_SECRET_OWNER_ID,
+        field_name=W3_PASSWORD_FIELD,
+        value="w3-password",
+    )

--- a/tests/unit_tests/gateway/test_acp_mcp_relay.py
+++ b/tests/unit_tests/gateway/test_acp_mcp_relay.py
@@ -25,7 +25,7 @@ from relay_teams.metrics import (
     MetricRecorder,
     MetricRegistry,
 )
-from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
+from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec, McpToolInfo
 from relay_teams.mcp.mcp_registry import McpRegistry
 
 
@@ -481,6 +481,597 @@ def test_gateway_aware_mcp_registry_filters_unknowns_after_wildcard() -> None:
     assert resolved == ("filesystem", "zed-tools")
 
 
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_prepares_w3_env_on_base_registry() -> None:
+    class _TrackingMcpRegistry(McpRegistry):
+        def __init__(self) -> None:
+            super().__init__(
+                (
+                    McpServerSpec(
+                        name="filesystem",
+                        config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                        server_config={
+                            "command": "npx",
+                            "env": {"X_AUTH_TOKEN": "placeholder"},
+                        },
+                        source=McpConfigScope.APP,
+                    ),
+                )
+            )
+            self.prepare_calls: list[tuple[tuple[str, ...], bool, str | None]] = []
+
+        async def prepare_w3_auth_env(
+            self,
+            names: tuple[str, ...],
+            *,
+            strict: bool = True,
+            consumer: str | None = None,
+        ) -> None:
+            self.prepare_calls.append((names, strict, consumer))
+
+    relay = AcpMcpRelay()
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="zed-tools",
+                name="zed-tools",
+                transport="acp",
+                config={"transport": "acp", "id": "zed-tools"},
+            ),
+        ),
+    )
+    base_registry = _TrackingMcpRegistry()
+    registry = GatewayAwareMcpRegistry(
+        base_registry=base_registry,
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        await registry.prepare_w3_auth_env(
+            ("*",),
+            strict=False,
+            consumer="test.consumer",
+        )
+
+    assert base_registry.prepare_calls == [(("filesystem",), False, "test.consumer")]
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_prepares_w3_env_for_session_stdio_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relay = AcpMcpRelay()
+    built_tokens: list[str | None] = []
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return "runtime-token"
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FakeToolset:
+        built_tokens.append(w3_x_auth_token)
+        return _FakeToolset((), tool_prefix=spec.name)
+
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "build_mcp_server",
+        fake_build_mcp_server,
+    )
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="w3-session",
+                name="w3-session",
+                transport="stdio",
+                config={
+                    "command": "npx",
+                    "env": {"xAuthToken": "placeholder"},
+                },
+            ),
+        ),
+    )
+    registry = GatewayAwareMcpRegistry(
+        base_registry=McpRegistry(()),
+        relay=relay,
+    )
+
+    relay.prepare_current_session_w3_auth_token(("w3-session",), token="ignored")
+    assert relay.current_session_w3_auth_tokens() == ()
+    assert acp_mcp_relay_module._gateway_server_declares_w3_auth_env(None) is False
+
+    with relay.session_scope("gws_123"):
+        await registry.prepare_w3_auth_env(("w3-session",), consumer="test.consumer")
+        assert registry.runtime_w3_x_auth_token() == "runtime-token"
+        toolsets = registry.get_toolsets(("w3-session",))
+
+    assert len(toolsets) == 1
+    assert built_tokens == ["runtime-token"]
+    assert registry.runtime_w3_x_auth_token() is None
+
+    relay.bind_session_servers("gws_123", ())
+    with relay.session_scope("gws_123"):
+        assert registry.runtime_w3_x_auth_token() is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_prepares_w3_env_for_session_local_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relay = AcpMcpRelay()
+    built_tokens: list[str | None] = []
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return "runtime-token"
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FakeToolset:
+        built_tokens.append(w3_x_auth_token)
+        return _FakeToolset((), tool_prefix=spec.name)
+
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "build_mcp_server",
+        fake_build_mcp_server,
+    )
+    local_spec = GatewayMcpServerSpec(
+        server_id="local-session",
+        name="local-session",
+        transport="local",
+        config={
+            "type": "local",
+            "command": "npx",
+            "env": {"X_AUTH_TOKEN": "placeholder"},
+        },
+    )
+    relay.bind_session_servers("gws_123", (local_spec,))
+    registry = GatewayAwareMcpRegistry(
+        base_registry=McpRegistry(()),
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        await registry.prepare_w3_auth_env(
+            ("local-session",),
+            consumer="test.consumer",
+        )
+        assert registry.get_toolsets(("local-session",))
+
+    assert built_tokens == ["runtime-token"]
+    assert acp_mcp_relay_module._gateway_server_declares_w3_auth_env(local_spec) is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_prepares_shadowed_session_w3_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _TrackingMcpRegistry(McpRegistry):
+        def __init__(self) -> None:
+            super().__init__(
+                (
+                    McpServerSpec(
+                        name="shared",
+                        config={"mcpServers": {"shared": {"command": "npx"}}},
+                        server_config={
+                            "command": "npx",
+                            "env": {"AUTH_TOKEN": "base-placeholder"},
+                        },
+                        source=McpConfigScope.APP,
+                    ),
+                )
+            )
+            self.prepare_calls: list[tuple[tuple[str, ...], bool, str | None]] = []
+
+        async def prepare_w3_auth_env(
+            self,
+            names: tuple[str, ...],
+            *,
+            strict: bool = True,
+            consumer: str | None = None,
+        ) -> None:
+            self.prepare_calls.append((names, strict, consumer))
+
+    relay = AcpMcpRelay()
+    built_tokens: list[str | None] = []
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return "runtime-token"
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FakeToolset:
+        built_tokens.append(w3_x_auth_token)
+        return _FakeToolset((), tool_prefix=spec.name)
+
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "build_mcp_server",
+        fake_build_mcp_server,
+    )
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="shared",
+                name="shared",
+                transport="stdio",
+                config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "session-placeholder"},
+                },
+            ),
+        ),
+    )
+    base_registry = _TrackingMcpRegistry()
+    registry = GatewayAwareMcpRegistry(
+        base_registry=base_registry,
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        spec = registry.get_w3_auth_env_spec("shared")
+        raw_env = spec.server_config["env"]
+        assert isinstance(raw_env, dict)
+        assert acp_mcp_relay_module.env_declares_w3_x_auth_token(
+            raw_env,
+        )
+        await registry.prepare_w3_auth_env(("shared",), consumer="test.consumer")
+        assert registry.get_toolsets(("shared",))
+
+    assert base_registry.prepare_calls == []
+    assert built_tokens == ["runtime-token"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_preserves_and_reenables_session_w3_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relay = AcpMcpRelay()
+    resolved_tokens: list[str | None] = ["runtime-token", None]
+    built_tokens: list[str | None] = []
+
+    async def fake_resolve_w3_x_auth_token() -> str | None:
+        return resolved_tokens.pop(0)
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FakeToolset:
+        built_tokens.append(w3_x_auth_token)
+        if w3_x_auth_token is None:
+            raise RuntimeError("startup failed")
+        return _FakeToolset((), tool_prefix=spec.name)
+
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "build_mcp_server",
+        fake_build_mcp_server,
+    )
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="w3-session",
+                name="w3-session",
+                transport="stdio",
+                config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+            ),
+        ),
+    )
+    registry = GatewayAwareMcpRegistry(
+        base_registry=McpRegistry(()),
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        assert registry.get_toolsets(("w3-session",)) == ()
+        await registry.prepare_w3_auth_env(("w3-session",), consumer="test.consumer")
+        toolsets = registry.get_toolsets(("w3-session",))
+        assert registry.runtime_w3_x_auth_token() == "runtime-token"
+        await registry.prepare_w3_auth_env(("w3-session",), consumer="test.consumer")
+        preserved_toolsets = registry.get_toolsets(("w3-session",))
+        assert registry.runtime_w3_x_auth_token() == "runtime-token"
+
+    assert len(toolsets) == 1
+    assert preserved_toolsets == toolsets
+    assert built_tokens == [None, "runtime-token"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_discovers_session_stdio_with_w3_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relay = AcpMcpRelay()
+    built_tokens: list[str | None] = []
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return "runtime-token"
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FakeToolset:
+        built_tokens.append(w3_x_auth_token)
+        return _FakeToolset(
+            (
+                _FakeListedTool(
+                    name="echo",
+                    description="Echo",
+                    input_schema={"type": "object"},
+                ),
+            ),
+            tool_prefix=spec.name,
+        )
+
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "build_mcp_server",
+        fake_build_mcp_server,
+    )
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="w3-session",
+                name="w3-session",
+                transport="stdio",
+                config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+            ),
+        ),
+    )
+    registry = GatewayAwareMcpRegistry(
+        base_registry=McpRegistry(()),
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        await registry.prepare_w3_auth_env(("w3-session",), consumer="test.consumer")
+        tools = await registry.list_tools_for_discovery("w3-session")
+
+    assert built_tokens == ["runtime-token"]
+    assert tools == (
+        McpToolInfo(
+            name="w3-session_echo",
+            description="Echo",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_discovery_delegates_without_session() -> None:
+    class _TrackingMcpRegistry(McpRegistry):
+        def __init__(self) -> None:
+            super().__init__(())
+            self.calls: list[str] = []
+
+        async def list_tools_for_discovery(
+            self,
+            name: str,
+        ) -> tuple[McpToolInfo, ...]:
+            self.calls.append(name)
+            return (McpToolInfo(name="base_echo", description="Echo"),)
+
+    base_registry = _TrackingMcpRegistry()
+    registry = GatewayAwareMcpRegistry(
+        base_registry=base_registry,
+        relay=AcpMcpRelay(),
+    )
+
+    tools = await registry.list_tools_for_discovery("base")
+
+    assert tools == (McpToolInfo(name="base_echo", description="Echo"),)
+    assert base_registry.calls == ["base"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_discovery_returns_empty_for_inactive_acp() -> (
+    None
+):
+    relay = AcpMcpRelay()
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="zed-tools",
+                name="zed-tools",
+                transport="acp",
+                config={"transport": "acp", "id": "zed-tools"},
+            ),
+        ),
+    )
+    registry = GatewayAwareMcpRegistry(
+        base_registry=McpRegistry(()),
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        tools = await registry.list_tools_for_discovery("zed-tools")
+
+    assert tools == ()
+    assert (
+        acp_mcp_relay_module._gateway_server_declares_w3_auth_env(
+            GatewayMcpServerSpec(
+                server_id="zed-tools",
+                name="zed-tools",
+                transport="acp",
+                config={"transport": "acp", "env": {"X_AUTH_TOKEN": "placeholder"}},
+            )
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_discovery_disables_failed_stdio_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relay = AcpMcpRelay()
+    calls = 0
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FakeToolset:
+        _ = spec, w3_x_auth_token
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("startup failed")
+
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "build_mcp_server",
+        fake_build_mcp_server,
+    )
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="w3-session",
+                name="w3-session",
+                transport="stdio",
+                config={"command": "npx"},
+            ),
+        ),
+    )
+    registry = GatewayAwareMcpRegistry(
+        base_registry=McpRegistry(()),
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        with pytest.raises(RuntimeError, match="startup failed"):
+            await registry.list_tools_for_discovery("w3-session")
+        tools = await registry.list_tools_for_discovery("w3-session")
+
+    assert tools == ()
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_aware_mcp_registry_discovery_disables_failed_tool_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relay = AcpMcpRelay()
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FailingListToolset:
+        _ = spec, w3_x_auth_token
+        return _FailingListToolset(
+            (),
+            error=RuntimeError("listing failed"),
+            tool_prefix=spec.name,
+        )
+
+    monkeypatch.setattr(
+        acp_mcp_relay_module,
+        "build_mcp_server",
+        fake_build_mcp_server,
+    )
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="w3-session",
+                name="w3-session",
+                transport="stdio",
+                config={"command": "npx"},
+            ),
+        ),
+    )
+    registry = GatewayAwareMcpRegistry(
+        base_registry=McpRegistry(()),
+        relay=relay,
+    )
+
+    with relay.session_scope("gws_123"):
+        with pytest.raises(RuntimeError, match="listing failed"):
+            await registry.list_tools_for_discovery("w3-session")
+        tools = await registry.list_tools_for_discovery("w3-session")
+
+    assert tools == ()
+
+
+def test_acp_mcp_relay_prunes_session_w3_tokens_when_servers_rebind() -> None:
+    relay = AcpMcpRelay()
+
+    with relay.session_scope("other-session"):
+        relay.prepare_current_session_w3_auth_token(("other",), token="other-token")
+    with relay.session_scope("gws_123"):
+        relay.prepare_current_session_w3_auth_token(("kept",), token="kept-token")
+        relay.prepare_current_session_w3_auth_token(("removed",), token="old-token")
+
+    relay.bind_session_servers(
+        "gws_123",
+        (
+            GatewayMcpServerSpec(
+                server_id="kept",
+                name="kept",
+                transport="stdio",
+                config={"command": "npx"},
+            ),
+        ),
+    )
+
+    with relay.session_scope("gws_123"):
+        assert relay.current_session_w3_auth_tokens() == ("kept-token",)
+        relay.prepare_current_session_w3_auth_token(("kept",), token=None)
+        assert relay.current_session_w3_auth_tokens() == ()
+    with relay.session_scope("other-session"):
+        assert relay.current_session_w3_auth_tokens() == ("other-token",)
+
+
 def test_gateway_aware_mcp_registry_validates_exact_wildcard_only() -> None:
     registry = GatewayAwareMcpRegistry(
         base_registry=McpRegistry(()),
@@ -709,6 +1300,21 @@ class _FakeToolset:
         return self._tools
 
 
+class _FailingListToolset(_FakeToolset):
+    def __init__(
+        self,
+        tools: tuple[_FakeListedTool, ...],
+        *,
+        error: RuntimeError,
+        tool_prefix: str | None = None,
+    ) -> None:
+        super().__init__(tools, tool_prefix=tool_prefix)
+        self._error = error
+
+    async def list_tools(self) -> tuple[_FakeListedTool, ...]:
+        raise self._error
+
+
 @pytest.mark.asyncio
 async def test_gateway_aware_mcp_registry_exposes_session_scoped_stdio_servers(
     monkeypatch: pytest.MonkeyPatch,
@@ -716,7 +1322,13 @@ async def test_gateway_aware_mcp_registry_exposes_session_scoped_stdio_servers(
     relay = AcpMcpRelay()
     built_specs: list[McpServerSpec] = []
 
-    def fake_build_mcp_server(spec: McpServerSpec) -> _FakeToolset:
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        w3_x_auth_token: str | None = None,
+        **_kwargs: object,
+    ) -> _FakeToolset:
+        _ = w3_x_auth_token
         built_specs.append(spec)
         return _FakeToolset(
             (

--- a/tests/unit_tests/mcp/test_mcp_config_manager.py
+++ b/tests/unit_tests/mcp/test_mcp_config_manager.py
@@ -223,12 +223,12 @@ def test_load_registry_preserves_process_proxy_for_mcp_runtime(
     monkeypatch.setenv("HTTPS_PROXY", "http://process-proxy.internal:8443")
     monkeypatch.setenv("NO_PROXY", "localhost,.internal")
     monkeypatch.setitem(
-        runtime_env._PROCESS_ENV_BASELINE,
+        runtime_env.PROCESS_ENV_BASELINE,
         "HTTPS_PROXY",
         "http://process-proxy.internal:8443",
     )
     monkeypatch.setitem(
-        runtime_env._PROCESS_ENV_BASELINE,
+        runtime_env.PROCESS_ENV_BASELINE,
         "NO_PROXY",
         "localhost,.internal",
     )

--- a/tests/unit_tests/mcp/test_mcp_service.py
+++ b/tests/unit_tests/mcp/test_mcp_service.py
@@ -10,6 +10,7 @@ from types import TracebackType
 
 import pytest
 import httpx
+from pydantic import JsonValue
 from pydantic_ai.mcp import MCPServerSSE, MCPServerStdio, MCPServerStreamableHTTP
 
 from relay_teams.env.proxy_env import ProxyEnvConfig
@@ -23,7 +24,11 @@ from relay_teams.mcp.mcp_models import (
     McpToolSchema,
 )
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
-from relay_teams.mcp.mcp_registry import McpRegistry, build_mcp_server
+from relay_teams.mcp.mcp_registry import (
+    McpRegistry,
+    build_mcp_server,
+    overlay_mcp_server_config_w3_auth_env,
+)
 from relay_teams.mcp.mcp_service import McpService
 from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.trace import get_trace_context
@@ -607,9 +612,10 @@ async def test_registry_discovery_tools_do_not_mark_server_runtime_failed(
         *,
         proxy_env: Mapping[str, str] | None = None,
         stdio_default_timeout_seconds: float = 15.0,
+        w3_x_auth_token: str | None = None,
     ) -> _FailingAsyncToolset:
         nonlocal build_calls
-        _ = spec, proxy_env, stdio_default_timeout_seconds
+        _ = spec, proxy_env, stdio_default_timeout_seconds, w3_x_auth_token
         build_calls += 1
         return _FailingAsyncToolset()
 
@@ -1158,6 +1164,453 @@ def test_build_mcp_server_stdio_expands_explicit_env_references(
     assert server.env["MODE"] == "stdio"
     assert server.env["MISSING"] == "${MCP_MISSING}"
     assert server.env["TEMPLATE_MISSING"] == "{{MCP_MISSING}}"
+
+
+def test_build_mcp_server_overlays_declared_w3_auth_token_env() -> None:
+    server_config = {
+        "command": "npx",
+        "args": ["-y", "@example/w3-mcp"],
+        "env": {
+            "xAuthToken": "placeholder",
+            "AUTH_TOKEN": "keep",
+        },
+    }
+    server = build_mcp_server(
+        McpServerSpec(
+            name="w3",
+            config={"mcpServers": {"w3": server_config}},
+            server_config=server_config,
+            source=McpConfigScope.APP,
+        ),
+        w3_x_auth_token="runtime-token",
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert server.env["xAuthToken"] == "runtime-token"
+    assert server.env["AUTH_TOKEN"] == "keep"
+    assert server_config["env"]["xAuthToken"] == "placeholder"
+
+
+def test_build_mcp_server_treats_local_transport_as_stdio_for_w3_env() -> None:
+    server_config = {
+        "type": "local",
+        "transport": "local",
+        "command": "npx",
+        "env": {"X_AUTH_TOKEN": "placeholder"},
+    }
+    server = build_mcp_server(
+        McpServerSpec(
+            name="local-w3",
+            config={"mcpServers": {"local-w3": server_config}},
+            server_config=server_config,
+            source=McpConfigScope.SESSION,
+        ),
+        w3_x_auth_token="runtime-token",
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert server.env["X_AUTH_TOKEN"] == "runtime-token"
+
+
+def test_build_mcp_server_replaces_inherited_w3_auth_token_variants(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("X_AUTH_TOKEN", "ambient-token")
+    server_config = {
+        "command": "npx",
+        "args": ["-y", "@example/w3-mcp"],
+        "env": {"x_auth_token": "placeholder"},
+    }
+
+    server = build_mcp_server(
+        McpServerSpec(
+            name="w3",
+            config={"mcpServers": {"w3": server_config}},
+            server_config=server_config,
+            source=McpConfigScope.APP,
+        ),
+        w3_x_auth_token="runtime-token",
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert "X_AUTH_TOKEN" not in server.env
+    assert server.env["x_auth_token"] == "runtime-token"
+
+
+def test_build_mcp_server_does_not_overlay_w3_auth_token_without_declared_key() -> None:
+    server = build_mcp_server(
+        McpServerSpec(
+            name="plain",
+            config={"mcpServers": {"plain": {"command": "npx"}}},
+            server_config={
+                "command": "npx",
+                "args": ["-y", "@example/plain-mcp"],
+                "env": {"AUTH_TOKEN": "keep"},
+            },
+            source=McpConfigScope.APP,
+        ),
+        w3_x_auth_token="runtime-token",
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert server.env["AUTH_TOKEN"] == "keep"
+    assert "X_AUTH_TOKEN" not in server.env
+
+
+def test_overlay_mcp_server_config_w3_auth_env_only_updates_env_copy() -> None:
+    server_config = {
+        "command": "npx",
+        "headers": {"X-Auth-Token": "header-placeholder"},
+        "env": {"X-Auth-Token": "env-placeholder"},
+    }
+
+    overlay = overlay_mcp_server_config_w3_auth_env(
+        server_config,
+        w3_x_auth_token="runtime-token",
+    )
+
+    assert overlay["headers"] == {"X-Auth-Token": "header-placeholder"}
+    assert overlay["env"] == {"X-Auth-Token": "runtime-token"}
+    assert server_config["env"]["X-Auth-Token"] == "env-placeholder"
+
+
+def test_overlay_mcp_server_config_w3_auth_env_skips_remote_servers() -> None:
+    server_config = {
+        "url": "https://example.com/mcp",
+        "headers": {"X-Auth-Token": "header-placeholder"},
+        "env": {"X-Auth-Token": "env-placeholder"},
+    }
+
+    overlay = overlay_mcp_server_config_w3_auth_env(
+        server_config,
+        w3_x_auth_token="runtime-token",
+    )
+
+    assert overlay["headers"] == {"X-Auth-Token": "header-placeholder"}
+    assert overlay["env"] == {"X-Auth-Token": "env-placeholder"}
+
+
+@pytest.mark.parametrize(
+    "server_config",
+    (
+        {"env": {"X_AUTH_TOKEN": "placeholder"}},
+        {"command": "npx", "env": "X_AUTH_TOKEN=placeholder"},
+        {"command": "npx", "env": {"AUTH_TOKEN": "keep"}},
+    ),
+)
+def test_overlay_mcp_server_config_w3_auth_env_skips_non_declared_configs(
+    server_config: dict[str, JsonValue],
+) -> None:
+    overlay = overlay_mcp_server_config_w3_auth_env(
+        server_config,
+        w3_x_auth_token="runtime-token",
+    )
+
+    assert overlay == server_config
+
+
+def test_overlay_mcp_server_config_w3_auth_env_skips_without_token() -> None:
+    server_config = {"command": "npx", "env": {"X_AUTH_TOKEN": "placeholder"}}
+
+    overlay = overlay_mcp_server_config_w3_auth_env(
+        server_config,
+        w3_x_auth_token=None,
+    )
+
+    assert overlay == server_config
+
+
+@pytest.mark.asyncio
+async def test_registry_prepares_w3_auth_token_only_for_declared_mcp_env(
+    monkeypatch,
+) -> None:
+    calls = 0
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        nonlocal calls
+        calls += 1
+        return "runtime-token"
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="w3",
+                config={"mcpServers": {"w3": {"command": "npx"}}},
+                server_config={
+                    "command": "npx",
+                    "env": {"x-auth-token": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+            McpServerSpec(
+                name="plain",
+                config={"mcpServers": {"plain": {"command": "npx"}}},
+                server_config={"command": "npx", "env": {"AUTH_TOKEN": "keep"}},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    await registry.prepare_w3_auth_env(("plain",), consumer="test")
+    assert calls == 0
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+    assert calls == 1
+
+    server = registry.get_toolsets(("w3",))[0]
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert server.env["x-auth-token"] == "runtime-token"
+
+
+@pytest.mark.asyncio
+async def test_registry_does_not_prepare_w3_token_for_remote_mcp_env(
+    monkeypatch,
+) -> None:
+    calls = 0
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        nonlocal calls
+        calls += 1
+        return "runtime-token"
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="remote-w3",
+                config={
+                    "mcpServers": {"remote-w3": {"url": "https://example.com/mcp"}}
+                },
+                server_config={
+                    "url": "https://example.com/mcp",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    await registry.prepare_w3_auth_env(("remote-w3",), consumer="test")
+
+    assert calls == 0
+    assert registry.runtime_w3_x_auth_token() is None
+
+
+@pytest.mark.asyncio
+async def test_registry_refreshes_w3_auth_token_for_cached_toolset(
+    monkeypatch,
+) -> None:
+    tokens = ["runtime-token-1", "runtime-token-2"]
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return tokens.pop(0)
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="w3",
+                config={"mcpServers": {"w3": {"command": "npx"}}},
+                server_config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+    first_server = registry.get_toolsets(("w3",))[0]
+    assert isinstance(first_server, MCPServerStdio)
+    assert first_server.env is not None
+    assert first_server.env["X_AUTH_TOKEN"] == "runtime-token-1"
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+    refreshed_server = registry.get_toolsets(("w3",))[0]
+    assert isinstance(refreshed_server, MCPServerStdio)
+    assert refreshed_server is not first_server
+    assert refreshed_server.env is not None
+    assert refreshed_server.env["X_AUTH_TOKEN"] == "runtime-token-2"
+
+
+@pytest.mark.asyncio
+async def test_registry_preserves_w3_auth_token_on_transient_resolve_failure(
+    monkeypatch,
+) -> None:
+    tokens: list[str | None] = ["runtime-token", None]
+
+    async def fake_resolve_w3_x_auth_token() -> str | None:
+        return tokens.pop(0)
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="w3",
+                config={"mcpServers": {"w3": {"command": "npx"}}},
+                server_config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+    first_server = registry.get_toolsets(("w3",))[0]
+    assert isinstance(first_server, MCPServerStdio)
+    assert first_server.env is not None
+    assert first_server.env["X_AUTH_TOKEN"] == "runtime-token"
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+    preserved_server = registry.get_toolsets(("w3",))[0]
+
+    assert preserved_server is first_server
+    assert registry.runtime_w3_x_auth_token() == "runtime-token"
+
+
+@pytest.mark.asyncio
+async def test_registry_invalidates_all_w3_toolsets_when_token_rotates(
+    monkeypatch,
+) -> None:
+    tokens = ["runtime-token-1", "runtime-token-2", "runtime-token-2"]
+
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return tokens.pop(0)
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="w3-one",
+                config={"mcpServers": {"w3-one": {"command": "npx"}}},
+                server_config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+            McpServerSpec(
+                name="w3-two",
+                config={"mcpServers": {"w3-two": {"command": "npx"}}},
+                server_config={
+                    "command": "npx",
+                    "env": {"xAuthToken": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    await registry.prepare_w3_auth_env(("w3-one", "w3-two"), consumer="test")
+    first_two = registry.get_toolsets(("w3-two",))[0]
+    assert isinstance(first_two, MCPServerStdio)
+    assert first_two.env is not None
+    assert first_two.env["xAuthToken"] == "runtime-token-1"
+
+    await registry.prepare_w3_auth_env(("w3-one",), consumer="test")
+    await registry.prepare_w3_auth_env(("w3-two",), consumer="test")
+    refreshed_two = registry.get_toolsets(("w3-two",))[0]
+    assert isinstance(refreshed_two, MCPServerStdio)
+    assert refreshed_two is not first_two
+    assert refreshed_two.env is not None
+    assert refreshed_two.env["xAuthToken"] == "runtime-token-2"
+
+
+@pytest.mark.asyncio
+async def test_registry_rebuilds_cached_w3_toolset_when_token_becomes_available(
+    monkeypatch,
+) -> None:
+    tokens: list[str | None] = [None, "runtime-token"]
+
+    async def fake_resolve_w3_x_auth_token() -> str | None:
+        return tokens.pop(0)
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="w3",
+                config={"mcpServers": {"w3": {"command": "npx"}}},
+                server_config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+    placeholder_server = registry.get_toolsets(("w3",))[0]
+    assert isinstance(placeholder_server, MCPServerStdio)
+    assert placeholder_server.env is not None
+    assert placeholder_server.env["X_AUTH_TOKEN"] == "placeholder"
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+    authenticated_server = registry.get_toolsets(("w3",))[0]
+    assert isinstance(authenticated_server, MCPServerStdio)
+    assert authenticated_server is not placeholder_server
+    assert authenticated_server.env is not None
+    assert authenticated_server.env["X_AUTH_TOKEN"] == "runtime-token"
+
+
+@pytest.mark.asyncio
+async def test_registry_clears_runtime_failed_w3_server_when_token_becomes_available(
+    monkeypatch,
+) -> None:
+    async def fake_resolve_w3_x_auth_token() -> str:
+        return "runtime-token"
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.resolve_w3_x_auth_token",
+        fake_resolve_w3_x_auth_token,
+    )
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="w3",
+                config={"mcpServers": {"w3": {"command": "npx"}}},
+                server_config={
+                    "command": "npx",
+                    "env": {"X_AUTH_TOKEN": "placeholder"},
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    registry.mark_server_runtime_failed("w3")
+
+    await registry.prepare_w3_auth_env(("w3",), consumer="test")
+
+    assert registry.is_server_runtime_failed("w3") is False
+    assert len(registry.get_toolsets(("w3",))) == 1
 
 
 def test_registry_resolve_server_names_ignores_unknown_servers_when_not_strict() -> (

--- a/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
+from os import pathsep
 from pathlib import Path
 import signal
-import os
 import subprocess
 
 import pytest
@@ -306,6 +307,97 @@ async def test_build_command_env_respects_case_variant_python_env_on_windows(
 
 
 @pytest.mark.asyncio
+async def test_build_command_env_applies_w3_auth_token_overlay_for_declared_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    powershell_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+
+    async def fake_overlay(
+        env: Mapping[str, str],
+        *,
+        declared_env: Mapping[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        result = dict(env)
+        if declared_env is not None and "X-Auth-Token" in declared_env:
+            result["X-Auth-Token"] = "runtime-token"
+        return result
+
+    monkeypatch.setattr(runtime_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(runtime_module, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(runtime_module, "resolve_existing_gh_path", lambda: None)
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_clawhub_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(runtime_module, "overlay_w3_x_auth_token_env", fake_overlay)
+    monkeypatch.setattr(runtime_module.os, "environ", {"PATH": r"C:\Windows\System32"})
+
+    env = await build_command_env(
+        {"X-Auth-Token": "placeholder", "WEB_TOKEN": "keep"},
+        runtime=powershell_runtime,
+        command="Write-Output ok",
+    )
+
+    assert env["X-Auth-Token"] == "runtime-token"
+    assert env["WEB_TOKEN"] == "keep"
+
+
+@pytest.mark.asyncio
+async def test_build_command_env_does_not_overlay_inherited_w3_auth_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    powershell_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+    observed_declared_env: list[Mapping[str, object] | None] = []
+
+    async def fake_overlay(
+        env: Mapping[str, str],
+        *,
+        declared_env: Mapping[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        observed_declared_env.append(declared_env)
+        result = dict(env)
+        if declared_env is not None and "X_AUTH_TOKEN" in declared_env:
+            result["X_AUTH_TOKEN"] = "runtime-token"
+        return result
+
+    monkeypatch.setattr(runtime_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(runtime_module, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(runtime_module, "resolve_existing_gh_path", lambda: None)
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_clawhub_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(runtime_module, "overlay_w3_x_auth_token_env", fake_overlay)
+    monkeypatch.setattr(
+        runtime_module.os,
+        "environ",
+        {"PATH": r"C:\Windows\System32", "X_AUTH_TOKEN": "ambient-token"},
+    )
+
+    env = await build_command_env(
+        runtime=powershell_runtime,
+        command="Write-Output ok",
+    )
+
+    assert observed_declared_env == [{}]
+    assert env["X_AUTH_TOKEN"] == "ambient-token"
+
+
+@pytest.mark.asyncio
 async def test_build_command_env_prepends_existing_gh_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -337,7 +429,7 @@ async def test_build_command_env_prepends_existing_gh_path(
         command="gh auth status",
     )
 
-    assert env["PATH"].split(os.pathsep)[0] == str(gh.parent)
+    assert env["PATH"].split(pathsep)[0] == str(gh.parent)
 
 
 @pytest.mark.asyncio
@@ -381,7 +473,7 @@ async def test_build_command_env_prepends_existing_clawhub_path(
         command="clawhub --version",
     )
 
-    assert env["PATH"].split(os.pathsep)[0] == str(clawhub.parent)
+    assert env["PATH"].split(pathsep)[0] == str(clawhub.parent)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
@@ -412,6 +412,80 @@ async def test_background_task_manager_ssh_pipe_uses_prepared_subprocess_helper(
 
 
 @pytest.mark.asyncio
+async def test_background_task_manager_ssh_pipe_overlays_declared_w3_auth_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.sessions.runs.background_tasks import manager as manager_module
+
+    repo = BackgroundTaskRepository(tmp_path / "background-terminal-ssh-w3.db")
+    hub = RunEventHub()
+    ssh_service = _FakePreparedSshProfileService(tmp_path / "ssh-temp-w3")
+    manager = BackgroundTaskManager(
+        repository=repo,
+        run_event_hub=hub,
+        ssh_profile_service=cast(SshProfileService, ssh_service),
+    )
+    workspace = _build_ssh_workspace_handle(tmp_path)
+    ssh_context = manager._resolve_ssh_execution_context(
+        workspace=workspace,
+        cwd=workspace.execution_root,
+    )
+    assert ssh_context is not None
+
+    async def fake_overlay_w3_x_auth_token_env(
+        env: dict[str, str],
+        *,
+        declared_env: dict[str, str] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        result = dict(env)
+        if declared_env is not None and "xAuthToken" in declared_env:
+            result["xAuthToken"] = "runtime-token"
+        return result
+
+    async def fake_create_prepared_subprocess(
+        *,
+        argv: tuple[str, ...],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        stdin: int | None = None,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> _FakePipeProcess:
+        _ = (argv, cwd, env, stdin, stdout, stderr)
+        return _FakePipeProcess()
+
+    monkeypatch.setattr(
+        manager_module,
+        "overlay_w3_x_auth_token_env",
+        fake_overlay_w3_x_auth_token_env,
+    )
+    monkeypatch.setattr(
+        manager_module,
+        "create_prepared_subprocess",
+        fake_create_prepared_subprocess,
+    )
+
+    transport = await manager._spawn_ssh_pipe_transport(
+        command="pwd",
+        ssh_context=ssh_context,
+        env={"xAuthToken": "placeholder", "AUTH_TOKEN": "keep"},
+    )
+
+    assert ssh_service.calls == [
+        (
+            "prod",
+            "pwd",
+            "/srv/app",
+            {"xAuthToken": "runtime-token", "AUTH_TOKEN": "keep"},
+            False,
+        )
+    ]
+    await transport.close()
+
+
+@pytest.mark.asyncio
 async def test_background_task_manager_ssh_tty_uses_windows_conpty(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -477,6 +551,89 @@ async def test_background_task_manager_ssh_tty_uses_windows_conpty(
     assert ssh_service.temp_root.is_dir()
     await transport.close()
     assert not ssh_service.temp_root.exists()
+
+
+@pytest.mark.asyncio
+async def test_background_task_manager_ssh_tty_overlays_declared_w3_auth_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.sessions.runs.background_tasks import manager as manager_module
+
+    repo = BackgroundTaskRepository(tmp_path / "background-terminal-ssh-tty-w3.db")
+    hub = RunEventHub()
+    ssh_service = _FakePreparedSshProfileService(tmp_path / "ssh-temp-tty-w3")
+    manager = BackgroundTaskManager(
+        repository=repo,
+        run_event_hub=hub,
+        ssh_profile_service=cast(SshProfileService, ssh_service),
+    )
+    workspace = _build_ssh_workspace_handle(tmp_path)
+    ssh_context = manager._resolve_ssh_execution_context(
+        workspace=workspace,
+        cwd=workspace.execution_root,
+    )
+    assert ssh_context is not None
+    fake_process = _FakeWindowsPtyProcess()
+
+    async def fake_overlay_w3_x_auth_token_env(
+        env: dict[str, str],
+        *,
+        declared_env: dict[str, str] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        result = dict(env)
+        if declared_env is not None and "X_AUTH_TOKEN" in declared_env:
+            result["X_AUTH_TOKEN"] = "runtime-token"
+        return result
+
+    def fake_spawn_windows_pty_argv_process(
+        *,
+        argv: tuple[str, ...],
+        cwd: Path,
+        env: dict[str, str],
+        columns: int,
+        rows: int,
+    ) -> _FakeWindowsPtyProcess:
+        _ = (argv, cwd, env, columns, rows)
+        return fake_process
+
+    monkeypatch.setattr(manager_module, "_posix_pty_supported", lambda: False)
+    monkeypatch.setattr(manager_module, "_windows_tty_supported", lambda: True)
+    monkeypatch.setattr(
+        manager_module,
+        "overlay_w3_x_auth_token_env",
+        fake_overlay_w3_x_auth_token_env,
+    )
+    monkeypatch.setattr(
+        manager_module,
+        "_spawn_windows_pty_argv_process",
+        fake_spawn_windows_pty_argv_process,
+    )
+
+    transport = await manager._spawn_ssh_tty_transport(
+        command="bash",
+        ssh_context=ssh_context,
+        env={"X_AUTH_TOKEN": "placeholder", "AUTH_TOKEN": "keep"},
+    )
+
+    assert ssh_service.calls == [
+        (
+            "prod",
+            "bash",
+            "/srv/app",
+            {"X_AUTH_TOKEN": "runtime-token", "AUTH_TOKEN": "keep"},
+            True,
+        )
+    ]
+    await transport.close()
+
+
+@pytest.mark.asyncio
+async def test_build_ssh_remote_env_preserves_missing_env() -> None:
+    from relay_teams.sessions.runs.background_tasks import manager as manager_module
+
+    assert await manager_module._build_ssh_remote_env(None) is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/tools/workspace_tools/test_shell.py
+++ b/tests/unit_tests/tools/workspace_tools/test_shell.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import asyncio
-import os
+from collections.abc import Mapping
+from os import pathsep
 from pathlib import Path
 import subprocess
 from typing import cast
@@ -520,7 +521,7 @@ async def test_spawn_shell_injects_github_token_and_bundled_path(
     assert env["GH_TOKEN"] == "ghp_secret"
     assert env["GITHUB_TOKEN"] == "ghp_secret"
     assert env["GH_PROMPT_DISABLED"] == "1"
-    assert str(gh.parent) == env["PATH"].split(os.pathsep)[0]
+    assert str(gh.parent) == env["PATH"].split(pathsep)[0]
 
 
 @pytest.mark.asyncio
@@ -641,7 +642,7 @@ async def test_spawn_shell_prepends_existing_clawhub_path(
 
     env = captured_kwargs.get("env")
     assert isinstance(env, dict)
-    assert env["PATH"].split(os.pathsep)[0] == str(clawhub.parent)
+    assert env["PATH"].split(pathsep)[0] == str(clawhub.parent)
 
 
 @pytest.mark.asyncio
@@ -813,6 +814,104 @@ async def test_build_shell_env_respects_case_variant_python_env_on_windows(
     assert env["pythonutf8"] == "0"
     assert "PYTHONIOENCODING" not in env
     assert "PYTHONUTF8" not in env
+
+
+@pytest.mark.asyncio
+async def test_build_shell_env_applies_w3_auth_token_overlay_for_declared_env(
+    monkeypatch,
+) -> None:
+    from relay_teams.tools.workspace_tools import shell_executor
+
+    async def fake_overlay(
+        env: Mapping[str, str],
+        *,
+        declared_env: Mapping[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        result = dict(env)
+        if declared_env is not None and "x-auth-token" in declared_env:
+            result["x-auth-token"] = "runtime-token"
+        return result
+
+    shell = shell_executor.ResolvedShell(
+        kind=shell_executor.ShellKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+    monkeypatch.setattr(shell_executor, "_is_windows", lambda: True)
+    monkeypatch.setattr(shell_executor, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(shell_executor, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_gh_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_clawhub_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(shell_executor, "overlay_w3_x_auth_token_env", fake_overlay)
+    monkeypatch.setattr(shell_executor.os, "environ", {"PATH": "base"})
+
+    env = await shell_executor.build_shell_env(
+        {"x-auth-token": "placeholder", "AUTH_TOKEN": "keep"},
+        shell=shell,
+    )
+
+    assert env["x-auth-token"] == "runtime-token"
+    assert env["AUTH_TOKEN"] == "keep"
+
+
+@pytest.mark.asyncio
+async def test_build_shell_env_does_not_overlay_inherited_w3_auth_token(
+    monkeypatch,
+) -> None:
+    from relay_teams.tools.workspace_tools import shell_executor
+
+    observed_declared_env: list[Mapping[str, object] | None] = []
+
+    async def fake_overlay(
+        env: Mapping[str, str],
+        *,
+        declared_env: Mapping[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, str]:
+        observed_declared_env.append(declared_env)
+        result = dict(env)
+        if declared_env is not None and "X_AUTH_TOKEN" in declared_env:
+            result["X_AUTH_TOKEN"] = "runtime-token"
+        return result
+
+    shell = shell_executor.ResolvedShell(
+        kind=shell_executor.ShellKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+    monkeypatch.setattr(shell_executor, "_is_windows", lambda: True)
+    monkeypatch.setattr(shell_executor, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(shell_executor, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_gh_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_clawhub_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(shell_executor, "overlay_w3_x_auth_token_env", fake_overlay)
+    monkeypatch.setattr(
+        shell_executor.os,
+        "environ",
+        {"PATH": "base", "X_AUTH_TOKEN": "ambient-token"},
+    )
+
+    env = await shell_executor.build_shell_env(shell=shell)
+
+    assert observed_declared_env == [{}]
+    assert env["X_AUTH_TOKEN"] == "ambient-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a W3 X-Auth-Token runtime env overlay helper that matches X_AUTH_TOKEN, x-auth-token, X-Auth-Token, and xAuthToken variants
- inject W3 MaaS auth tokens only into explicitly declared matching env keys for MCP, shell/background command env, and external stdio agents
- leave headers, tool parameters, config files, and unrelated env keys untouched; warn and preserve existing env when W3 credentials or login are unavailable

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests/env/test_w3_auth_token_env.py tests/unit_tests/connector/test_w3_service.py tests/unit_tests/providers/test_w3_auth_source.py tests/unit_tests/mcp tests/unit_tests/tools/workspace_tools/test_shell.py tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py tests/unit_tests/agent_runtimes/test_acp_client.py tests/unit_tests/agent_runtimes/test_cli_client.py tests/unit_tests/agent_runtimes/test_provider.py
- uv run --extra dev pytest -q tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_uses_conservative_mcp_context_budget_without_schema_probe tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_skips_mcp_schema_probe_when_context_window_unset
- uv run --extra dev pytest -q tests/unit_tests/tools/workspace_tools/test_edit.py::test_apply_edit_preserves_crlf_when_inputs_use_lf

Full unit suite note: `uv run --extra dev pytest -q tests/unit_tests --basetemp .pytest-tmp-w3-final` reached 7107 passed / 5 skipped, then hit one unrelated transient Windows `os.replace` WinError 5 in `test_apply_edit_preserves_crlf_when_inputs_use_lf`; that single test passed when rerun directly.

Fixes #753