### PR TITLE
Fix memory skill synthesis identifiers

### DIFF
--- a/src/relay_teams/memory/skill_synthesis_service.py
+++ b/src/relay_teams/memory/skill_synthesis_service.py
@@ -78,6 +78,11 @@ Return only valid JSON matching the requested schema."""
 
 _RUNTIME_NAME_CLEANUP = re.compile(r"[^a-z0-9-]+")
 _DUPLICATE_HYPHENS = re.compile(r"-+")
+_SYNTHESIS_RUN_ID = "memory-skill-draft-generation"
+_SYNTHESIS_SESSION_ID = "memory-skill-draft-generation"
+_SYNTHESIS_TASK_ID = "memory-skill-draft-generation"
+_SYNTHESIS_INSTANCE_ID = "memory-skill-synthesis"
+_SYNTHESIS_ROLE_ID = "memory-skill-synthesis"
 
 
 class MemorySkillSynthesisService:
@@ -454,13 +459,13 @@ class MemorySkillSynthesisService:
         source_entries: tuple[MemoryEntry, ...],
     ) -> _GeneratedMemorySkillDrafts:
         llm_request = LLMRequest(
-            run_id="memory-skill-draft-generation",
-            trace_id="memory-skill-draft-generation",
-            task_id="",
-            session_id="",
+            run_id=_SYNTHESIS_RUN_ID,
+            trace_id=_SYNTHESIS_RUN_ID,
+            task_id=_SYNTHESIS_TASK_ID,
+            session_id=_SYNTHESIS_SESSION_ID,
             workspace_id=request.workspace_id or "",
-            instance_id="memory-skill-synthesis",
-            role_id="memory-skill-synthesis",
+            instance_id=_SYNTHESIS_INSTANCE_ID,
+            role_id=_SYNTHESIS_ROLE_ID,
             system_prompt=_SYSTEM_PROMPT,
             user_prompt=_build_generation_prompt(request, source_entries),
         )

--- a/tests/unit_tests/memory/test_memory_skill_drafts.py
+++ b/tests/unit_tests/memory/test_memory_skill_drafts.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import json
 import asyncio
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import override
@@ -58,9 +58,11 @@ pytestmark = pytest.mark.asyncio
 class _JsonProvider(LLMProvider):
     def __init__(self, payload: dict[str, object]) -> None:
         self._payload = payload
+        self.requests: list[LLMRequest] = []
 
     @override
-    async def generate(self, _request: LLMRequest) -> str:
+    async def generate(self, request: LLMRequest) -> str:
+        self.requests.append(request)
         return json.dumps(self._payload)
 
 
@@ -146,6 +148,46 @@ async def test_generation_merges_one_draft_per_memory_output(tmp_path: Path) -> 
     assert result.source_memory_count == 2
     assert len(result.items) == 1
     assert result.items[0].source_memory_count == 2
+
+
+async def test_generation_uses_non_blank_auxiliary_llm_identifiers(
+    tmp_path: Path,
+) -> None:
+    provider = _JsonProvider(
+        {
+            "drafts": [
+                {
+                    "draft_kind": "skill",
+                    "runtime_name": "workspace-memory",
+                    "description": "Use workspace memory.",
+                    "instructions": "Use captured workspace memory.",
+                    "source_memory_ids": [],
+                }
+            ]
+        }
+    )
+    memory_service, _, synthesis = _build_services(tmp_path, provider)
+    await _create_memory(
+        memory_service,
+        workspace_id="ws-1",
+        title="Workspace memory",
+        body="Generate a reusable skill from this memory.",
+    )
+
+    result = await synthesis.generate_drafts_async(
+        GenerateMemorySkillDraftsRequest(
+            scope_kind=MemorySkillDraftScopeKind.WORKSPACE,
+            workspace_id="ws-1",
+        )
+    )
+
+    assert result.error_message == ""
+    assert len(provider.requests) == 1
+    request = provider.requests[0]
+    assert request.session_id == "memory-skill-draft-generation"
+    assert request.task_id == "memory-skill-draft-generation"
+    assert request.run_id == "memory-skill-draft-generation"
+    assert request.trace_id == "memory-skill-draft-generation"
 
 
 async def test_cross_workspace_generation_uses_multiple_workspaces(


### PR DESCRIPTION
Fixes #848

## Summary
- Use stable non-empty auxiliary run/session/task identifiers for memory skill draft LLM generation.
- Add regression coverage asserting the synthesis provider receives valid identifiers.

## Validation
- `uv run --extra dev ruff check --fix src/relay_teams/memory/skill_synthesis_service.py tests/unit_tests/memory/test_memory_skill_drafts.py`
- `uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/memory/skill_synthesis_service.py tests/unit_tests/memory/test_memory_skill_drafts.py`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/memory/test_memory_skill_drafts.py`
- `uv run --extra dev pytest -q tests/unit_tests/interfaces/server/routers/test_memories.py tests/unit_tests/interfaces/cli/test_memories_cli.py tests/unit_tests/memory`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests`