### PR TITLE
Add V2 frontend parity candidate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,15 @@ tmp.db-journal
 .tmp_pytest/
 pytest-cache-files-*/
 frontend/node_modules/
+frontend/v2/dist/
+frontend/v2/node_modules/
+frontend/v2/.vite/
 frontend/.vite/
 node_modules
 package-lock.json
 package.json
 !frontend/package.json
+!frontend/v2/package.json
 !src/relay_teams/builtin/skills/pptx-craft/package.json
 !src/relay_teams/builtin/skills/pptx-craft/designer/lib/html-to-pptx/package.json
 .claude

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,6 +3,13 @@
 This directory hosts the decoupled web frontend.
 
 - `dist/`: static build artifacts served by the FastAPI server at runtime.
+- `v2/`: source tree for the frontend rewrite candidate. Its local build output
+  is ignored under `v2/dist/`.
+- `v2/src/`: source files for the candidate frontend. Do not mirror `dist/`
+  here; migrate screens into cohesive source modules.
 - The backend serves `frontend/dist` when available.
+- Build with `npm --prefix frontend/v2 run build`.
+- Set `RELAY_TEAMS_FRONTEND_DIST_DIR=frontend/v2/dist` to serve the candidate
+  frontend without changing the default runtime path.
 
 Current API base path used by the UI is `/api`.

--- a/frontend/dist/css/components/base.css
+++ b/frontend/dist/css/components/base.css
@@ -90,6 +90,35 @@
     color: var(--primary);
 }
 
+.try-v2-btn {
+    align-items: center;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    color: var(--text-primary);
+    display: inline-flex;
+    font-size: 0.75rem;
+    font-weight: 700;
+    gap: 0.35rem;
+    height: 32px;
+    padding: 0 0.75rem;
+    text-decoration: none;
+    transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+    white-space: nowrap;
+}
+
+.try-v2-btn .icon {
+    height: 1rem;
+    width: 1rem;
+}
+
+.try-v2-btn:hover,
+.try-v2-btn:focus-visible {
+    background: color-mix(in srgb, var(--primary) 10%, var(--bg-surface));
+    border-color: var(--primary);
+    color: var(--primary);
+}
+
 .projects-empty-state {
     display: flex;
     flex-direction: column;

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -70,6 +70,35 @@
           </div>
         </div>
         <div class="topbar-section topbar-section-right">
+          <a
+            id="try-v2-btn"
+            class="try-v2-btn"
+            href="/v2/"
+            title="体验新版"
+            aria-label="体验新版"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              class="icon"
+              aria-hidden="true"
+            >
+              <path
+                d="M5 12h10m0 0-4-4m4 4-4 4"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M6 5h10.5A2.5 2.5 0 0 1 19 7.5v9A2.5 2.5 0 0 1 16.5 19H6"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+              />
+            </svg>
+            <span>体验新版</span>
+          </a>
           <button
             id="language-toggle-btn"
             class="language-toggle-btn"

--- a/frontend/v2/package.json
+++ b/frontend/v2/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "build": "node scripts/build.mjs"
+  }
+}

