### PR TITLE
Add built-in relay-knowledge skill

### DIFF
--- a/src/relay_teams/builtin/skills/relay-knowledge/SKILL.md
+++ b/src/relay_teams/builtin/skills/relay-knowledge/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: relay-knowledge
+description: Use Relay Knowledge from Agent Teams through the built-in CLI connector. Use this for local knowledge graph status, service diagnostics, code repository registration, full or incremental repository indexing, code search, impact analysis, reports, file indexing, graph inspection, workers, audit queries, setup profiles, and MCP service startup.
+---
+
+# Relay Knowledge
+
+Use this skill when the user asks Agent Teams to use Relay Knowledge, build or refresh a code repository index, query indexed code, inspect graph or index health, run local knowledge/file retrieval, analyze code impact, or start/check the Relay Knowledge service.
+
+Always invoke Relay Knowledge through the wrapper script so the runtime uses the connector-managed CLI path first and falls back to a system `relay-knowledge` on `PATH`.
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- <relay-knowledge arguments>
+```
+
+Prefer `--format json` for machine-readable commands. Use non-JSON formats only when the user explicitly wants a markdown report or human CLI output.
+
+## Global Flags
+
+Allowed global flags:
+
+- `--version`
+- `--help`
+- `--format text|json|markdown|streaming-json`
+
+Use global flags before the Relay Knowledge command and after the wrapper separator:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- --version
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- --help
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- --format json status
+```
+
+Do not use `--format streaming-json` with `version`; that command only supports `text`, `json`, and `markdown`. Prefer `text` or `json` for `help`.
+
+## Command Allowlist
+
+Only use the Relay Knowledge commands listed in this skill. Do not infer, invent, or try adjacent commands.
+
+Allowed top-level commands:
+
+- `status`
+- `health`
+- `version`
+- `help`
+- `ingest`
+- `query`
+- `graph inspect`
+- `index refresh`
+- `files index`
+- `files query`
+- `worker status`
+- `worker run-once`
+- `audit query`
+- `provider probe`
+- `proposal list`
+- `proposal show`
+- `proposal accept`
+- `proposal reject`
+- `proposal supersede`
+- `service status`
+- `service doctor`
+- `service run`
+- `service plan install`
+- `service plan uninstall`
+- `service definition write`
+- `service operator status`
+- `service operator pause`
+- `service operator resume`
+- `setup doctor`
+- `setup profile`
+
+Allowed `repo` subcommands:
+
+- `repo register`
+- `repo index`
+- `repo index-worker`
+- `repo scope preview`
+- `repo update`
+- `repo query`
+- `repo impact`
+- `repo report`
+- `repo status`
+
+Do not run bare `repo`; only run the listed `repo ...` subcommands. Do not use `repo list`; this CLI does not provide it. If an alias is unknown, do not try to enumerate repositories.
+
+For diagnostic or status-only requests, do not register a repository just to discover an alias; ask for the alias or report that the alias is required. For indexing or code-query requests where the user asks to use the current repository and no alias is provided, derive a conservative alias from the current repository directory name and run `repo register "<repo-root>" --alias <alias> --format json` before indexing or querying.
+
+## Common Workflows
+
+Check availability and health:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- --version
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- version --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- status --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- health --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- service doctor --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- setup doctor --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- setup profile local --format json
+```
+
+Register and index a repository:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo register "<repo-root>" --alias <alias> --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- repo index <alias> --ref HEAD --format json
+```
+
+Long-running relay-teams shell tool shape:
+
+```text
+shell(command='python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- repo index <alias> --ref HEAD --format json', timeout_ms=1200000)
+```
+
+When running `repo index`, configure the outer relay-teams command execution timeout to `1200000` ms. This is the current maximum supported by relay-teams command execution. The wrapper `--timeout 1140` controls the Relay Knowledge child process and leaves cleanup/error-reporting time before the outer shell timeout; it does not override an outer `timeout_ms` such as 120000 ms.
+
+After `repo index` returns, inspect the JSON before claiming the index is usable. If the response contains a `task`, use `task.state` as the authoritative state for this index attempt; treat the index as ready only when `task.state` is `succeeded`. Use `status.state=fresh` only when the response has no `task`. If the response contains an active, queued, running, retrying, or failed task state, report that task state and do not start `repo query`, `repo impact`, or `repo report` unless the user explicitly asks to continue with stale data.
+
+Only run `repo status <alias> --format json` after `repo index` if the index response does not already prove `task.state=succeeded` or, when no task is present, `status.state=fresh`.
+
+Use `--path <filter>` and repeated `--language <id>` on `repo register` and `repo query` when the user scopes the request to specific source paths or languages. Do not pass `--path` or `--language` to `repo index`; that subcommand only accepts the alias plus `--ref` and `--dry-run`.
+
+Query code:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo query <alias> --query "<text>" --kind hybrid --ref HEAD --limit 10 --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo query <alias> --query "<symbol>" --kind symbol --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo query <alias> --query "<symbol>" --kind definition --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo query <alias> --query "<symbol>" --kind references --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo query <alias> --query "<symbol>" --kind callers --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo query <alias> --query "<symbol>" --kind callees --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo query <alias> --query "<module>" --kind imports --format json
+```
+
+Allowed `repo query --kind` values: `hybrid`, `symbol`, `definition`, `references`, `callers`, `callees`, `imports`.
+
+Update and analyze changes:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- repo update <alias> --base main --head HEAD --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo impact <alias> --base main --head HEAD --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- repo report <alias> --format markdown
+```
+
+Use outer `timeout_ms=1200000` for `repo update`:
+
+```text
+shell(command='python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- repo update <alias> --base main --head HEAD --format json', timeout_ms=1200000)
+```
+
+After `repo update` returns, inspect the response before running `repo impact`, `repo query`, or `repo report`. If the command fails or reports a missing or stale base scope, report that result and index or reindex the base ref before retrying the update; do not continue analysis from a failed update.
+
+Continue an existing code index task:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- repo index-worker --task-id <task_id> --format json
+```
+
+Use outer `timeout_ms=1200000` for `repo index-worker`:
+
+```text
+shell(command='python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- repo index-worker --task-id <task_id> --format json', timeout_ms=1200000)
+```
+
+Use `repo index-worker` only for executing or recovering an already queued code index task. Do not use it as the normal first choice for building an index; use `repo index <alias> --ref <ref>` for ordinary repository indexing. If `repo index-worker` returns empty output, report that no queued task was claimed or executed; do not claim that indexing completed.
+
+Graph, index, files, workers, and audit:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- ingest --source <scope> --content "<text>" --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- query "<text>" --source <scope> --limit 10 --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- graph inspect --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- index refresh --kind bm25 --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 --env RELAY_KNOWLEDGE_FILE_INDEX_ROOTS="<absolute-root>" -- files index --root "<absolute-root>" --source local-files --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- files query "<text>" --source local-files --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- worker status --kind embedding --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- worker run-once --kind embedding --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- audit query --limit 50 --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- provider probe --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- proposal list --state proposed --limit 20 --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- proposal show <proposal_id> --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- proposal reject <proposal_id> --by <actor> --reason "<reason>" --format json
+```
+
+Long-running relay-teams shell tool shapes:
+
+```text
+shell(command='python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- index refresh --kind bm25 --format json', timeout_ms=1200000)
+shell(command='python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 --env RELAY_KNOWLEDGE_FILE_INDEX_ROOTS="<absolute-root>" -- files index --root "<absolute-root>" --source local-files --format json', timeout_ms=1200000)
+shell(command='python "<skill_dir>/scripts/relay_knowledge_cli.py" --timeout 1140 -- worker run-once --kind embedding --format json', timeout_ms=1200000)
+```
+
+Allowed `index refresh --kind` values: `bm25`, `semantic`, `vector`.
+Allowed `worker --kind` values: `embedding`, `ocr`, `vision`, `extractor`.
+Allowed `--freshness` values for knowledge and repo queries: `allow-stale`, `wait-until-fresh`, `graph-only`.
+Use `allow-stale` by default. Use `wait-until-fresh` only when the user explicitly asks for the latest indexed state or strong freshness; it may wait for indexing work. When using `wait-until-fresh`, pass wrapper `--timeout 1140` and outer `timeout_ms=1200000`.
+Allowed `proposal list --state` values: `proposed`, `accepted`, `rejected`, `superseded`.
+`proposal accept`, `proposal reject`, and `proposal supersede` require a proposal id and `--by <actor>`. Do not run a proposal decision command if either value is unknown.
+
+Service and MCP access:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- service status --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- service plan install --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- service operator status --format json
+```
+
+Do not run `service run` as a normal synchronous shell command. It starts a long-lived service and should only be used when the user explicitly asks to start the Relay Knowledge service. When using relay-teams shell execution, run `python "<skill_dir>/scripts/relay_knowledge_cli.py" -- service run --web --mcp streamable-http` with the outer shell tool `background=true`.
+
+Pseudo tool call shape:
+
+```text
+shell(command='python "<skill_dir>/scripts/relay_knowledge_cli.py" -- service run --web --mcp streamable-http', background=true)
+```
+
+Setup profiles:
+
+```bash
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- setup profile local --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- setup profile agent-readonly --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- setup profile service --format json
+python "<skill_dir>/scripts/relay_knowledge_cli.py" -- setup profile external-embedding --format json
+```
+
+`setup doctor` and `setup profile` may return suggested remediation commands containing raw `relay-knowledge ...` invocations. Do not execute those commands verbatim. Convert each suggestion to the wrapper form in this skill, then apply this skill's timeout, mutation, and background-service rules before running it.
+
+## Operating Rules
+
+- If the CLI is missing, tell the user Relay Knowledge CLI must be installed from the Relay Knowledge connector. Use `--install-if-missing` only when the user asks you to install or update it.
+- Do not use wrapper `--detach`. Run `repo index` synchronously with a long outer command timeout so Relay Knowledge owns the SQLite database in a single CLI process until indexing completes.
+- For cold `repo index`, request outer `timeout_ms=1200000` and pass wrapper `--timeout 1140` before the first `--`. If a repository is expected to take more than 19 minutes, do not claim that the skill-only synchronous path can finish it; tell the user relay-teams must raise its command timeout limit or relay-knowledge must support safe background status checks.
+- Run `repo status <alias> --format json` after the synchronous `repo index` command returns only if the index response does not already prove `task.state=succeeded` or, when no task is present, `status.state=fresh`. If both `task` and `status` are present, `task.state` is authoritative for the current attempt. Do not start status/query/report commands concurrently with the indexing command.
+- Use `repo scope preview <alias> --ref <ref> --format json` or `repo index <alias> --dry-run --format json` before indexing if the requested scope is unclear or large.
+- Do not use `--path` or `--language` with `repo index`; use scoped `repo register` first when path or language filters are needed.
+- Use `repo index-worker --task-id <task_id>` only for existing queued index tasks. Do not invent a task id, and do not use `repo index-worker` when the goal is to start indexing a repository from an alias. Use wrapper `--timeout 1140` and outer `timeout_ms=1200000` for `repo index-worker`.
+- Treat empty output from `repo index-worker` as "no queued task was claimed"; do not interpret it as success.
+- Use wrapper `--timeout 1140` and outer `timeout_ms=1200000` for potentially long mutation or worker commands: `repo update`, `files index`, `index refresh`, and `worker run-once`.
+- Use `--freshness allow-stale` unless the user explicitly asks for latest indexed data. For `--freshness wait-until-fresh`, use wrapper `--timeout 1140` and outer `timeout_ms=1200000`.
+- Run `service run` only as an outer background shell task. Do not wait on it synchronously as part of a normal question-answering workflow.
+- Use `setup profile` only with one of `local`, `agent-readonly`, `service`, or `external-embedding`.
+- Convert raw `relay-knowledge ...` commands returned by setup diagnostics into `python "<skill_dir>/scripts/relay_knowledge_cli.py" -- ...` wrapper commands before execution.
+- Only run mutation commands when the user explicitly asks to change Relay Knowledge state, start work, or control a service. Mutation commands are `ingest`, `repo register`, `repo index`, `repo index-worker`, `repo update`, `index refresh`, `files index`, `worker run-once`, `proposal accept`, `proposal reject`, `proposal supersede`, `service definition write`, `service operator pause`, `service operator resume`, and `service run`.
+- Use `repo update` for explicit base-to-head diffs. If it reports a missing base scope, index the base ref first.
+- Use `--ref worktree` only when the user wants dirty worktree or overlay indexing.
+- Do not mutate Relay Knowledge state for diagnostic requests. Status, health, version, help, setup doctor/profile, provider probe, service status/doctor/plan, service operator status, proposal list/show, reports, and audit queries are read-only diagnostics; repository registration, ingest, repository index/update/index-worker, index refresh, worker run-once, proposal accept/reject/supersede, service definition writes, service operator pause/resume, and service run mutate runtime state or start long-lived processes.
+
+## Scripts
+
+- relay_knowledge_cli: Resolve the connector-managed Relay Knowledge CLI and pass through arbitrary CLI arguments. (scripts/relay_knowledge_cli.py)

--- a/src/relay_teams/builtin/skills/relay-knowledge/scripts/relay_knowledge_cli.py
+++ b/src/relay_teams/builtin/skills/relay-knowledge/scripts/relay_knowledge_cli.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import argparse
+import asyncio
+import codecs
+import os
+from pathlib import Path
+import queue
+import signal
+import subprocess
+import sys
+import threading
+import time
+from typing import BinaryIO
+
+_SCRIPT_PATH = Path(__file__).resolve()
+for _parent in _SCRIPT_PATH.parents:
+    if (_parent / "relay_teams").is_dir():
+        sys.path.insert(0, str(_parent))
+        break
+
+from relay_teams.binary_tools import BinaryToolId, BinaryToolService, BinaryToolStatus  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    command = _normalize_command(args.command)
+    if not command:
+        print(
+            "Usage: relay_knowledge_cli.py [--cwd DIR] [--timeout SECONDS] "
+            "[--install-if-missing] [--env KEY=VALUE] -- <relay-knowledge args>",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        cli_path = _resolve_cli_path(install_if_missing=args.install_if_missing)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 127
+
+    cwd_path = _resolve_cwd(args.cwd)
+    cwd = str(cwd_path)
+    env = _build_env(args.env)
+
+    try:
+        return _run_cli_process(
+            [str(cli_path), *command],
+            cwd=cwd,
+            env=env,
+            timeout=args.timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"relay-knowledge command timed out after {args.timeout:g} seconds.",
+            file=sys.stderr,
+        )
+        return 124
+    except OSError as exc:
+        print(f"failed to execute relay-knowledge: {exc}", file=sys.stderr)
+        return 127
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Relay Knowledge through the Agent Teams CLI connector.",
+    )
+    parser.add_argument("--cwd", help="Working directory for the CLI process.")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Command timeout in seconds. Defaults to no timeout.",
+    )
+    parser.add_argument(
+        "--install-if-missing",
+        action="store_true",
+        help="Download the connector-managed Relay Knowledge CLI when missing.",
+    )
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Environment override for the CLI process. May be repeated.",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def _normalize_command(command: list[str]) -> list[str]:
+    if command and command[0] == "--":
+        return command[1:]
+    return command
+
+
+def _resolve_cwd(cwd_arg: str | None) -> Path:
+    if cwd_arg is None:
+        return Path.cwd().resolve()
+    return Path(cwd_arg).expanduser().resolve()
+
+
+def _resolve_cli_path(*, install_if_missing: bool) -> Path:
+    service = BinaryToolService()
+    if install_if_missing:
+        return asyncio.run(service.ensure_tool_path(BinaryToolId.RELAY_KNOWLEDGE))
+
+    item = service.inspect_tool(BinaryToolId.RELAY_KNOWLEDGE)
+    if item.status == BinaryToolStatus.READY and item.path:
+        return Path(item.path)
+
+    target_version = (
+        f" target version {item.target_version}" if item.target_version else ""
+    )
+    raise RuntimeError(
+        "Relay Knowledge CLI is not installed. Install it from the Relay Knowledge "
+        f"connector{target_version}, or rerun this script with --install-if-missing."
+    )
+
+
+def _build_env(overrides: list[str]) -> dict[str, str]:
+    env = os.environ.copy()
+    for override in overrides:
+        key, separator, value = override.partition("=")
+        key = key.strip()
+        if not separator or not key:
+            raise SystemExit(f"invalid --env value: {override!r}; expected KEY=VALUE")
+        env[key] = value
+    return env
+
+
+def _run_cli_process(
+    command: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+    timeout: float | None,
+) -> int:
+    proc = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=os.name != "nt",
+        creationflags=_creation_flags(),
+    )
+    output_queue: queue.Queue[tuple[str, str] | None] = queue.Queue()
+    streams = tuple(
+        (name, stream)
+        for name, stream in (("stdout", proc.stdout), ("stderr", proc.stderr))
+        if stream is not None
+    )
+    threads = [
+        threading.Thread(
+            target=_pump_stream,
+            args=(name, stream, output_queue),
+            daemon=True,
+        )
+        for name, stream in streams
+    ]
+    for thread in threads:
+        thread.start()
+
+    deadline = None if timeout is None else time.monotonic() + timeout
+    closed_streams = 0
+    while closed_streams < len(threads):
+        queue_timeout = None
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                assert timeout is not None
+                _terminate_process_tree(proc)
+                raise subprocess.TimeoutExpired(command, timeout)
+            queue_timeout = max(0.001, remaining)
+        try:
+            item = output_queue.get(timeout=queue_timeout)
+        except queue.Empty as exc:
+            assert timeout is not None
+            _terminate_process_tree(proc)
+            raise subprocess.TimeoutExpired(command, timeout) from exc
+
+        if item is None:
+            closed_streams += 1
+            continue
+
+        stream_name, chunk = item
+        target = sys.stdout if stream_name == "stdout" else sys.stderr
+        target.write(chunk)
+        target.flush()
+
+    if deadline is None:
+        return proc.wait()
+
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        assert timeout is not None
+        _terminate_process_tree(proc)
+        raise subprocess.TimeoutExpired(command, timeout)
+
+    try:
+        return proc.wait(timeout=remaining)
+    except subprocess.TimeoutExpired as exc:
+        assert timeout is not None
+        _terminate_process_tree(proc)
+        raise subprocess.TimeoutExpired(command, timeout) from exc
+
+
+def _pump_stream(
+    stream_name: str,
+    stream: BinaryIO,
+    output_queue: queue.Queue[tuple[str, str] | None],
+) -> None:
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    try:
+        while chunk := stream.read(4096):
+            output_queue.put((stream_name, decoder.decode(chunk)))
+        remainder = decoder.decode(b"", final=True)
+        if remainder:
+            output_queue.put((stream_name, remainder))
+    finally:
+        output_queue.put(None)
+
+
+def _creation_flags() -> int:
+    if os.name != "nt":
+        return 0
+    return int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
+
+
+def _terminate_process_tree(proc: subprocess.Popen[bytes]) -> None:
+    if os.name == "nt":
+        taskkill_succeeded = _taskkill_process_tree(proc.pid)
+        if not taskkill_succeeded:
+            print(
+                "warning: taskkill failed while terminating relay-knowledge process tree; "
+                "falling back to direct process kill.",
+                file=sys.stderr,
+            )
+    else:
+        signal_succeeded = _signal_process_group(proc.pid, signal.SIGTERM)
+        if not signal_succeeded and proc.poll() is None:
+            proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        if os.name == "nt":
+            taskkill_succeeded = _taskkill_process_tree(proc.pid)
+            if not taskkill_succeeded:
+                proc.kill()
+        else:
+            signal_succeeded = _signal_process_group(proc.pid, signal.SIGKILL)
+            if not signal_succeeded and proc.poll() is None:
+                proc.kill()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            print(
+                "warning: relay-knowledge process did not exit after forced kill; "
+                "continuing best-effort shutdown.",
+                file=sys.stderr,
+            )
+
+
+def _taskkill_process_tree(pid: int) -> bool:
+    try:
+        completed = subprocess.run(
+            ["taskkill", "/f", "/t", "/pid", str(pid)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+        return completed.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _signal_process_group(pid: int, sig: signal.Signals) -> bool:
+    killpg = getattr(os, "killpg", None)
+    if killpg is None:
+        print(
+            "warning: process-group signaling is unavailable; falling back to direct "
+            "relay-knowledge process termination.",
+            file=sys.stderr,
+        )
+        return False
+    try:
+        killpg(pid, sig)
+        return True
+    except (ProcessLookupError, PermissionError):
+        print(
+            "warning: relay-knowledge process group could not be signaled; "
+            "continuing best-effort shutdown.",
+            file=sys.stderr,
+        )
+        return False
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit_tests/builtin/test_relay_knowledge_skill.py
+++ b/tests/unit_tests/builtin/test_relay_knowledge_skill.py
@@ -1,0 +1,791 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import importlib.util
+from io import BytesIO
+import os
+from pathlib import Path
+import queue
+import signal
+import subprocess
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from relay_teams.builtin import get_builtin_skills_dir
+from relay_teams.skills.skill_registry import SkillRegistry
+
+
+def _load_wrapper_module() -> ModuleType:
+    script_path = (
+        get_builtin_skills_dir()
+        / "relay-knowledge"
+        / "scripts"
+        / "relay_knowledge_cli.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "relay_knowledge_cli_test_module",
+        script_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _child_process_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in tuple(env):
+        normalized_key = key.upper()
+        if normalized_key.startswith("COV_CORE_") or normalized_key.startswith(
+            "COVERAGE_",
+        ):
+            env.pop(key)
+    return env
+
+
+def test_builtin_relay_knowledge_skill_is_discoverable(tmp_path: Path) -> None:
+    registry = SkillRegistry.from_skill_dirs(
+        app_skills_dir=tmp_path / "skills",
+        builtin_skills_dir=get_builtin_skills_dir(),
+    )
+
+    skill = registry.get_skill_definition("relay-knowledge")
+
+    assert skill is not None
+    assert skill.metadata.name == "relay-knowledge"
+    assert "scripts/relay_knowledge_cli.py" in skill.metadata.resources
+
+
+def test_builtin_relay_knowledge_skill_constrains_cli_commands() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "## Command Allowlist" in content
+    assert "Allowed `repo` subcommands" in content
+    assert "Do not use `repo list`" in content
+    assert "Do not run bare `repo`" in content
+    assert "- `repo`\n" not in content
+    assert "- `health`" in content
+    assert "- `version`" in content
+    assert "- `help`" in content
+    assert "- `ingest`" in content
+    assert "- `provider probe`" in content
+    assert "- `proposal list`" in content
+    assert "- `service definition write`" in content
+    assert "- `service operator pause`" in content
+    assert "- `repo register`" in content
+    assert "- `repo status`" in content
+
+
+def test_builtin_relay_knowledge_skill_declares_global_flags() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "## Global Flags" in content
+    assert "- `--version`" in content
+    assert "- `--help`" in content
+    assert "- `--format text|json|markdown|streaming-json`" in content
+    assert 'relay_knowledge_cli.py" -- --version' in content
+    assert "Do not use `--format streaming-json` with `version`" in content
+    assert "Prefer `text` or `json` for `help`." in content
+
+
+def test_builtin_relay_knowledge_skill_requires_synchronous_long_timeout_index() -> (
+    None
+):
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "Do not use wrapper `--detach`." in content
+    assert 'relay_knowledge_cli.py" --detach' not in content
+    assert "--timeout 1140 -- repo index" in content
+    assert "--timeout 1200 -- repo index" not in content
+    assert "outer command timeout" in content
+    assert "`1200000` ms" in content
+    assert "`1800000` ms" not in content
+    assert "`3600000` ms" not in content
+    assert "treat the index as ready only when `task.state` is `succeeded`" in content
+    assert "use `task.state` as the authoritative state" in content
+    assert "Use `status.state=fresh` only when the response has no `task`" in content
+    assert "do not start `repo query`, `repo impact`, or `repo report`" in content
+    assert "shell(command='python" in content
+    assert (
+        "repo index <alias> --ref HEAD --format json', timeout_ms=1200000)" in content
+    )
+    register_block = content.split("Register and index a repository:", 1)[1].split(
+        "When running `repo index`",
+        1,
+    )[0]
+    assert "repo status <alias>" not in register_block
+    assert (
+        "Only run `repo status <alias> --format json` after `repo index` "
+        "if the index response does not already prove" in content
+    )
+
+
+def test_builtin_relay_knowledge_skill_constrains_repo_index_options() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "Do not pass `--path` or `--language` to `repo index`" in content
+    assert "only accepts the alias plus `--ref` and `--dry-run`" in content
+    assert (
+        "Use `--path <filter>` and repeated `--language <id>` on `repo register`, "
+        "`repo index`, `repo query`" not in content
+    )
+
+
+def test_builtin_relay_knowledge_skill_does_not_register_for_diagnostics() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert (
+        "For diagnostic or status-only requests, do not register a repository just "
+        "to discover an alias" in content
+    )
+    assert "ask for the alias or report that the alias is required" in content
+    assert "repository registration" in content
+
+
+def test_builtin_relay_knowledge_skill_requires_background_service_run() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+    service_block = content.split("Service and MCP access:", 1)[1].split(
+        "Do not run `service run`",
+        1,
+    )[0]
+
+    assert "Do not run `service run` as a normal synchronous shell command." in content
+    assert "outer shell tool `background=true`" in content
+    assert "shell(command=" in content
+    assert "background=true)" in content
+    assert "Run `service run` only as an outer background shell task." in content
+    assert "service run --web --mcp streamable-http" not in service_block
+
+
+def test_builtin_relay_knowledge_skill_lists_setup_profiles() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "setup profile local" in content
+    assert "setup profile agent-readonly" in content
+    assert "setup profile service" in content
+    assert "setup profile external-embedding" in content
+    assert "Use `setup profile` only with one of" in content
+
+
+def test_builtin_relay_knowledge_skill_lists_parameter_enums() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert (
+        "Allowed `repo query --kind` values: `hybrid`, `symbol`, `definition`, "
+        "`references`, `callers`, `callees`, `imports`." in content
+    )
+    assert (
+        "Allowed `index refresh --kind` values: `bm25`, `semantic`, `vector`."
+        in content
+    )
+    assert (
+        "Allowed `worker --kind` values: `embedding`, `ocr`, `vision`, "
+        "`extractor`." in content
+    )
+    assert (
+        "Allowed `--freshness` values for knowledge and repo queries: "
+        "`allow-stale`, `wait-until-fresh`, `graph-only`." in content
+    )
+    assert "Use `allow-stale` by default." in content
+    assert "Use `wait-until-fresh` only when the user explicitly asks" in content
+    assert (
+        "For `--freshness wait-until-fresh`, use wrapper `--timeout 1140` "
+        "and outer `timeout_ms=1200000`." in content
+    )
+    assert (
+        "Allowed `proposal list --state` values: `proposed`, `accepted`, "
+        "`rejected`, `superseded`." in content
+    )
+
+
+def test_builtin_relay_knowledge_skill_requires_explicit_mutation_request() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "Only run mutation commands when the user explicitly asks" in content
+    assert "`repo index-worker`" in content
+    assert "`proposal accept`" in content
+    assert "`service operator resume`" in content
+    assert "`service run`" in content
+
+
+def test_builtin_relay_knowledge_skill_constrains_proposal_decisions() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "proposal reject <proposal_id> --by <actor>" in content
+    assert (
+        "`proposal accept`, `proposal reject`, and `proposal supersede` require "
+        "a proposal id and `--by <actor>`." in content
+    )
+    assert (
+        "Do not run a proposal decision command if either value is unknown." in content
+    )
+
+
+def test_builtin_relay_knowledge_skill_constrains_index_worker_usage() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "repo index-worker --task-id <task_id>" in content
+    assert (
+        "only for executing or recovering an already queued code index task" in content
+    )
+    assert "Do not invent a task id" in content
+    assert "use `repo index <alias> --ref <ref>`" in content
+    assert "--timeout 1140 -- repo index-worker" in content
+    assert (
+        "repo index-worker --task-id <task_id> --format json', timeout_ms=1200000)"
+        in content
+    )
+    assert "If `repo index-worker` returns empty output" in content
+    assert (
+        'Treat empty output from `repo index-worker` as "no queued task was claimed"'
+        in content
+    )
+
+
+def test_builtin_relay_knowledge_skill_uses_long_timeout_for_other_mutations() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "--timeout 1140 -- index refresh" in content
+    assert "--timeout 1140 --env RELAY_KNOWLEDGE_FILE_INDEX_ROOTS" in content
+    assert "--timeout 1140 -- worker run-once" in content
+    assert "--timeout 1140 -- repo update" in content
+    assert (
+        "repo update <alias> --base main --head HEAD --format json', timeout_ms=1200000)"
+        in content
+    )
+    assert "After `repo update` returns, inspect the response" in content
+    assert "missing or stale base scope" in content
+    assert "do not continue analysis from a failed update" in content
+    assert "index refresh --kind bm25 --format json', timeout_ms=1200000)" in content
+    assert "files index --root" in content
+    assert (
+        "worker run-once --kind embedding --format json', timeout_ms=1200000)"
+        in content
+    )
+    assert (
+        "Use wrapper `--timeout 1140` and outer `timeout_ms=1200000` for "
+        "potentially long mutation or worker commands" in content
+    )
+    assert (
+        "`repo update`, `files index`, `index refresh`, and `worker run-once`"
+        in content
+    )
+
+
+def test_builtin_relay_knowledge_skill_converts_setup_commands_to_wrapper() -> None:
+    skill_path = get_builtin_skills_dir() / "relay-knowledge" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert "Do not execute those commands verbatim" in content
+    assert "Convert each suggestion to the wrapper form in this skill" in content
+    assert (
+        "Convert raw `relay-knowledge ...` commands returned by setup diagnostics "
+        'into `python "<skill_dir>/scripts/relay_knowledge_cli.py" -- ...` '
+        "wrapper commands before execution." in content
+    )
+
+
+def test_relay_knowledge_cli_wrapper_passes_through_command(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_wrapper_module()
+    monkeypatch.setattr(
+        module, "_resolve_cli_path", lambda install_if_missing: Path(sys.executable)
+    )
+    monkeypatch.setattr(module, "_build_env", lambda overrides: _child_process_env())
+
+    exit_code = module.main(["--", "-c", "print('relay-knowledge-ok')"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.replace("\r\n", "\n") == "relay-knowledge-ok\n"
+    assert captured.err == ""
+
+
+def test_relay_knowledge_cli_wrapper_reports_missing_cli(monkeypatch, capsys) -> None:
+    module = _load_wrapper_module()
+
+    def resolve_cli_path(*, install_if_missing: bool) -> Path:
+        raise RuntimeError("relay knowledge missing")
+
+    monkeypatch.setattr(module, "_resolve_cli_path", resolve_cli_path)
+
+    exit_code = module.main(["--", "status"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 127
+    assert "relay knowledge missing" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_reports_timeout(monkeypatch, capsys) -> None:
+    module = _load_wrapper_module()
+    monkeypatch.setattr(
+        module, "_resolve_cli_path", lambda install_if_missing: Path(sys.executable)
+    )
+
+    def run_cli_process(
+        command: list[str],
+        *,
+        cwd: str,
+        env: dict[str, str],
+        timeout: float | None,
+    ) -> int:
+        raise subprocess.TimeoutExpired(command, timeout or 0)
+
+    monkeypatch.setattr(module, "_run_cli_process", run_cli_process)
+
+    exit_code = module.main(["--timeout", "1", "--", "status"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 124
+    assert "timed out after 1 seconds" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_reports_execution_error(
+    monkeypatch, capsys
+) -> None:
+    module = _load_wrapper_module()
+    monkeypatch.setattr(
+        module, "_resolve_cli_path", lambda install_if_missing: Path(sys.executable)
+    )
+
+    def run_cli_process(
+        command: list[str],
+        *,
+        cwd: str,
+        env: dict[str, str],
+        timeout: float | None,
+    ) -> int:
+        raise OSError("boom")
+
+    monkeypatch.setattr(module, "_run_cli_process", run_cli_process)
+
+    exit_code = module.main(["--", "status"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 127
+    assert "failed to execute relay-knowledge: boom" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_resolves_cwd_and_env(monkeypatch) -> None:
+    module = _load_wrapper_module()
+
+    assert module._resolve_cwd(None) == Path.cwd().resolve()
+    assert module._resolve_cwd(".") == Path.cwd().resolve()
+
+    env = module._build_env(["RELAY_TEST=value"])
+    assert env["RELAY_TEST"] == "value"
+
+    with pytest.raises(SystemExit):
+        module._build_env(["missing-separator"])
+
+
+def test_relay_knowledge_cli_wrapper_resolves_cli_path(monkeypatch) -> None:
+    module = _load_wrapper_module()
+
+    class ReadyService:
+        def inspect_tool(self, tool_id: object) -> object:
+            return SimpleNamespace(
+                status=module.BinaryToolStatus.READY,
+                path=str(Path(sys.executable)),
+                target_version="1.2.3",
+            )
+
+    monkeypatch.setattr(module, "BinaryToolService", ReadyService)
+
+    assert module._resolve_cli_path(install_if_missing=False) == Path(sys.executable)
+
+
+def test_relay_knowledge_cli_wrapper_installs_cli_when_requested(monkeypatch) -> None:
+    module = _load_wrapper_module()
+
+    class InstallService:
+        async def ensure_tool_path(self, tool_id: object) -> Path:
+            return Path(sys.executable)
+
+    monkeypatch.setattr(module, "BinaryToolService", InstallService)
+
+    assert module._resolve_cli_path(install_if_missing=True) == Path(sys.executable)
+
+
+def test_relay_knowledge_cli_wrapper_errors_when_cli_missing(monkeypatch) -> None:
+    module = _load_wrapper_module()
+
+    class MissingService:
+        def inspect_tool(self, tool_id: object) -> object:
+            return SimpleNamespace(status=object(), path=None, target_version="1.2.3")
+
+    monkeypatch.setattr(module, "BinaryToolService", MissingService)
+
+    with pytest.raises(RuntimeError, match="target version 1.2.3"):
+        module._resolve_cli_path(install_if_missing=False)
+
+
+def test_relay_knowledge_cli_wrapper_times_out_immediately(
+    monkeypatch,
+) -> None:
+    module = _load_wrapper_module()
+    terminated_pids: list[int] = []
+
+    def terminate_process(proc: subprocess.Popen[bytes]) -> None:
+        terminated_pids.append(proc.pid)
+        proc.kill()
+        proc.wait(timeout=2)
+
+    monkeypatch.setattr(module, "_terminate_process_tree", terminate_process)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        module._run_cli_process(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            cwd=str(Path.cwd()),
+            env=_child_process_env(),
+            timeout=0,
+        )
+
+    assert terminated_pids
+
+
+def test_relay_knowledge_cli_wrapper_times_out_while_streams_are_open(
+    monkeypatch,
+) -> None:
+    module = _load_wrapper_module()
+    terminated_pids: list[int] = []
+
+    def terminate_process(proc: subprocess.Popen[bytes]) -> None:
+        terminated_pids.append(proc.pid)
+        proc.kill()
+        proc.wait(timeout=2)
+
+    monkeypatch.setattr(module, "_terminate_process_tree", terminate_process)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        module._run_cli_process(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            cwd=str(Path.cwd()),
+            env=_child_process_env(),
+            timeout=0.1,
+        )
+
+    assert terminated_pids
+
+
+def test_relay_knowledge_cli_wrapper_times_out_after_streams_close(
+    monkeypatch,
+) -> None:
+    module = _load_wrapper_module()
+    terminated_pids: list[int] = []
+
+    def terminate_process(proc: subprocess.Popen[bytes]) -> None:
+        terminated_pids.append(proc.pid)
+        proc.kill()
+        proc.wait(timeout=2)
+
+    monkeypatch.setattr(module, "_terminate_process_tree", terminate_process)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        module._run_cli_process(
+            [
+                sys.executable,
+                "-c",
+                "import sys, time; sys.stdout.close(); sys.stderr.close(); "
+                + "time.sleep(10)",
+            ],
+            cwd=str(Path.cwd()),
+            env=_child_process_env(),
+            timeout=0.1,
+        )
+
+    assert terminated_pids
+
+
+def test_relay_knowledge_cli_wrapper_pumps_stream_remainder() -> None:
+    module = _load_wrapper_module()
+    output_queue: queue.Queue[tuple[str, str] | None] = queue.Queue()
+
+    module._pump_stream("stdout", BytesIO(b"\xe2\x82"), output_queue)
+
+    assert output_queue.get_nowait() == ("stdout", "")
+    assert output_queue.get_nowait() == ("stdout", "\ufffd")
+    assert output_queue.get_nowait() is None
+
+
+def test_relay_knowledge_cli_wrapper_terminates_child_when_group_signal_fails(
+    monkeypatch,
+) -> None:
+    module = _load_wrapper_module()
+
+    class FakeProc:
+        pid = 123
+
+        def __init__(self) -> None:
+            self.wait_calls = 0
+            self.terminated = False
+            self.killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def wait(self, timeout: float | None = None) -> int:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired(["relay-knowledge"], timeout or 0)
+            return 0
+
+    proc = FakeProc()
+    monkeypatch.setattr(module.os, "name", "posix")
+    monkeypatch.setattr(module.signal, "SIGKILL", signal.SIGTERM, raising=False)
+    monkeypatch.setattr(module, "_signal_process_group", lambda pid, sig: False)
+
+    module._terminate_process_tree(cast(subprocess.Popen[bytes], proc))
+
+    assert proc.terminated is True
+    assert proc.killed is True
+
+
+def test_relay_knowledge_cli_wrapper_terminates_windows_process_tree(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_wrapper_module()
+
+    class FakeProc:
+        pid = 123
+
+        def __init__(self) -> None:
+            self.wait_calls = 0
+            self.killed = False
+
+        def wait(self, timeout: float | None = None) -> int:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired(["relay-knowledge"], timeout or 0)
+            return 0
+
+        def kill(self) -> None:
+            self.killed = True
+
+    proc = FakeProc()
+    monkeypatch.setattr(module.os, "name", "nt")
+    monkeypatch.setattr(module, "_taskkill_process_tree", lambda pid: False)
+
+    module._terminate_process_tree(cast(subprocess.Popen[bytes], proc))
+
+    captured = capsys.readouterr()
+    assert proc.killed is True
+    assert "taskkill failed" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_warns_when_forced_kill_does_not_exit(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_wrapper_module()
+
+    class FakeProc:
+        pid = 123
+
+        def poll(self) -> None:
+            return None
+
+        def wait(self, timeout: float | None = None) -> int:
+            raise subprocess.TimeoutExpired(["relay-knowledge"], timeout or 0)
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    proc = FakeProc()
+    monkeypatch.setattr(module.os, "name", "posix")
+    monkeypatch.setattr(module.signal, "SIGKILL", signal.SIGTERM, raising=False)
+    monkeypatch.setattr(module, "_signal_process_group", lambda pid, sig: False)
+
+    module._terminate_process_tree(cast(subprocess.Popen[bytes], proc))
+
+    captured = capsys.readouterr()
+    assert "did not exit after forced kill" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_taskkill_success_and_failure(
+    monkeypatch,
+) -> None:
+    module = _load_wrapper_module()
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0),
+    )
+    assert module._taskkill_process_tree(123) is True
+
+    def fail_run(*args: object, **kwargs: object) -> object:
+        raise OSError
+
+    monkeypatch.setattr(module.subprocess, "run", fail_run)
+    assert module._taskkill_process_tree(123) is False
+
+
+def test_relay_knowledge_cli_wrapper_creation_flags(monkeypatch) -> None:
+    module = _load_wrapper_module()
+
+    monkeypatch.setattr(module.os, "name", "posix")
+    assert module._creation_flags() == 0
+
+    monkeypatch.setattr(module.os, "name", "nt")
+    monkeypatch.setattr(
+        module.subprocess, "CREATE_NEW_PROCESS_GROUP", 512, raising=False
+    )
+    assert module._creation_flags() == 512
+
+
+def test_relay_knowledge_cli_wrapper_signals_process_group(monkeypatch) -> None:
+    module = _load_wrapper_module()
+    calls: list[tuple[int, signal.Signals]] = []
+
+    def killpg(pid: int, sig: signal.Signals) -> None:
+        calls.append((pid, sig))
+
+    monkeypatch.setattr(module.os, "killpg", killpg, raising=False)
+
+    assert module._signal_process_group(123, signal.SIGTERM) is True
+    assert calls == [(123, signal.SIGTERM)]
+
+
+def test_relay_knowledge_cli_wrapper_falls_back_when_group_signal_unavailable(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_wrapper_module()
+    monkeypatch.delattr(module.os, "killpg", raising=False)
+
+    assert module._signal_process_group(123, signal.SIGTERM) is False
+
+    captured = capsys.readouterr()
+    assert "process-group signaling is unavailable" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_falls_back_when_group_signal_fails(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_wrapper_module()
+
+    def killpg(pid: int, sig: signal.Signals) -> None:
+        raise PermissionError
+
+    monkeypatch.setattr(module.os, "killpg", killpg, raising=False)
+
+    assert module._signal_process_group(123, signal.SIGTERM) is False
+
+    captured = capsys.readouterr()
+    assert "process group could not be signaled" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_uses_streaming_process_execution() -> None:
+    script_path = (
+        get_builtin_skills_dir()
+        / "relay-knowledge"
+        / "scripts"
+        / "relay_knowledge_cli.py"
+    )
+    content = script_path.read_text(encoding="utf-8")
+
+    assert "subprocess.Popen(" in content
+    assert "capture_output=True" not in content
+    assert "stream.read(4096)" in content
+    assert "getincrementaldecoder" in content
+    assert "for line in stream" not in content
+
+
+def test_relay_knowledge_cli_wrapper_uses_strict_timeout_and_tree_kill() -> None:
+    script_path = (
+        get_builtin_skills_dir()
+        / "relay-knowledge"
+        / "scripts"
+        / "relay_knowledge_cli.py"
+    )
+    content = script_path.read_text(encoding="utf-8")
+
+    assert "remaining <= 0" in content
+    assert "proc.wait(timeout=remaining)" in content
+    assert "_terminate_process_tree(proc)" in content
+    assert "taskkill" in content
+    assert "killpg(pid" in content
+    assert "proc.terminate()" in content
+    assert "proc.kill()" in content
+    assert "signal.SIGKILL" in content
+    assert "return False" in content
+    assert "CREATE_NEW_PROCESS_GROUP" in content
+    assert 'start_new_session=os.name != "nt"' in content
+    assert (
+        "warning: taskkill failed while terminating relay-knowledge process tree"
+        in content
+    )
+    assert "return completed.returncode == 0" in content
+    assert "if proc.poll() is not None:\n        return" not in content
+
+
+def test_relay_knowledge_cli_wrapper_bootstraps_src_path() -> None:
+    script_path = (
+        get_builtin_skills_dir()
+        / "relay-knowledge"
+        / "scripts"
+        / "relay_knowledge_cli.py"
+    )
+    content = script_path.read_text(encoding="utf-8")
+
+    assert "_SCRIPT_PATH = Path(__file__).resolve()" in content
+    assert '(_parent / "relay_teams").is_dir()' in content
+    assert "sys.path.insert(0, str(_parent))" in content
+
+
+def test_relay_knowledge_cli_wrapper_requires_command(capsys) -> None:
+    module = _load_wrapper_module()
+
+    exit_code = module.main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Usage: relay_knowledge_cli.py" in captured.err
+
+
+def test_relay_knowledge_cli_wrapper_defaults_to_no_timeout() -> None:
+    module = _load_wrapper_module()
+
+    args = module._parse_args(["--", "--version"])
+
+    assert args.timeout is None
+
+
+def test_relay_knowledge_cli_wrapper_accepts_long_timeout() -> None:
+    module = _load_wrapper_module()
+
+    args = module._parse_args(["--timeout", "1140", "--", "repo", "index", "core"])
+
+    assert args.timeout == 1140
+    assert module._normalize_command(args.command) == ["repo", "index", "core"]


### PR DESCRIPTION
## Summary
- add a built-in `relay-knowledge` skill that routes Agent Teams usage through the connector-managed CLI wrapper
- document allowed Relay Knowledge commands, long-running index/update timeout rules, mutation boundaries, and service background execution rules
- add a streaming CLI wrapper with connector resolution, env overrides, explicit timeout handling, and process-tree cleanup
- add unit coverage for skill discovery, command constraints, workflow rules, and wrapper behavior

## Validation
- `uv run pytest tests/unit_tests/builtin/test_relay_knowledge_skill.py tests/unit_tests/tools/test_package_data.py::test_builtin_skill_files_are_declared_in_package_data`
- `uv run ruff check src/relay_teams/builtin/skills/relay-knowledge/scripts/relay_knowledge_cli.py tests/unit_tests/builtin/test_relay_knowledge_skill.py`
- `uv run pyright src/relay_teams/builtin/skills/relay-knowledge/scripts/relay_knowledge_cli.py tests/unit_tests/builtin/test_relay_knowledge_skill.py`

Closes #859