### PR TITLE
Fix settings modal outside click behavior

### DIFF
--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -64,7 +64,6 @@ import { errorToPayload, logError, sysLog } from '../../utils/logger.js';
 let settingsModal = null;
 let currentTab = 'appearance';
 let initialized = false;
-let overlayPointerDown = false;
 let actionOwnershipObserver = null;
 let panelLoadRequestId = 0;
 let settingsWarmupPromise = null;
@@ -1055,18 +1054,6 @@ function setupEventListeners() {
         closeBtn.onclick = closeSettings;
     }
 
-    settingsModal.onmousedown = (e) => {
-        overlayPointerDown = e.target === settingsModal;
-    };
-
-    settingsModal.onclick = (e) => {
-        const shouldClose = overlayPointerDown && e.target === settingsModal;
-        overlayPointerDown = false;
-        if (shouldClose) {
-            closeSettings();
-        }
-    };
-
     document.querySelectorAll('.settings-tab').forEach(tab => {
         tab.onclick = () => {
             currentTab = tab.dataset.tab;
@@ -1364,7 +1351,6 @@ export function openSettings(tab = null) {
 
 export function closeSettings() {
     if (!settingsModal) return;
-    overlayPointerDown = false;
     settingsModal.classList.remove('settings-modal-visible');
     settingsModal.style.display = 'none';
 }

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -639,7 +639,7 @@ def test_browser_model_profile_custom_provider_keeps_manual_base_url(
     )
 
 
-def test_browser_settings_modal_does_not_close_after_dragging_out_of_content(
+def test_browser_settings_modal_stays_open_on_outside_click(
     browser_page: Page,
     integration_env: IntegrationEnvironment,
 ) -> None:
@@ -669,6 +669,9 @@ def test_browser_settings_modal_does_not_close_after_dragging_out_of_content(
     expect(settings_modal).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
 
     page.mouse.click(end_x, end_y)
+    expect(settings_modal).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+    page.locator("#settings-close").click()
     expect(settings_modal).to_be_hidden(timeout=_WAIT_TIMEOUT_MS)
 
 

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -1659,7 +1659,7 @@ console.log(JSON.stringify({
     assert load_calls["workspace"] == 1
 
 
-def test_settings_modal_only_closes_for_direct_overlay_click(tmp_path: Path) -> None:
+def test_settings_modal_does_not_close_from_overlay_click(tmp_path: Path) -> None:
     payload = _run_settings_script(
         tmp_path=tmp_path,
         runner_source="""
@@ -1669,23 +1669,20 @@ initSettings();
 await openSettings();
 
 const settingsModal = document.getElementById("settings-modal");
-const modalContent = settingsModal.children[0];
 
-settingsModal.onmousedown({ target: modalContent });
-settingsModal.onclick({ target: settingsModal });
-const afterDraggedReleaseDisplay = settingsModal.style.display;
+settingsModal.onmousedown?.({ target: settingsModal });
+settingsModal.onclick?.({ target: settingsModal });
+const afterOverlayClickDisplay = settingsModal.style.display;
 
-await openSettings();
-settingsModal.onmousedown({ target: settingsModal });
-settingsModal.onclick({ target: settingsModal });
-const afterDirectOverlayClickDisplay = settingsModal.style.display;
+document.getElementById("settings-close").onclick();
+const afterCloseButtonDisplay = settingsModal.style.display;
 
 console.log(JSON.stringify({
-    afterDraggedReleaseDisplay,
-    afterDirectOverlayClickDisplay,
+    afterOverlayClickDisplay,
+    afterCloseButtonDisplay,
 }));
 """.strip(),
     )
 
-    assert payload["afterDraggedReleaseDisplay"] == "flex"
-    assert payload["afterDirectOverlayClickDisplay"] == "none"
+    assert payload["afterOverlayClickDisplay"] == "flex"
+    assert payload["afterCloseButtonDisplay"] == "none"


### PR DESCRIPTION
  - 修复设置页交互：打开 Settings 后，点击设置页外部遮罩不再关闭页面。
  - 保留显式关闭：只有点击 Settings 的关闭按钮才会关闭弹窗。
  - 更新回归测试：
      - 前端单测覆盖“外部点击不关闭，关闭按钮关闭”。
      - Browser integration 测试同步更新为新预期。

## Summary
- keep the Settings modal open when users click outside the modal content
- remove the backdrop click dismissal handler from the settings shell
- update the settings shell regression test so only the close button dismisses the modal

## Tests
- node --check frontend\\dist\\js\\components\\settings\\index.js
- uv run --extra dev pytest -q tests\\unit_tests\\frontend\\test_settings_shell_ui.py
- pre-commit during commit: ruff-check, ruff-format, basedpyright-check

Closes #881