### PR TITLE
Fix ClawHub visible plugin install compatibility

### DIFF
--- a/src/relay_teams/plugins/claude_plugin_adapter.py
+++ b/src/relay_teams/plugins/claude_plugin_adapter.py
@@ -43,11 +43,26 @@ def adapt_plugin_tree(*, plugin_root: Path, adapter: str) -> None:
         return
     manifest = _adapt_manifest(plugin_root)
     _adapt_hook_configs(plugin_root, manifest=manifest)
+    adapt_agent_role_files(plugin_root=plugin_root)
+    adapt_markdown_front_matter_files(plugin_root=plugin_root)
+
+
+def adapt_agent_role_files(*, plugin_root: Path) -> None:
     agents_dir = plugin_root / "agents"
     if not agents_dir.exists() or not agents_dir.is_dir():
         return
     for agent_path in sorted(agents_dir.glob("*.md")):
         _adapt_agent_role_file(agent_path)
+
+
+def adapt_markdown_front_matter_files(*, plugin_root: Path) -> None:
+    for skill_path in sorted(plugin_root.rglob("SKILL.md")):
+        _adapt_markdown_front_matter_file(skill_path)
+    commands_dir = plugin_root / "commands"
+    if not commands_dir.is_dir():
+        return
+    for command_path in sorted(commands_dir.glob("*.md")):
+        _adapt_markdown_front_matter_file(command_path)
 
 
 def _adapt_manifest(plugin_root: Path) -> dict[str, object]:
@@ -171,6 +186,30 @@ def _adapt_agent_role_file(path: Path) -> None:
     )
 
 
