### PR TITLE
Fix foreground server Ctrl+C shutdown

### DIFF
--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -1256,6 +1256,7 @@ class ServerContainer:
             self.run_intent_repo,
             self.background_task_repository,
             self.todo_repository,
+            self.board_todo_repository,
             self.run_state_repo,
             self.trigger_repository,
             self.session_repo,

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -14,6 +14,7 @@ from relay_teams.env.environment_variable_models import (
     EnvironmentVariableScope,
 )
 from relay_teams.interfaces.server.container import ServerContainer
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.plugins.config_manager import PluginConfigManager
 from relay_teams.roles import RoleLoader
 from relay_teams.skills.discovery import SkillsDirectory
@@ -423,6 +424,25 @@ def test_container_registers_discord_repositories_for_shutdown_close(
 
     assert container.discord_account_repository in container._async_closeables
     assert container.discord_inbound_queue_repo in container._async_closeables
+
+
+def test_container_registers_all_shared_sqlite_repositories_for_shutdown_close(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = ServerContainer(config_dir=config_dir)
+
+    closeables = set(container._async_closeables)
+    missing = [
+        name
+        for name, value in vars(container).items()
+        if isinstance(value, SharedSqliteRepository) and value not in closeables
+    ]
+
+    assert missing == []
 
 
 def test_roles_reload_updates_long_lived_role_registry_references(


### PR DESCRIPTION
## Summary
- close the BoardTodoRepository during server shutdown so its aiosqlite worker thread cannot keep the foreground server process alive after Ctrl+C
- add a container regression test that every ServerContainer-owned SharedSqliteRepository is registered for async shutdown close

## Validation
- uv run --extra dev ruff check --fix src/relay_teams/interfaces/server/container.py tests/unit_tests/interfaces/server/test_container.py
- uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/interfaces/server/container.py tests/unit_tests/interfaces/server/test_container.py
- uv run --extra dev pytest -q tests/unit_tests/interfaces/server/test_container.py
- uv run --extra dev pytest -q tests/unit_tests/boards/test_todo_service.py
- manual foreground server Ctrl+C verification on Windows with a temporary RELAY_TEAMS_CONFIG_DIR

Fixes #870