### PR TITLE
Separate user-facing run errors from recovery prompts

### DIFF
--- a/src/relay_teams/sessions/runs/assistant_errors.py
+++ b/src/relay_teams/sessions/runs/assistant_errors.py
@@ -32,6 +32,15 @@ class AssistantRunError(RuntimeError):
         super().__init__(payload.error_message or payload.assistant_message)
 
 
+class RunErrorPresentation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    error_code: str = ""
+    user_message: str
+    recovery_prompt: str | None = None
+    diagnostic_message: str = ""
+
+
 INVALID_TOOL_ARGS_RECOVERY_MESSAGE = (
     "The previous tool call arguments were not valid JSON. "
     "Do not repeat already successful tool calls. "
@@ -63,51 +72,90 @@ def _append_error_detail(message: str, detail: str) -> str:
     return f"{message} Details: {normalized_detail}"
 
 
-def _append_error_detail_block(message: str, detail: str) -> str:
-    normalized_detail = detail.strip()
-    if not normalized_detail:
-        return message
-    return f"{message}\n\nDetails:\n```text\n{normalized_detail}\n```"
-
-
-def _build_recovery_guidance_message(
+def _build_user_error_message(
     error_code: str,
     *,
     detail: str = "",
-) -> str | None:
+) -> str:
     if error_code == "model_tool_args_invalid_json":
-        return INVALID_TOOL_ARGS_RECOVERY_MESSAGE
+        return (
+            "The model returned invalid tool call arguments. "
+            "The run can continue after the arguments are corrected."
+        )
     if error_code == "network_stream_interrupted":
-        return _append_error_detail(
+        return (
             "The model response stream was interrupted by a temporary network or transport failure. "
-            "Retry to continue from the latest saved conversation state.",
-            detail,
+            "Retry the run to continue."
         )
     if error_code == "network_timeout":
-        return _append_error_detail(
-            "The request reached the model endpoint path but timed out while waiting for the provider to respond. "
-            "Check whether the provider is responding slowly, then review connect_timeout_seconds, proxy settings, and the configured base_url. "
-            "If this keeps happening, retry with a longer timeout or inspect upstream latency.",
-            detail,
+        return (
+            "The model request timed out while waiting for the provider to respond. "
+            "Check provider latency, proxy settings, base_url, or increase the configured timeout."
         )
     if error_code == "network_error":
-        return _append_error_detail(
-            "The request failed before a usable response was received from the model endpoint. "
-            "Check DNS resolution, outbound network connectivity, proxy or NO_PROXY settings, and whether the configured base_url is reachable at all.",
-            detail,
+        return (
+            "The model request failed before a usable response was received. "
+            "Check DNS, outbound network connectivity, proxy or NO_PROXY settings, and base_url."
         )
     if error_code == "proxy_blocked":
-        return _append_error_detail_block(
+        return (
             "The model request reached an enterprise proxy block page instead of the model endpoint. "
-            "Check the configured base_url, HTTP_PROXY/HTTPS_PROXY routing, proxy credentials, and NO_PROXY entries for the model host.",
-            detail,
+            "Check base_url, proxy routing, proxy credentials, and NO_PROXY entries for the model host."
         )
     if error_code == "auth_invalid":
         return (
-            "The previous request could not continue because the API key is invalid. "
-            "The conversation state already persisted is still valid."
+            "The model provider rejected the request because the API key is invalid. "
+            "Check the current model profile credentials and try again."
         )
-    return None
+    if error_code == "verification_failed":
+        return _append_error_detail(
+            "The task verification did not pass. "
+            "Review the task spec and evidence expectations, then continue with corrected output.",
+            detail,
+        )
+    if error_code == "incomplete_todos":
+        return (
+            "The request could not be marked complete because run-scoped todos "
+            "are still incomplete. Reconcile the todo list with actual progress "
+            "before finalizing."
+        )
+    lowered = detail.lower()
+    if "prompt is too long" in lowered:
+        return (
+            "The model request prompt is too long. Reduce the input or context size, "
+            "then try again."
+        )
+    if "credit balance is too low" in lowered:
+        return (
+            "The model provider rejected the request because the API credit balance is too low. "
+            "Add credit or switch to another configured model profile."
+        )
+    if "x-api-key" in lowered or "api key" in lowered:
+        return (
+            "The model provider rejected the request because the API key is invalid. "
+            "Check the current model profile credentials and try again."
+        )
+    if detail:
+        return (
+            "The request could not be completed because of an API or execution error. "
+            f"Details: {detail}"
+        )
+    return "The request could not be completed because of an API or execution error."
+
+
+def build_error_presentation(
+    *,
+    error_code: str | None,
+    error_message: str | None,
+) -> RunErrorPresentation:
+    code = str(error_code or "").strip().lower()
+    detail = str(error_message or "").strip()
+    return RunErrorPresentation(
+        error_code=code,
+        user_message=_build_user_error_message(code, detail=detail),
+        recovery_prompt=build_auto_recovery_prompt(code),
+        diagnostic_message=detail,
+    )
 
 
 def build_assistant_error_message(
@@ -115,55 +163,10 @@ def build_assistant_error_message(
     error_code: str | None,
     error_message: str | None,
 ) -> str:
-    code = str(error_code or "").strip().lower()
-    detail = str(error_message or "").strip()
-
-    recovery_guidance = _build_recovery_guidance_message(code, detail=detail)
-    if recovery_guidance is not None:
-        return recovery_guidance
-    if code == "verification_failed":
-        return _append_error_detail(
-            "The task verification did not pass. "
-            "Review the task spec and evidence expectations, then continue with corrected output.",
-            detail,
-        )
-    if code == "incomplete_todos":
-        return _append_error_detail(
-            "The previous request could not be marked complete because "
-            "run-scoped todos are still incomplete. Continue from the latest "
-            "successful conversation state already persisted. Do not repeat "
-            "already successful tool calls. Reconcile the persisted todo list "
-            "with actual progress before finalizing.",
-            detail,
-        )
-    lowered = detail.lower()
-    if "prompt is too long" in lowered:
-        return (
-            "The previous request could not continue because the prompt is too long. "
-            "Continue from the latest persisted conversation state and keep the next response focused."
-        )
-    if "credit balance is too low" in lowered:
-        return (
-            "The previous request could not continue because the API credit balance is too low. "
-            "The conversation state already persisted is still valid."
-        )
-    if "x-api-key" in lowered or "api key" in lowered:
-        return (
-            "The previous request could not continue because the API key is invalid. "
-            "The conversation state already persisted is still valid."
-        )
-    if detail:
-        return (
-            "The previous request could not be completed because of an API or execution error. "
-            "Continue from the latest successful conversation state already persisted. "
-            "Do not repeat already successful tool calls. "
-            f"Details: {detail}"
-        )
-    return (
-        "The previous request could not be completed because of an API or execution error. "
-        "Continue from the latest successful conversation state already persisted. "
-        "Do not repeat already successful tool calls."
-    )
+    return build_error_presentation(
+        error_code=error_code,
+        error_message=error_message,
+    ).user_message
 
 
 def build_tool_error_result(

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -4681,7 +4681,11 @@ async def test_generate_does_not_retry_after_streamed_text_side_effect_for_non_t
     final_message = history[-1]
     assert isinstance(final_message, ModelResponse)
     assert isinstance(final_message.parts[0], TextPart)
-    assert "Continue from the latest successful conversation state" in (
+    assert "API or execution error" in final_message.parts[0].content
+    assert "Continue from the latest successful conversation state" not in (
+        final_message.parts[0].content
+    )
+    assert "Do not repeat already successful tool calls" not in (
         final_message.parts[0].content
     )
 
@@ -5164,7 +5168,10 @@ async def test_generate_pauses_on_invalid_tool_args_json_after_committed_tool_ev
     final_message = history[-1]
     assert isinstance(final_message, ModelResponse)
     assert isinstance(final_message.parts[0], TextPart)
-    assert "not valid JSON" in final_message.parts[0].content
+    assert "invalid tool call arguments" in final_message.parts[0].content
+    assert "Do not repeat already successful tool calls" not in (
+        final_message.parts[0].content
+    )
 
 
 @pytest.mark.asyncio
@@ -5654,6 +5661,10 @@ async def test_generate_publishes_retry_exhausted_event_on_final_failure(
     final_message = history[-1]
     assert isinstance(final_message, ModelResponse)
     assert isinstance(final_message.parts[0], TextPart)
-    assert "Continue from the latest successful conversation state" in (
+    assert "API or execution error" in final_message.parts[0].content
+    assert "Continue from the latest successful conversation state" not in (
+        final_message.parts[0].content
+    )
+    assert "Do not repeat already successful tool calls" not in (
         final_message.parts[0].content
     )

--- a/tests/unit_tests/sessions/runs/test_assistant_errors.py
+++ b/tests/unit_tests/sessions/runs/test_assistant_errors.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import pytest
+
 from relay_teams.sessions.runs.assistant_errors import (
     INVALID_TOOL_ARGS_RECOVERY_MESSAGE,
     NETWORK_EXCEPTION_RECOVERY_MESSAGE,
     build_assistant_error_message,
     build_auto_recovery_prompt,
+    build_error_presentation,
 )
 
 
@@ -13,13 +16,13 @@ def test_build_auto_recovery_prompt_reuses_invalid_tool_args_guidance() -> None:
         build_auto_recovery_prompt("model_tool_args_invalid_json")
         == INVALID_TOOL_ARGS_RECOVERY_MESSAGE
     )
-    assert (
-        build_assistant_error_message(
-            error_code="model_tool_args_invalid_json",
-            error_message=None,
-        )
-        == INVALID_TOOL_ARGS_RECOVERY_MESSAGE
+    message = build_assistant_error_message(
+        error_code="model_tool_args_invalid_json",
+        error_message=None,
     )
+
+    assert "invalid tool call arguments" in message
+    assert "Do not repeat already successful tool calls" not in message
 
 
 def test_build_auto_recovery_prompt_reuses_network_stream_guidance() -> None:
@@ -52,18 +55,17 @@ def test_build_assistant_error_message_uses_specific_network_messages() -> None:
     )
 
     assert "response stream was interrupted" in stream_message
-    assert (
-        "Retry to continue from the latest saved conversation state" in stream_message
-    )
-    assert "incomplete chunked read" in stream_message
+    assert "Retry the run to continue" in stream_message
+    assert "latest saved conversation state" not in stream_message
+    assert "incomplete chunked read" not in stream_message
 
     assert "timed out while waiting for the provider to respond" in timeout_message
-    assert "responding slowly" in timeout_message
-    assert "request timed out" in timeout_message
+    assert "increase the configured timeout" in timeout_message
+    assert "Details:" not in timeout_message
 
     assert "before a usable response was received" in network_message
-    assert "DNS resolution" in network_message
-    assert "connection refused" in network_message
+    assert "DNS" in network_message
+    assert "connection refused" not in network_message
 
 
 def test_build_assistant_error_message_uses_auth_invalid_code() -> None:
@@ -73,6 +75,8 @@ def test_build_assistant_error_message_uses_auth_invalid_code() -> None:
     )
 
     assert "API key is invalid" in message
+    assert "conversation state" not in message
+    assert "persisted" not in message
 
 
 def test_build_assistant_error_message_includes_full_proxy_block_detail() -> None:
@@ -89,8 +93,8 @@ def test_build_assistant_error_message_includes_full_proxy_block_detail() -> Non
     )
 
     assert "enterprise proxy block page" in message
-    assert "```text" in message
-    assert detail in message
+    assert "```text" not in message
+    assert detail not in message
 
 
 def test_build_assistant_error_message_uses_incomplete_todos_guidance() -> None:
@@ -101,8 +105,9 @@ def test_build_assistant_error_message_uses_incomplete_todos_guidance() -> None:
 
     assert "could not be marked complete" in message
     assert "run-scoped todos are still incomplete" in message
-    assert "Reconcile the persisted todo list" in message
-    assert "Do not repeat already successful tool calls" in message
+    assert "Reconcile the todo list" in message
+    assert "Do not repeat already successful tool calls" not in message
+    assert "persisted" not in message
     assert "API or execution error" not in message
 
 
@@ -127,3 +132,107 @@ def test_build_assistant_error_message_verification_failed_without_detail() -> N
     assert "verification did not pass" in message
     assert "Review the task spec and evidence expectations" in message
     assert "API or execution error" not in message
+
+
+def test_build_error_presentation_separates_user_recovery_and_diagnostics() -> None:
+    presentation = build_error_presentation(
+        error_code="network_timeout",
+        error_message="provider request timed out after 30 seconds",
+    )
+
+    assert presentation.error_code == "network_timeout"
+    assert "timed out while waiting for the provider" in presentation.user_message
+    assert "conversation state already persisted" not in presentation.user_message
+    assert presentation.recovery_prompt == NETWORK_EXCEPTION_RECOVERY_MESSAGE
+    assert (
+        presentation.diagnostic_message == "provider request timed out after 30 seconds"
+    )
+
+
+def test_build_error_presentation_keeps_auth_error_user_facing_only() -> None:
+    presentation = build_error_presentation(
+        error_code="auth_invalid",
+        error_message="provider rejected request status_code: 401",
+    )
+
+    assert "API key is invalid" in presentation.user_message
+    assert "conversation state" not in presentation.user_message
+    assert presentation.recovery_prompt is None
+    assert (
+        presentation.diagnostic_message == "provider rejected request status_code: 401"
+    )
+
+
+@pytest.mark.parametrize(
+    ("error_code", "error_message", "expected_fragment"),
+    [
+        (
+            "task_timeout",
+            "Task timed out after 120s",
+            "API or execution error",
+        ),
+        (
+            "internal_execution_error",
+            "worker crashed",
+            "API or execution error",
+        ),
+        (
+            "orchestration_cycles_exhausted",
+            "2 delegated task(s) are still pending.",
+            "API or execution error",
+        ),
+        (
+            "delegated_task_execution_disabled",
+            "Delegated task execution is disabled by policy.",
+            "API or execution error",
+        ),
+        (
+            "run_start_failed",
+            "startup failed",
+            "API or execution error",
+        ),
+        (
+            "run_worker_failed",
+            "worker failed",
+            "API or execution error",
+        ),
+        (
+            "",
+            "prompt is too long for this model",
+            "prompt is too long",
+        ),
+        (
+            "",
+            "credit balance is too low",
+            "credit balance is too low",
+        ),
+        (
+            "",
+            "x-api-key header is invalid",
+            "API key is invalid",
+        ),
+        (
+            "",
+            "",
+            "API or execution error",
+        ),
+    ],
+)
+def test_build_error_presentation_keeps_known_terminal_errors_user_facing(
+    error_code: str,
+    error_message: str,
+    expected_fragment: str,
+) -> None:
+    presentation = build_error_presentation(
+        error_code=error_code,
+        error_message=error_message,
+    )
+
+    assert expected_fragment in presentation.user_message
+    assert "conversation state" not in presentation.user_message
+    assert "persisted" not in presentation.user_message
+    assert (
+        "Do not repeat already successful tool calls" not in presentation.user_message
+    )
+    assert presentation.recovery_prompt is None
+    assert presentation.diagnostic_message == error_message


### PR DESCRIPTION
将运行失败信息拆分为用户可见文案、模型恢复提示和诊断详情，避免把内部恢复指令暴露给用户

  - 新增结构化 RunErrorPresentation，拆分 user_message、recovery_prompt、diagnostic_message
  - 保留 auto-recovery prompt 给恢复流程使用
  - 防止终态 assistant/user-visible 错误消息暴露 “continue from persisted state / do not repeat tool calls” 这类模型恢复提示
  - 补充 provider、run error、terminal error 场景测试

## Summary
- add structured run error presentation with user-facing, recovery, and diagnostic fields
- keep recovery prompts available for auto-recovery while preventing them from being emitted as terminal assistant/user-visible errors
- update provider and run error tests to assert recovery guidance is not exposed in user-visible failure messages

## Issue
Closes #864

## Validation
- pre-commit: ruff-check, ruff-format, basedpyright-check
- uv run --extra dev ruff check src/relay_teams/sessions/runs/assistant_errors.py tests/unit_tests/sessions/runs/test_assistant_errors.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py
- uv run --extra dev basedpyright
- targeted pytest coverage across assistant errors, provider retry/error handling, run recovery, task execution, background tasks, and terminal status flows