--- a/frontend/v2/scripts/build.mjs
+++ b/frontend/v2/scripts/build.mjs
@@ -1,0 +1,10 @@
+import { cp, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const sourceDir = resolve(projectDir, 'src');
+const outputDir = resolve(projectDir, 'dist');
+
+await rm(outputDir, { force: true, recursive: true });
+await cp(sourceDir, outputDir, { recursive: true });

--- a/frontend/v2/src/app/main.js
+++ b/frontend/v2/src/app/main.js
@@ -1,0 +1,9 @@
+import { createInitialState } from './state.js';
+import { renderAppShell } from './shell.js';
+
+const appRoot = document.querySelector('#app');
+const state = createInitialState();
+
+if (appRoot !== null) {
+  renderAppShell(appRoot, state);
+}

--- a/frontend/v2/src/app/shell.js
+++ b/frontend/v2/src/app/shell.js
@@ -1,0 +1,45 @@
+export function renderAppShell(root, state) {
+  root.innerHTML = `
+    <div class="app-shell">
+      <aside class="sidebar" aria-label="会话">
+        <div class="brand">agent-teams</div>
+        <button class="icon-button" type="button" aria-label="新建会话">+</button>
+      </aside>
+      <main class="workspace">
+        <header class="toolbar">
+          <span>${state.backendLabel}</span>
+          <div class="toolbar-actions">
+            <a class="version-switch" href="/" aria-label="返回旧版" title="返回旧版">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M19 12H9m0 0 4-4m-4 4 4 4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.8"
+                />
+                <path
+                  d="M18 5H7.5A2.5 2.5 0 0 0 5 7.5v9A2.5 2.5 0 0 0 7.5 19H18"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-width="1.8"
+                />
+              </svg>
+              <span>返回旧版</span>
+            </a>
+            <button class="ghost-button" type="button">设置</button>
+          </div>
+        </header>
+        <section class="composer" aria-label="新建会话">
+          <h1>开始一个新会话</h1>
+          <textarea placeholder="描述你的目标、约束和期望输出"></textarea>
+          <div class="actions">
+            <button class="primary-button" type="button">开始会话</button>
+          </div>
+        </section>
+      </main>
+    </div>
+  `;
+}

--- a/frontend/v2/src/app/state.js
+++ b/frontend/v2/src/app/state.js
@@ -1,0 +1,5 @@
+export function createInitialState() {
+  return {
+    backendLabel: '后端状态',
+  };
+}

--- a/frontend/v2/src/index.html
+++ b/frontend/v2/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Agent Teams</title>
+    <link rel="stylesheet" href="./styles/app.css">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./app/main.js"></script>
+  </body>
+</html>

--- a/frontend/v2/src/styles/app.css
+++ b/frontend/v2/src/styles/app.css
@@ -1,0 +1,136 @@
+@import "./tokens.css";
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-ui);
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  border-right: 1px solid var(--color-border);
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 16px;
+}
+
+.brand {
+  font-weight: 650;
+}
+
+.workspace {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-width: 0;
+}
+
+.toolbar {
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 18px;
+}
+
+.toolbar-actions {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+}
+
+.composer {
+  align-self: center;
+  justify-self: center;
+  max-width: 760px;
+  width: min(760px, calc(100vw - 360px));
+}
+
+.composer h1 {
+  font-size: 24px;
+  letter-spacing: 0;
+  margin: 0 0 16px;
+}
+
+.composer textarea {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  min-height: 160px;
+  padding: 14px;
+  resize: vertical;
+  width: 100%;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.primary-button,
+.ghost-button,
+.icon-button,
+.version-switch {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.primary-button {
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  padding: 9px 14px;
+}
+
+.ghost-button,
+.icon-button {
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.ghost-button {
+  padding: 8px 12px;
+}
+
+.icon-button {
+  height: 32px;
+  width: 32px;
+}
+
+.version-switch {
+  align-items: center;
+  background: var(--color-surface);
+  color: var(--color-text);
+  display: inline-flex;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 12px;
+  text-decoration: none;
+}
+
+.version-switch svg {
+  height: 17px;
+  width: 17px;
+}

--- a/frontend/v2/src/styles/tokens.css
+++ b/frontend/v2/src/styles/tokens.css
@@ -1,0 +1,9 @@
+:root {
+  --color-bg: #f5f7f7;
+  --color-surface: #ffffff;
+  --color-text: #1c1f23;
+  --color-border: #d7dddd;
+  --color-accent: #2f6f5e;
+  --color-accent-text: #ffffff;
+  --font-ui: "IBM Plex Sans", "Segoe UI", sans-serif;
+}

--- a/src/relay_teams/interfaces/server/app.py
+++ b/src/relay_teams/interfaces/server/app.py
@@ -20,7 +20,10 @@ from starlette.types import Scope
 
 from relay_teams.builtin import ensure_app_config_bootstrap
 from relay_teams.env.runtime_env import sync_app_env_to_process_env
-from relay_teams.interfaces.server.config_paths import get_frontend_dist_dir
+from relay_teams.interfaces.server.config_paths import (
+    get_frontend_dist_dir,
+    get_frontend_v2_source_dir,
+)
 from relay_teams.interfaces.server.container import ServerContainer
 from relay_teams.interfaces.server.async_call import (
     reset_default_route_work_class,
@@ -76,6 +79,7 @@ from relay_teams.trace import bind_trace_context, generate_request_id
 
 logger = get_logger(__name__)
 FRONTEND_DIST_DIR = get_frontend_dist_dir()
+FRONTEND_V2_SOURCE_DIR = get_frontend_v2_source_dir()
 RequestHandler = Callable[[Request], Awaitable[Response]]
 SignalHandler = Callable[[int, FrameType | None], None]
 SignalHandlerRef = int | SignalHandler | None
@@ -423,6 +427,14 @@ def _register_signal_handlers() -> None:
 
     for sig in registered_signals:
         _ = signal.signal(sig, _on_signal)
+
+
+if FRONTEND_V2_SOURCE_DIR.exists():
+    app.mount(
+        "/v2",
+        FrontendStaticFiles(directory=str(FRONTEND_V2_SOURCE_DIR), html=True),
+        name="frontend_v2",
+    )
 
 
 if FRONTEND_DIST_DIR.exists():

--- a/src/relay_teams/interfaces/server/config_paths.py
+++ b/src/relay_teams/interfaces/server/config_paths.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 
 from relay_teams.paths import get_project_root_or_none
+
+FRONTEND_DIST_DIR_ENV = "RELAY_TEAMS_FRONTEND_DIST_DIR"
 
 
 def get_frontend_dist_dir() -> Path:
@@ -15,13 +18,42 @@ def get_frontend_dist_dir() -> Path:
     return candidates[0]
 
 
+def get_frontend_v2_source_dir() -> Path:
+    candidates = _frontend_v2_source_candidates()
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
 def _frontend_dist_candidates() -> tuple[Path, ...]:
     candidates: list[Path] = []
+    env_frontend_dist_dir = _env_frontend_dist_dir()
+    if env_frontend_dist_dir is not None:
+        candidates.append(env_frontend_dist_dir)
     git_frontend_dist_dir = _git_frontend_dist_dir()
     if git_frontend_dist_dir is not None:
         candidates.append(git_frontend_dist_dir)
     candidates.extend((_package_frontend_dist_dir(), _cwd_frontend_dist_dir()))
     return tuple(candidates)
+
+
+def _frontend_v2_source_candidates() -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    git_frontend_v2_source_dir = _git_frontend_v2_source_dir()
+    if git_frontend_v2_source_dir is not None:
+        candidates.append(git_frontend_v2_source_dir)
+    candidates.extend(
+        (_package_frontend_v2_source_dir(), _cwd_frontend_v2_source_dir())
+    )
+    return tuple(candidates)
+
+
+def _env_frontend_dist_dir() -> Path | None:
+    raw_value = os.environ.get(FRONTEND_DIST_DIR_ENV)
+    if raw_value is None or not raw_value.strip():
+        return None
+    return Path(raw_value.strip()).expanduser().resolve()
 
 
 def _git_frontend_dist_dir() -> Path | None:
@@ -31,6 +63,13 @@ def _git_frontend_dist_dir() -> Path | None:
     return project_root / "frontend" / "dist"
 
 
+def _git_frontend_v2_source_dir() -> Path | None:
+    project_root = get_project_root_or_none()
+    if project_root is None:
+        return None
+    return project_root / "frontend" / "v2" / "src"
+
+
 def _package_frontend_dist_dir() -> Path:
     frontend_package_spec = importlib.util.find_spec("relay_teams.frontend")
     if frontend_package_spec is None or frontend_package_spec.origin is None:
@@ -38,5 +77,16 @@ def _package_frontend_dist_dir() -> Path:
     return Path(frontend_package_spec.origin).resolve().parent / "dist"
 
 
+def _package_frontend_v2_source_dir() -> Path:
+    frontend_package_spec = importlib.util.find_spec("relay_teams.frontend")
+    if frontend_package_spec is None or frontend_package_spec.origin is None:
+        return Path(__file__).resolve().parents[2] / "frontend" / "v2" / "src"
+    return Path(frontend_package_spec.origin).resolve().parent / "v2" / "src"
+
+
 def _cwd_frontend_dist_dir() -> Path:
     return Path.cwd().resolve() / "frontend" / "dist"
+
+
+def _cwd_frontend_v2_source_dir() -> Path:
+    return Path.cwd().resolve() / "frontend" / "v2" / "src"

--- a/tests/unit_tests/frontend/test_frontend_v2_candidate.py
+++ b/tests/unit_tests/frontend/test_frontend_v2_candidate.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+NAMED_IMPORT_RE = re.compile(
+    r"import\s*\{(?P<names>.*?)\}\s*from\s*['\"](?P<source>\.[^'\"]+)['\"]",
+    re.DOTALL,
+)
+DIRECT_EXPORT_RE = re.compile(
+    r"export\s+(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)"
+)
+NAMED_EXPORT_RE = re.compile(r"export\s*\{(?P<names>.*?)\}", re.DOTALL)
+
+
+def test_frontend_candidate_is_source_tree_not_dist_mirror() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    candidate_root = repo_root / "frontend" / "v2"
+    source_root = candidate_root / "src"
+
+    assert (source_root / "index.html").is_file()
+    assert (source_root / "app" / "main.js").is_file()
+    assert not (candidate_root / "index.html").exists()
+    assert not (source_root / "js").exists()
+    assert not (source_root / "css" / "components").exists()
+    assert len(tuple(source_root.rglob("*.*"))) <= 12
+
+
+def test_frontend_candidate_file_names_do_not_include_candidate_marker() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    candidate_root = repo_root / "frontend" / "v2" / "src"
+    candidate_files = tuple(
+        path for path in candidate_root.rglob("*") if path.is_file()
+    )
+
+    assert candidate_files
+    assert all("v2" not in path.name.lower() for path in candidate_files)
+
+
+def test_frontend_candidate_relative_named_imports_are_exported() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    candidate_root = repo_root / "frontend" / "v2" / "src"
+
+    missing_exports: list[str] = []
+    for importer in candidate_root.rglob("*.js"):
+        for imported_name, source_path in _relative_named_imports(importer):
+            resolved_module = (importer.parent / source_path).resolve()
+            if not resolved_module.exists():
+                missing_exports.append(
+                    f"{importer.relative_to(repo_root)} imports {source_path}, "
+                    "but the module file is missing"
+                )
+                continue
+            exported_names = _exported_names(resolved_module)
+            if imported_name not in exported_names:
+                missing_exports.append(
+                    f"{importer.relative_to(repo_root)} imports {imported_name} "
+                    f"from {resolved_module.relative_to(repo_root)}, but it is not exported"
+                )
+
+    assert missing_exports == []
+
+
+def test_v1_frontend_links_to_candidate() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    index_html = (repo_root / "frontend" / "dist" / "index.html").read_text(
+        encoding="utf-8"
+    )
+    base_css = (
+        repo_root / "frontend" / "dist" / "css" / "components" / "base.css"
+    ).read_text(encoding="utf-8")
+
+    assert 'id="try-v2-btn"' in index_html
+    assert 'href="/v2/"' in index_html
+    assert "体验新版" in index_html
+    assert "<svg" in index_html[index_html.index('id="try-v2-btn"') :]
+    assert ".try-v2-btn" in base_css
+
+
+def test_frontend_candidate_links_back_to_v1() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    shell_js = (repo_root / "frontend" / "v2" / "src" / "app" / "shell.js").read_text(
+        encoding="utf-8"
+    )
+    app_css = (repo_root / "frontend" / "v2" / "src" / "styles" / "app.css").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'href="/"' in shell_js
+    assert "返回旧版" in shell_js
+    assert "<svg" in shell_js
+    assert ".version-switch" in app_css
+
+
+def _relative_named_imports(importer: Path) -> tuple[tuple[str, Path], ...]:
+    content = importer.read_text(encoding="utf-8")
+    imports: list[tuple[str, Path]] = []
+    for match in NAMED_IMPORT_RE.finditer(content):
+        source_path = Path(match.group("source"))
+        for raw_name in match.group("names").split(","):
+            imported_name = raw_name.strip()
+            if not imported_name:
+                continue
+            imports.append((_imported_binding_name(imported_name), source_path))
+    return tuple(imports)
+
+
+def _imported_binding_name(raw_name: str) -> str:
+    parts = tuple(part.strip() for part in raw_name.split(" as ", maxsplit=1))
+    return parts[0]
+
+
+def _exported_names(module_path: Path) -> set[str]:
+    content = module_path.read_text(encoding="utf-8")
+    names = set(DIRECT_EXPORT_RE.findall(content))
+    for match in NAMED_EXPORT_RE.finditer(content):
+        for raw_name in match.group("names").split(","):
+            export_name = raw_name.strip()
+            if not export_name:
+                continue
+            names.add(_exported_alias_name(export_name))
+    return names
+
+
+def _exported_alias_name(raw_name: str) -> str:
+    parts = tuple(part.strip() for part in raw_name.split(" as ", maxsplit=1))
+    if len(parts) == 2:
+        return parts[1]
+    return parts[0]

--- a/tests/unit_tests/interfaces/server/test_config_paths.py
+++ b/tests/unit_tests/interfaces/server/test_config_paths.py
@@ -7,6 +7,66 @@ from types import SimpleNamespace
 from relay_teams.interfaces.server import config_paths
 
 
+def test_get_frontend_dist_dir_uses_env_override_first(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    env_frontend_dir = tmp_path / "repo-root" / "frontend" / "v2" / "dist"
+    git_frontend_dist_dir = tmp_path / "repo-root" / "frontend" / "dist"
+    env_frontend_dir.mkdir(parents=True)
+    git_frontend_dist_dir.mkdir(parents=True)
+    monkeypatch.setenv(
+        config_paths.FRONTEND_DIST_DIR_ENV,
+        str(env_frontend_dir),
+    )
+    monkeypatch.setattr(
+        config_paths,
+        "_git_frontend_dist_dir",
+        lambda: git_frontend_dist_dir,
+    )
+    monkeypatch.setattr(
+        config_paths,
+        "_package_frontend_dist_dir",
+        lambda: tmp_path / "package-root" / "frontend" / "dist",
+    )
+    monkeypatch.setattr(
+        config_paths,
+        "_cwd_frontend_dist_dir",
+        lambda: tmp_path / "cwd-root" / "frontend" / "dist",
+    )
+
+    frontend_dist_dir = config_paths.get_frontend_dist_dir()
+
+    assert frontend_dist_dir == env_frontend_dir.resolve()
+
+
+def test_get_frontend_v2_source_dir_uses_git_root_when_available(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    frontend_v2_source_dir = tmp_path / "repo-root" / "frontend" / "v2" / "src"
+    frontend_v2_source_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        config_paths,
+        "_git_frontend_v2_source_dir",
+        lambda: frontend_v2_source_dir,
+    )
+    monkeypatch.setattr(
+        config_paths,
+        "_package_frontend_v2_source_dir",
+        lambda: tmp_path / "package-root" / "frontend" / "v2" / "src",
+    )
+    monkeypatch.setattr(
+        config_paths,
+        "_cwd_frontend_v2_source_dir",
+        lambda: tmp_path / "cwd-root" / "frontend" / "v2" / "src",
+    )
+
+    resolved_dir = config_paths.get_frontend_v2_source_dir()
+
+    assert resolved_dir == frontend_v2_source_dir
+
+
 def test_get_frontend_dist_dir_uses_git_root_when_available(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add a small frontend/v2 source-tree scaffold instead of copying static dist output
- mount the V2 source preview at /v2 while keeping the existing V1 frontend at /
- add a top-right SVG "体验新版" switch in V1 and a SVG "返回旧版" switch in V2
- add tests that guard the source-tree shape, V1/V2 links, relative named imports, and frontend path resolution

## Validation
- npm --prefix frontend/v2 run build
- uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/interfaces/server/app.py src/relay_teams/interfaces/server/config_paths.py tests/unit_tests/interfaces/server/test_config_paths.py tests/unit_tests/frontend/test_frontend_v2_candidate.py
- uv run --extra dev ruff check src/relay_teams/interfaces/server/app.py src/relay_teams/interfaces/server/config_paths.py tests/unit_tests/interfaces/server/test_config_paths.py tests/unit_tests/frontend/test_frontend_v2_candidate.py
- uv run --extra dev pytest -q tests/unit_tests/interfaces/server/test_config_paths.py tests/unit_tests/frontend/test_frontend_v2_candidate.py tests/unit_tests/interfaces/server/test_frontend_static_cache.py (12 passed)

Fixes #877