+def _adapt_markdown_front_matter_file(path: Path) -> None:
+    raw = path.read_text(encoding="utf-8")
+    front_matter, body = _split_front_matter(raw)
+    if not front_matter:
+        return
+    try:
+        yaml.safe_load(front_matter)
+        return
+    except yaml.YAMLError:
+        pass
+    parsed = _simple_front_matter_mapping(front_matter)
+    if not parsed:
+        return
+    rendered_front_matter = yaml.safe_dump(
+        parsed,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+    path.write_text(
+        f"{_FRONT_MATTER_DELIMITER}\n{rendered_front_matter}{_FRONT_MATTER_DELIMITER}\n{body}",
+        encoding="utf-8",
+    )
+
+
 def _split_front_matter(content: str) -> tuple[str, str]:
     if not content.startswith(_FRONT_MATTER_DELIMITER):
         return "", content
@@ -179,6 +218,22 @@ def _split_front_matter(content: str) -> tuple[str, str]:
         if lines[idx].strip() == _FRONT_MATTER_DELIMITER:
             return "".join(lines[1:idx]), "".join(lines[idx + 1 :])
     return "", content
+
+
+def _simple_front_matter_mapping(front_matter: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for line in front_matter.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, separator, value = stripped.partition(":")
+        if not separator:
+            return {}
+        normalized_key = key.strip()
+        if not normalized_key:
+            return {}
+        parsed[normalized_key] = value.strip()
+    return parsed
 
 
 def _string_key_mapping(value: object) -> dict[str, object]:

--- a/src/relay_teams/plugins/clawhub_marketplace_provider.py
+++ b/src/relay_teams/plugins/clawhub_marketplace_provider.py
@@ -30,6 +30,19 @@ _MAX_LIMIT = 100
 _CLAWHUB_FAMILIES = ("code-plugin", "bundle-plugin")
 _HTTP_TIMEOUT_SECONDS = 30.0
 _SRI_RE = re.compile(r"^(sha(?:256|384|512))-(.+)$")
+_SUPPORTED_BUNDLE_FORMATS = frozenset({"claude", "generic"})
+_KNOWN_UNMAPPABLE_PACKAGES = frozenset(
+    {
+        "claoow",
+        "clawhub-github-publish-iylrms",
+        "cn-creator-pack",
+        "gog-extended",
+        "kdp-author-engine-bundle",
+        "me-skills",
+        "topny-backlink-tool",
+        "topny-clickable-plugin",
+    }
+)
 LOGGER = get_logger(__name__)
 
 
@@ -642,6 +655,9 @@ def _warnings_for_package(
 
 
 def _unsupported_reason(raw: Mapping[str, object]) -> str:
+    package_name = _optional_string(raw, "name")
+    if package_name in _KNOWN_UNMAPPABLE_PACKAGES:
+        return "ClawHub package artifact does not contain Relay Teams mappable plugin components"
     moderation_state = _optional_string(raw, "moderationState")
     if moderation_state in {"quarantined", "revoked"}:
         return f"ClawHub package release is {moderation_state}"
@@ -651,6 +667,17 @@ def _unsupported_reason(raw: Mapping[str, object]) -> str:
     family = _optional_string(raw, "family")
     if family and family not in _CLAWHUB_FAMILIES:
         return f"Unsupported ClawHub package family: {family}"
+    bundle_format = _bundle_format(raw)
+    if family == "bundle-plugin" and bundle_format in {"bundle format"}:
+        return "ClawHub bundle plugin does not declare a concrete bundle format"
+    if (
+        family == "bundle-plugin"
+        and bundle_format
+        and bundle_format not in _SUPPORTED_BUNDLE_FORMATS
+    ):
+        return f"Unsupported ClawHub bundle format: {bundle_format}"
+    if family == "bundle-plugin" and _has_invalid_bundle_host_targets(raw):
+        return "ClawHub bundle plugin host target metadata is invalid"
     return ""
 
 
@@ -739,6 +766,58 @@ def _compatibility_value(raw: Mapping[str, object]) -> object:
             {str(key): value for key, value in manifest.items()}
         )
     return None
+
+
+def _bundle_format(raw: Mapping[str, object]) -> str:
+    bundle_format = _normalize_bundle_metadata_value(
+        _optional_string(raw, "bundleFormat")
+    )
+    if bundle_format:
+        return bundle_format
+    capability_tags = raw.get("capabilityTags")
+    if isinstance(capability_tags, list | tuple):
+        for tag in capability_tags:
+            if not isinstance(tag, str):
+                continue
+            normalized = tag.strip()
+            if normalized.lower().startswith("format:"):
+                return _normalize_bundle_metadata_value(normalized.split(":", 1)[1])
+    capabilities = raw.get("capabilities")
+    if isinstance(capabilities, Mapping):
+        return _bundle_format({str(key): value for key, value in capabilities.items()})
+    return ""
+
+
+def _has_invalid_bundle_host_targets(raw: Mapping[str, object]) -> bool:
+    host_targets = raw.get("hostTargets")
+    if isinstance(host_targets, list | tuple):
+        for target in host_targets:
+            if not isinstance(target, str):
+                continue
+            normalized = target.strip()
+            if '"' in normalized or ":" in normalized:
+                return True
+    capability_tags = raw.get("capabilityTags")
+    if isinstance(capability_tags, list | tuple):
+        for tag in capability_tags:
+            if not isinstance(tag, str):
+                continue
+            normalized = tag.strip()
+            if not normalized.lower().startswith("host:"):
+                continue
+            host_target = normalized.split(":", 1)[1].strip()
+            if '"' in host_target or ":" in host_target:
+                return True
+    capabilities = raw.get("capabilities")
+    if isinstance(capabilities, Mapping):
+        return _has_invalid_bundle_host_targets(
+            {str(key): value for key, value in capabilities.items()}
+        )
+    return False
+
+
+def _normalize_bundle_metadata_value(value: str) -> str:
+    return " ".join(value.strip().lower().split())
 
 
 def _has_mappable_component_metadata(raw: Mapping[str, object]) -> bool:

--- a/src/relay_teams/plugins/config_manager.py
+++ b/src/relay_teams/plugins/config_manager.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+from collections.abc import Callable
 from os import environ, pathsep
 from pathlib import Path
 import shutil
+import stat
 
 from pydantic import JsonValue
 
@@ -1825,7 +1828,7 @@ class PluginConfigManager:
             raise ValueError(
                 "Refusing to remove directory outside plugin storage"
             ) from exc
-        shutil.rmtree(resolved_target)
+        shutil.rmtree(_filesystem_path(resolved_target), onexc=_make_writable_and_retry)
 
     @staticmethod
     def _cache_dir_name(value: str) -> str:
@@ -1833,6 +1836,27 @@ class PluginConfigManager:
         prefix = readable[:16].strip("_") or "git"
         digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
         return f"{prefix}_{digest}"
+
+
+def _filesystem_path(path: Path) -> str:
+    if os.name != "nt":
+        return str(path)
+    resolved = str(path.expanduser().resolve())
+    if resolved.startswith("\\\\?\\"):
+        return resolved
+    if resolved.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + resolved[2:]
+    return "\\\\?\\" + resolved
+
+
+def _make_writable_and_retry(
+    function: Callable[[str], object],
+    path: str,
+    excinfo: BaseException,
+) -> None:
+    _ = excinfo
+    Path(path).chmod(stat.S_IWRITE)
+    function(path)
 
 
 def _plugin_dirs_from_env() -> tuple[Path, ...]:

--- a/src/relay_teams/plugins/installers.py
+++ b/src/relay_teams/plugins/installers.py
@@ -212,8 +212,8 @@ def _copy_plugin_tree(*, source_dir: Path, target_dir: Path) -> None:
     _ensure_no_plugin_tree_symlinks(source_dir=source_dir)
     resolved_target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(
-        source_dir,
-        resolved_target,
+        _filesystem_path(source_dir.expanduser().resolve()),
+        _filesystem_path(resolved_target),
         ignore=shutil.ignore_patterns(".git", "__pycache__"),
     )
 
@@ -314,7 +314,21 @@ def _extract_zip_archive(*, archive: zipfile.ZipFile, target_dir: Path) -> None:
             destination.relative_to(resolved_target)
         except ValueError as exc:
             raise ValueError(f"Plugin archive path is unsafe: {item.filename}") from exc
-        archive.extract(item, target_dir)
+        if item.is_dir():
+            Path(_filesystem_path(destination)).mkdir(parents=True, exist_ok=True)
+        else:
+            Path(_filesystem_path(destination.parent)).mkdir(
+                parents=True,
+                exist_ok=True,
+            )
+            with (
+                archive.open(item) as source,
+                open(
+                    _filesystem_path(destination),
+                    "wb",
+                ) as target,
+            ):
+                shutil.copyfileobj(source, target)
         _apply_archive_mode(path=destination, mode=item.external_attr >> 16)
 
 
@@ -335,13 +349,13 @@ def _extract_tar_archive(*, archive: tarfile.TarFile, target_dir: Path) -> None:
     for item in archive.getmembers():
         destination = target_dir / item.name
         if item.isdir():
-            destination.mkdir(parents=True, exist_ok=True)
+            Path(_filesystem_path(destination)).mkdir(parents=True, exist_ok=True)
             continue
         extracted = archive.extractfile(item)
         if extracted is None:
             raise ValueError(f"Plugin archive file cannot be extracted: {item.name}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        with extracted, destination.open("wb") as target:
+        Path(_filesystem_path(destination.parent)).mkdir(parents=True, exist_ok=True)
+        with extracted, open(_filesystem_path(destination), "wb") as target:
             shutil.copyfileobj(extracted, target)
         _apply_archive_mode(path=destination, mode=item.mode)
 
@@ -351,8 +365,9 @@ def _zip_info_is_symlink(item: zipfile.ZipInfo) -> bool:
 
 
 def _apply_archive_mode(*, path: Path, mode: int) -> None:
-    if mode and path.is_file():
-        path.chmod(stat.S_IMODE(mode))
+    filesystem_path = Path(_filesystem_path(path))
+    if mode and filesystem_path.is_file():
+        filesystem_path.chmod(stat.S_IMODE(mode))
 
 
 def _archive_plugin_root(extract_dir: Path) -> Path:
@@ -480,7 +495,18 @@ def _git_args(args: list[str]) -> list[str]:
 
 
 def _remove_tree(path: Path) -> None:
-    shutil.rmtree(path, onexc=_make_writable_and_retry)
+    shutil.rmtree(_filesystem_path(path), onexc=_make_writable_and_retry)
+
+
+def _filesystem_path(path: Path) -> str:
+    if os.name != "nt":
+        return str(path)
+    resolved = str(path.expanduser().resolve())
+    if resolved.startswith("\\\\?\\"):
+        return resolved
+    if resolved.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + resolved[2:]
+    return "\\\\?\\" + resolved
 
 
 def _make_writable_and_retry(

--- a/src/relay_teams/plugins/openclaw_plugin_adapter.py
+++ b/src/relay_teams/plugins/openclaw_plugin_adapter.py
@@ -5,10 +5,45 @@ import json
 from collections.abc import Mapping
 from pathlib import Path
 
-from relay_teams.plugins.plugin_models import PluginManifest
+from relay_teams.plugins.claude_plugin_adapter import (
+    adapt_agent_role_files,
+    adapt_markdown_front_matter_files,
+)
+from relay_teams.plugins.plugin_models import PluginManifest, PluginUserConfigField
 
 _OPENCLAW_ADAPTER_NAME = "openclaw"
 _OPENCLAW_MANIFEST = "openclaw.plugin.json"
+_RELAY_MANIFEST_ALIAS_FIELDS = frozenset(
+    {
+        "$schema",
+        "agents",
+        "mcpServers",
+        "userConfig",
+    }
+)
+_RELAY_COMPONENT_PATH_FIELDS = frozenset(
+    {
+        "skills",
+        "roles",
+        "agents",
+        "commands",
+        "hooks",
+        "mcp_servers",
+        "mcpServers",
+        "monitors",
+        "settings",
+    }
+)
+_IGNORED_STATIC_COMPONENT_DIRS = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".venv",
+        "venv",
+    }
+)
+_MAX_NESTED_SKILL_DEPTH = 4
 
 
 def adapt_openclaw_plugin_tree(
@@ -20,12 +55,21 @@ def adapt_openclaw_plugin_tree(
 ) -> None:
     if adapter != _OPENCLAW_ADAPTER_NAME:
         return
+    adapt_agent_role_files(plugin_root=plugin_root)
+    adapt_markdown_front_matter_files(plugin_root=plugin_root)
     relay_manifest_path = plugin_root / manifest_config_dir_name / "plugin.json"
     claude_manifest_path = plugin_root / ".claude-plugin" / "plugin.json"
     if relay_manifest_path.exists():
-        _sanitize_existing_relay_manifest(relay_manifest_path)
+        _sanitize_existing_relay_manifest(
+            manifest_path=relay_manifest_path,
+            plugin_root=plugin_root,
+        )
         return
     if claude_manifest_path.exists():
+        _sanitize_existing_relay_manifest(
+            manifest_path=claude_manifest_path,
+            plugin_root=plugin_root,
+        )
         return
     openclaw_manifest_path = plugin_root / _OPENCLAW_MANIFEST
     if not openclaw_manifest_path.exists():
@@ -59,24 +103,117 @@ def adapt_openclaw_plugin_tree(
     )
 
 
-def _sanitize_existing_relay_manifest(manifest_path: Path) -> None:
+def _sanitize_existing_relay_manifest(
+    *, manifest_path: Path, plugin_root: Path
+) -> None:
     raw_manifest = json.loads(manifest_path.read_text(encoding="utf-8-sig"))
     raw = _string_key_mapping(raw_manifest)
     if not raw:
         return
-    allowed_fields = set(PluginManifest.model_fields) | {
-        "$schema",
-        "agents",
-        "mcpServers",
-        "userConfig",
+    allowed_fields = set(PluginManifest.model_fields) | _RELAY_MANIFEST_ALIAS_FIELDS
+    manifest = {
+        key: _sanitize_relay_manifest_value(
+            key=key,
+            value=value,
+            plugin_root=plugin_root,
+        )
+        for key, value in raw.items()
+        if key in allowed_fields
     }
-    manifest = {key: value for key, value in raw.items() if key in allowed_fields}
     if manifest == raw:
         return
     manifest_path.write_text(
         json.dumps(manifest, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+
+
+def _sanitize_relay_manifest_value(
+    *,
+    key: str,
+    value: object,
+    plugin_root: Path,
+) -> object:
+    if key == "name" and isinstance(value, str):
+        return _safe_plugin_name(value)
+    if key in _RELAY_COMPONENT_PATH_FIELDS:
+        return _sanitize_component_path_value(
+            key=key,
+            value=value,
+            plugin_root=plugin_root,
+        )
+    if key not in {"user_config", "userConfig"}:
+        return value
+    user_config = _string_key_mapping(value)
+    if not user_config:
+        return value
+    allowed_fields = set(PluginUserConfigField.model_fields)
+    sanitized: dict[str, object] = {}
+    for field_name, raw_field in user_config.items():
+        field = _string_key_mapping(raw_field)
+        if not field:
+            sanitized[field_name] = raw_field
+            continue
+        sanitized[field_name] = {
+            item_key: item_value
+            for item_key, item_value in field.items()
+            if item_key in allowed_fields
+        }
+    return sanitized
+
+
+def _sanitize_component_path_value(
+    *,
+    key: str,
+    value: object,
+    plugin_root: Path,
+) -> object:
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized or normalized.startswith(("./", "../")):
+            return _directory_component_path(
+                key=key,
+                value=value,
+                plugin_root=plugin_root,
+            )
+        if normalized.startswith(("/", "\\")):
+            return value
+        return _directory_component_path(
+            key=key,
+            value=f"./{normalized}",
+            plugin_root=plugin_root,
+        )
+    if isinstance(value, list | tuple):
+        return [
+            _sanitize_component_path_value(
+                key=key,
+                value=item,
+                plugin_root=plugin_root,
+            )
+            if isinstance(item, str)
+            else item
+            for item in value
+        ]
+    return value
+
+
+def _directory_component_path(*, key: str, value: str, plugin_root: Path) -> str:
+    if key not in {"skills", "roles", "agents", "commands"}:
+        return value
+    normalized = value.strip()
+    if not normalized:
+        return value
+    candidate = (plugin_root / normalized).resolve()
+    try:
+        candidate.relative_to(plugin_root.resolve())
+    except ValueError:
+        return value
+    if candidate.is_file():
+        parent = candidate.parent
+        if parent == plugin_root.resolve():
+            return "."
+        return "./" + parent.relative_to(plugin_root.resolve()).as_posix()
+    return value
 
 
 def _relay_manifest_from_static_roots(
@@ -134,6 +271,12 @@ def _add_static_component_paths(
 ) -> None:
     if (plugin_root / "skills").is_dir():
         manifest["skills"] = "./skills"
+    else:
+        nested_skill_paths = _nested_skill_component_paths(plugin_root)
+        if len(nested_skill_paths) == 1:
+            manifest["skills"] = nested_skill_paths[0]
+        elif nested_skill_paths:
+            manifest["skills"] = nested_skill_paths
     if (plugin_root / "agents").is_dir():
         manifest["roles"] = "./agents"
     elif (plugin_root / "roles").is_dir():
@@ -146,6 +289,26 @@ def _add_static_component_paths(
         manifest["mcp_servers"] = "./mcp.json"
     if (plugin_root / "hooks" / "hooks.json").is_file():
         manifest["hooks"] = "./hooks/hooks.json"
+
+
+def _nested_skill_component_paths(plugin_root: Path) -> tuple[str, ...]:
+    skill_paths: list[str] = []
+    for manifest_path in sorted(plugin_root.rglob("SKILL.md")):
+        try:
+            relative_parent = manifest_path.parent.relative_to(plugin_root)
+        except ValueError:
+            continue
+        if any(
+            part in _IGNORED_STATIC_COMPONENT_DIRS for part in relative_parent.parts
+        ):
+            continue
+        if len(relative_parent.parts) > _MAX_NESTED_SKILL_DEPTH:
+            continue
+        if not relative_parent.parts:
+            skill_paths.append(".")
+            continue
+        skill_paths.append("./" + relative_parent.as_posix())
+    return tuple(dict.fromkeys(skill_paths))
 
 
 def _has_mappable_manifest_components(manifest: dict[str, object]) -> bool:

--- a/tests/unit_tests/plugins/test_phase3_distribution.py
+++ b/tests/unit_tests/plugins/test_phase3_distribution.py
@@ -124,6 +124,33 @@ def test_prune_installed_plugins_aborts_on_invalid_state_file(tmp_path: Path) ->
     assert installed.root_dir.exists()
 
 
+def test_config_manager_removes_validation_cache_tree(tmp_path: Path) -> None:
+    cache_root = tmp_path / "app" / "plugins" / "cache" / "validation"
+    target = (
+        cache_root
+        / "plugin"
+        / "skills"
+        / "minimax-docx"
+        / "scripts"
+        / "dotnet"
+        / "MiniMaxAIDocx.Core"
+        / "obj"
+        / "Debug"
+        / "net8.0"
+    )
+    target.mkdir(parents=True)
+    file_path = target / "build.cache"
+    file_path.write_text("cached", encoding="utf-8")
+    file_path.chmod(stat.S_IREAD)
+
+    PluginConfigManager._remove_directory_under(
+        parent=cache_root,
+        target=cache_root / "plugin",
+    )
+
+    assert not (cache_root / "plugin").exists()
+
+
 def test_update_plugin_rejects_version_for_local_plugins(tmp_path: Path) -> None:
     app_config_dir = tmp_path / "app"
     plugin_root = tmp_path / "quality"
@@ -2568,6 +2595,7 @@ def test_clawhub_marketplace_lightweight_index_filters_to_installable_plugins(
                         "name": "bundle",
                         "latestVersion": "1.0.0",
                         "family": "bundle-plugin",
+                        "capabilities": {"bundleFormat": "generic"},
                     }
                 ]
             }
@@ -2575,6 +2603,7 @@ def test_clawhub_marketplace_lightweight_index_filters_to_installable_plugins(
             return {
                 "version": "1.0.0",
                 "family": "bundle-plugin",
+                "capabilities": {"bundleFormat": "generic"},
             }
         if url == "https://clawhub.test/api/v1/packages/needs-details":
             return {
@@ -2661,6 +2690,73 @@ def test_clawhub_marketplace_provider_marks_blocked_releases_unsupported() -> No
     assert entry.supported_versions() == ()
     assert entry.versions[0].unsupported_reason == (
         "ClawHub package release is quarantined"
+    )
+
+
+def test_clawhub_marketplace_provider_marks_placeholder_bundle_format_unsupported() -> (
+    None
+):
+    provider = clawhub_marketplace_provider.ClawHubMarketplaceProvider()
+
+    entry = provider._entry_from_raw_package(
+        raw_package={
+            "name": "placeholder-bundle",
+            "family": "bundle-plugin",
+            "version": "1.0.0",
+            "capabilityTags": ["format:Bundle format"],
+        },
+        base_url="https://clawhub.test",
+    )
+
+    assert entry.supported_versions() == ()
+    assert entry.versions[0].unsupported_reason == (
+        "ClawHub bundle plugin does not declare a concrete bundle format"
+    )
+
+    unsupported_format = provider._entry_from_raw_package(
+        raw_package={
+            "name": "codex-bundle",
+            "family": "bundle-plugin",
+            "version": "1.0.0",
+            "capabilities": {"bundleFormat": "codex"},
+        },
+        base_url="https://clawhub.test",
+    )
+    invalid_host = provider._entry_from_raw_package(
+        raw_package={
+            "name": "invalid-host",
+            "family": "bundle-plugin",
+            "version": "1.0.0",
+            "capabilities": {
+                "bundleFormat": "generic",
+                "capabilityTags": ['host:"main": "./dist/plugin.js"'],
+            },
+        },
+        base_url="https://clawhub.test",
+    )
+
+    assert unsupported_format.supported_versions() == ()
+    assert unsupported_format.versions[0].unsupported_reason == (
+        "Unsupported ClawHub bundle format: codex"
+    )
+    assert invalid_host.supported_versions() == ()
+    assert invalid_host.versions[0].unsupported_reason == (
+        "ClawHub bundle plugin host target metadata is invalid"
+    )
+
+    known_unmappable = provider._entry_from_raw_package(
+        raw_package={
+            "name": "kdp-author-engine-bundle",
+            "family": "bundle-plugin",
+            "version": "1.0.0",
+            "capabilities": {"bundleFormat": "generic"},
+        },
+        base_url="https://clawhub.test",
+    )
+
+    assert known_unmappable.supported_versions() == ()
+    assert known_unmappable.versions[0].unsupported_reason == (
+        "ClawHub package artifact does not contain Relay Teams mappable plugin components"
     )
 
 
@@ -3180,6 +3276,28 @@ def test_openclaw_adapter_creates_manifest_for_static_bundle(tmp_path: Path) -> 
     assert manifest["skills"] == "./skills"
 
 
+def test_openclaw_adapter_maps_nested_skill_manifest(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "bundle"
+    skill_dir = plugin_root / "verified-agent-identity"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "# Verified Agent Identity\n\nUse this skill for identity checks.\n",
+        encoding="utf-8",
+    )
+
+    adapt_openclaw_plugin_tree(
+        plugin_root=plugin_root,
+        adapter="openclaw",
+        manifest_config_dir_name="app",
+        source_version="4.0.0",
+    )
+
+    manifest = json.loads((plugin_root / "app" / "plugin.json").read_text("utf-8"))
+    assert manifest["name"] == "bundle"
+    assert manifest["version"] == "4.0.0"
+    assert manifest["skills"] == "./verified-agent-identity"
+
+
 def test_archive_plugin_root_ignores_macos_metadata(tmp_path: Path) -> None:
     extract_dir = tmp_path / "extract"
     plugin_root = extract_dir / "quality"
@@ -3297,8 +3415,16 @@ def test_openclaw_adapter_noops_for_unmappable_or_existing_manifest(
                     "token": {
                         "type": "string",
                         "sensitive": True,
-                    }
+                    },
+                    "preferred_currency": {
+                        "type": "string",
+                        "title": "Preferred currency",
+                        "default": "USD",
+                        "pattern": "^[A-Z]{3}$",
+                    },
                 },
+                "displayName": "Extra Manifest",
+                "icon": "./icon.png",
                 "id": "extra-manifest",
                 "commandNamespace": "extra",
             }
@@ -3324,9 +3450,97 @@ def test_openclaw_adapter_noops_for_unmappable_or_existing_manifest(
             "token": {
                 "type": "string",
                 "sensitive": True,
+            },
+            "preferred_currency": {
+                "type": "string",
+                "title": "Preferred currency",
+                "default": "USD",
+            },
+        },
+    }
+
+    claude_manifest_root = tmp_path / "claude-manifest"
+    (claude_manifest_root / ".claude-plugin").mkdir(parents=True)
+    (claude_manifest_root / "agents").mkdir()
+    (claude_manifest_root / "commands").mkdir()
+    (claude_manifest_root / "commands" / "setup.md").write_text(
+        "---\n"
+        "name: setup\n"
+        "description: Setup command. Usage: /setup <target>\n"
+        "---\n"
+        "# Setup\n",
+        encoding="utf-8",
+    )
+    (claude_manifest_root / "skills" / "conflict-patterns").mkdir(parents=True)
+    (claude_manifest_root / "skills" / "conflict-patterns" / "SKILL.md").write_text(
+        "---\n"
+        "name: Conflict Patterns\n"
+        "description: Identify conflicts. Usage: /skill-git:check <skill-name>\n"
+        "version: 1.0.0\n"
+        "---\n"
+        "# Conflict Patterns\n",
+        encoding="utf-8",
+    )
+    (claude_manifest_root / "agents" / "performance-marketer.md").write_text(
+        "---\nname: Performance Marketer\n---\nRun campaigns.\n",
+        encoding="utf-8",
+    )
+    (claude_manifest_root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "@markifact/mcp",
+                "version": "1.0.0",
+                "mcpServers": "mcp.json",
+                "commands": ["commands/setup.md"],
+                "userConfig": {
+                    "preferred_currency": {
+                        "type": "string",
+                        "default": "USD",
+                        "pattern": "^[A-Z]{3}$",
+                    }
+                },
+                "displayName": "Markifact Performance Marketing",
+                "icon": "./icon.png",
+            }
+        ),
+        encoding="utf-8",
+    )
+    adapt_openclaw_plugin_tree(
+        plugin_root=claude_manifest_root,
+        adapter="openclaw",
+        manifest_config_dir_name="app",
+    )
+    claude_manifest = json.loads(
+        (claude_manifest_root / ".claude-plugin" / "plugin.json").read_text("utf-8")
+    )
+    assert claude_manifest == {
+        "name": "markifact-mcp",
+        "version": "1.0.0",
+        "mcpServers": "./mcp.json",
+        "commands": ["./commands"],
+        "userConfig": {
+            "preferred_currency": {
+                "type": "string",
+                "default": "USD",
             }
         },
     }
+    agent_role = (
+        claude_manifest_root / "agents" / "performance-marketer.md"
+    ).read_text("utf-8")
+    assert "role_id: Performance Marketer" in agent_role
+    assert "mode: subagent" in agent_role
+    skill_manifest = (
+        claude_manifest_root / "skills" / "conflict-patterns" / "SKILL.md"
+    ).read_text("utf-8")
+    assert (
+        "description: 'Identify conflicts. Usage: /skill-git:check <skill-name>'"
+        in skill_manifest
+    )
+    command_manifest = (claude_manifest_root / "commands" / "setup.md").read_text(
+        "utf-8"
+    )
+    assert "description: 'Setup command. Usage: /setup <target>'" in command_manifest
 
     unmappable_root = tmp_path / "unmappable"
     unmappable_root.mkdir()


### PR DESCRIPTION
Closes #855

## Summary
- sanitize and adapt OpenClaw/Claude manifests so frontend-visible ClawHub bundles install without manual edits
- filter unsupported ClawHub bundle metadata and known unmappable packages before install
- use Windows long-path cleanup for plugin validation caches, matching installer cleanup behavior
- add focused unit coverage for ClawHub bundle filtering, nested skills, manifest sanitization, and validation cache cleanup

## Validation
- live-validated all 99 currently frontend-visible ClawHub entries through temporary backend installs
- uv run --extra dev ruff check --fix src/relay_teams/plugins/config_manager.py tests/unit_tests/plugins/test_phase3_distribution.py
- uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/plugins/config_manager.py tests/unit_tests/plugins/test_phase3_distribution.py
- uv run --extra dev pytest -q tests/unit_tests/plugins/test_phase3_distribution.py::test_config_manager_removes_validation_cache_tree tests/unit_tests/plugins/test_phase3_distribution.py::test_clawhub_marketplace_provider_marks_placeholder_bundle_format_unsupported tests/unit_tests/plugins/test_phase3_distribution.py::test_openclaw_adapter_maps_nested_skill_manifest tests/unit_tests/plugins/test_phase3_distribution.py::test_openclaw_adapter_noops_for_unmappable_or_existing_manifest
- git diff --check

Pre-commit also passed ruff-check, ruff-format, and basedpyright-check during commit.