### PR TITLE
Fix message timeline scroll anchor

### DIFF
--- a/frontend/dist/js/app/recovery.js
+++ b/frontend/dist/js/app/recovery.js
@@ -156,7 +156,7 @@ export async function hydrateSessionSwitchView(
     {
         priority = 'high',
         quiet = true,
-        roundsScrollPolicy = '',
+        roundsScrollPolicy = 'session-load',
         signal = null,
     } = {},
 ) {
@@ -172,7 +172,7 @@ export async function hydrateSessionSwitchView(
     await loadSessionRounds(safeSessionId, {
         priority,
         render: !shouldPreserveActiveSubagentView(safeSessionId),
-        scrollPolicy: roundsScrollPolicy || undefined,
+        scrollPolicy: roundsScrollPolicy || 'session-load',
         signal,
         timelineLoadMode: 'background',
     });

--- a/frontend/dist/js/app/sessionView.js
+++ b/frontend/dist/js/app/sessionView.js
@@ -19,14 +19,14 @@ export async function hydrateMainSessionForSwitch(
     {
         priority = 'high',
         quiet = true,
-        roundsScrollPolicy = '',
+        roundsScrollPolicy = 'session-load',
         signal = null,
     } = {},
 ) {
     return hydrateSessionSwitchView(sessionId, {
         priority,
         quiet,
-        roundsScrollPolicy,
+        roundsScrollPolicy: roundsScrollPolicy || 'session-load',
         signal,
     });
 }

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -758,10 +758,6 @@ function renderNavigatorForTimeline(options = {}) {
 
 function captureRoundRenderPlan(options = {}) {
     const explicitPolicy = String(options.scrollPolicy || '').trim();
-    const fallbackPolicy = options.preserveScroll === true
-        ? 'preserve-anchor'
-        : 'session-load';
-    const policy = explicitPolicy || fallbackPolicy;
     const container = els.chatMessages;
     const hasRenderedRounds = !!container?.querySelector?.('.session-round-section');
 
@@ -773,6 +769,11 @@ function captureRoundRenderPlan(options = {}) {
             preserveLoadedRounds: false,
         };
     }
+
+    const fallbackPolicy = options.preserveScroll === false
+        ? 'session-load'
+        : 'preserve-anchor';
+    const policy = explicitPolicy || fallbackPolicy;
 
     if (policy === 'completion-auto') {
         const latestRound = roundsState.currentRounds[roundsState.currentRounds.length - 1] || null;

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -2426,6 +2426,51 @@ function renderProjectsFromSnapshot({ syncStreams = false } = {}) {
     return true;
 }
 
+function getProjectsWorkspaceScroller() {
+    return els.projectsList?.querySelector?.('.projects-workspace-scroll') || null;
+}
+
+function captureProjectSidebarScrollAnchor() {
+    if (!els.projectsList) {
+        return null;
+    }
+    const workspaceScroller = getProjectsWorkspaceScroller();
+    return {
+        scrollTop: Number(els.projectsList.scrollTop || 0),
+        workspaceScrollTop: Number(workspaceScroller?.scrollTop || 0),
+    };
+}
+
+function restoreElementScrollTop(element, scrollTop) {
+    if (!element) {
+        return;
+    }
+    const scrollHeight = Number(element.scrollHeight || 0);
+    const clientHeight = Number(element.clientHeight || 0);
+    const hasScrollableRange = Number.isFinite(scrollHeight)
+        && Number.isFinite(clientHeight)
+        && scrollHeight > clientHeight;
+    const maxScrollTop = hasScrollableRange
+        ? Math.max(0, scrollHeight - clientHeight)
+        : Number.POSITIVE_INFINITY;
+    element.scrollTop = Math.max(0, Math.min(maxScrollTop, scrollTop));
+}
+
+function restoreProjectSidebarScrollAnchor(anchor) {
+    if (!els.projectsList || !anchor) {
+        return;
+    }
+    restoreElementScrollTop(els.projectsList, anchor.scrollTop);
+    restoreElementScrollTop(getProjectsWorkspaceScroller(), anchor.workspaceScrollTop);
+}
+
+function replaceProjectsListChildren(nodes) {
+    const scrollAnchor = captureProjectSidebarScrollAnchor();
+    els.projectsList.innerHTML = '';
+    nodes.forEach(node => els.projectsList.appendChild(node));
+    restoreProjectSidebarScrollAnchor(scrollAnchor);
+}
+
 function renderProjectSidebarData(
     workspaces,
     sessions,
@@ -2468,8 +2513,7 @@ function renderProjectSidebarData(
             renderProjectsWorkspaceShell(toolbarNode, workspaceContentNodes),
         ];
         lastProjectsRenderSignature = nextSignature;
-        els.projectsList.innerHTML = '';
-        nextNodes.forEach(node => els.projectsList.appendChild(node));
+        replaceProjectsListChildren(nextNodes);
         return;
     }
     if (!groups.some(group => group.key === openProjectMenuId)) {
@@ -2481,8 +2525,7 @@ function renderProjectSidebarData(
         renderProjectsWorkspaceShell(toolbarNode, workspaceContentNodes),
     ];
     lastProjectsRenderSignature = nextSignature;
-    els.projectsList.innerHTML = '';
-    nextNodes.forEach(node => els.projectsList.appendChild(node));
+    replaceProjectsListChildren(nextNodes);
     syncProjectSortButton();
     syncSubagentSessionListVisualState();
     playPendingSessionAnimation();

--- a/tests/integration_tests/browser/test_message_copy_actions.py
+++ b/tests/integration_tests/browser/test_message_copy_actions.py
@@ -260,6 +260,32 @@ def test_round_intent_toggle_survives_streaming_patch_and_overlap(
     }
 
 
+def test_round_timeline_click_rerender_preserves_scroll_anchor(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    _open_round_intent_harness(browser_page, tmp_path)
+
+    payload = cast(
+        dict[str, object],
+        browser_page.evaluate(
+            """
+        async () => window.__runRoundScrollAnchorScenario()
+        """
+        ),
+    )
+
+    assert payload["beforeRunId"] == "run-scroll-middle"
+    assert payload["afterRunId"] == "run-scroll-middle"
+    before_top = cast(float, payload["beforeTop"])
+    after_top = cast(float, payload["afterTop"])
+    session_load_top = cast(float, payload["sessionLoadTop"])
+    assert before_top > 120
+    assert abs(after_top - before_top) <= 12
+    assert session_load_top > after_top
+    assert payload["sessionLoadNearBottom"] is True
+
+
 def _open_message_copy_harness(page: Page, tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     html_path = tmp_path / "message_copy_actions.html"
@@ -378,6 +404,9 @@ def _round_intent_harness_html(base_url: str) -> str:
       margin-top: -42px;
       background: rgba(239, 68, 68, 0.18);
     }}
+    .session-round-section {{
+      min-height: 520px;
+    }}
   </style>
 </head>
 <body class="light-theme">
@@ -396,10 +425,14 @@ def _round_intent_harness_html(base_url: str) -> str:
     import {{
       createLiveRound,
       overlayRoundRecoveryState,
+      renderCurrentSessionTimeline,
     }} from "{base_url}/frontend/dist/js/components/rounds/timeline.js";
 
     const waitForLayout = () => new Promise(resolve => {{
       requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }});
+    const waitForRoundScrollAnimation = () => new Promise(resolve => {{
+      window.setTimeout(resolve, 900);
     }});
 
     window.__runRoundIntentScenario = async () => {{
@@ -455,6 +488,75 @@ def _round_intent_harness_html(base_url: str) -> str:
         closedBeforePatch,
         closedAfterPatch,
         toggleHit: hit === toggle || toggle?.contains(hit) === true,
+      }};
+    }};
+
+    function firstVisibleRoundId() {{
+      const container = document.getElementById('chat-messages');
+      const containerRect = container.getBoundingClientRect();
+      const sections = Array.from(document.querySelectorAll('.session-round-section'));
+      let best = null;
+      let bestDistance = Number.POSITIVE_INFINITY;
+      sections.forEach(section => {{
+        const rect = section.getBoundingClientRect();
+        if (rect.bottom < containerRect.top || rect.top > containerRect.bottom) {{
+          return;
+        }}
+        const distance = Math.abs(rect.top - containerRect.top);
+        if (distance < bestDistance) {{
+          bestDistance = distance;
+          best = section;
+        }}
+      }});
+      return best?.dataset?.runId || '';
+    }}
+
+    window.__runRoundScrollAnchorScenario = async () => {{
+      const container = document.getElementById('chat-messages');
+      const longIntent = [
+        'Analyze the frontend round timeline scroll behavior and keep the visible section stable.',
+        'This line gives the round enough height for meaningful anchor restoration.',
+        'Clicking a message should not make the transcript jump to the top.'
+      ].join('\\n\\n');
+
+      createLiveRound('run-scroll-oldest', longIntent);
+      createLiveRound('run-scroll-middle', longIntent);
+      createLiveRound('run-scroll-latest', longIntent);
+      await waitForLayout();
+      await waitForRoundScrollAnimation();
+
+      const middleSection = document.querySelector('[data-run-id="run-scroll-middle"]');
+      const middleTop = middleSection.getBoundingClientRect().top
+        - container.getBoundingClientRect().top
+        + container.scrollTop
+        - 32;
+      container.scrollTop = Math.max(0, middleTop);
+      await waitForLayout();
+
+      const message = middleSection.querySelector('.round-detail-header');
+      message?.dispatchEvent(new MouseEvent('click', {{ bubbles: true, cancelable: true }}));
+      const beforeTop = container.scrollTop;
+      const beforeRunId = firstVisibleRoundId();
+
+      renderCurrentSessionTimeline({{}});
+      await waitForLayout();
+      const afterTop = container.scrollTop;
+      const afterRunId = firstVisibleRoundId();
+
+      renderCurrentSessionTimeline({{ scrollPolicy: 'session-load' }});
+      await waitForLayout();
+      const sessionLoadTop = container.scrollTop;
+      const sessionLoadNearBottom = (
+        container.scrollHeight - container.scrollTop - container.clientHeight
+      ) <= 12;
+
+      return {{
+        beforeRunId,
+        afterRunId,
+        beforeTop,
+        afterTop,
+        sessionLoadTop,
+        sessionLoadNearBottom,
       }};
     }};
     window.__roundIntentReady = true;

--- a/tests/unit_tests/frontend/test_projects_sidebar_ui.py
+++ b/tests/unit_tests/frontend/test_projects_sidebar_ui.py
@@ -517,6 +517,121 @@ console.log(JSON.stringify({
     assert elapsed_ms < 300
 
 
+def test_projects_sidebar_preserves_scroll_after_session_list_rerender(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        mock_api_source="""
+const workspaces = [
+    {
+        workspace_id: "alpha-project",
+        root_path: "/work/Alpha Project",
+        updated_at: "2026-03-14T10:00:00Z",
+        profile: { file_scope: { backend: "project" } },
+    },
+];
+
+const sessions = Array.from({ length: 24 }, (_, index) => ({
+    session_id: `session-${String(index).padStart(2, "0")}`,
+    workspace_id: "alpha-project",
+    updated_at: new Date(Date.UTC(2026, 2, 14, 10, 0, index % 60)).toISOString(),
+    metadata: { title: `Session title ${index}` },
+    pending_tool_approval_count: 0,
+}));
+
+export async function fetchWorkspaces() {
+    return workspaces;
+}
+
+export async function fetchSessions() {
+    const suffix = globalThis.__sessionTitleSuffix || "";
+    return sessions.map(session => ({
+        ...session,
+        metadata: {
+            ...session.metadata,
+            title: `${session.metadata.title}${suffix}`,
+        },
+    }));
+}
+
+export async function fetchAutomationProjects() {
+    return [];
+}
+
+export async function fetchAutomationFeishuBindings() {
+    return [];
+}
+
+export async function startNewSession() {
+    throw new Error("not used");
+}
+
+export async function updateSession() {
+    return { status: "ok" };
+}
+
+export async function deleteSession() {
+    return { status: "ok" };
+}
+
+export async function deleteWorkspace() {
+    return { status: "ok" };
+}
+
+export async function forkWorkspace() {
+    return {};
+}
+
+export async function pickWorkspace() {
+    return { workspace_id: "alpha-project" };
+}
+
+export async function createAutomationProject() {
+    return {};
+}
+
+export async function deleteAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function disableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function enableAutomationProject() {
+    return { status: "ok" };
+}
+""".strip(),
+        runner_source="""
+import { loadProjects } from "./sidebar.mjs";
+
+installGlobals(createDomEnvironment());
+await loadProjects();
+
+const projectsList = document.getElementById("projects-list");
+const scroller = projectsList.querySelector(".projects-workspace-scroll");
+scroller.scrollTop = 360;
+scroller.scrollHeight = 1600;
+scroller.clientHeight = 480;
+globalThis.__sessionTitleSuffix = " updated";
+
+await loadProjects({ forceRefresh: true });
+await flushTasks();
+
+const firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
+const restoredScroller = projectsList.querySelector(".projects-workspace-scroll");
+console.log(JSON.stringify({
+    scrollTop: restoredScroller.scrollTop,
+    visibleSessionCount: firstProject.querySelectorAll(".session-item").length,
+}));
+""".strip(),
+    )
+
+    assert payload["scrollTop"] == 360
+    assert payload["visibleSessionCount"] == 10
+
+
 def test_projects_sidebar_clears_unread_indicator_immediately_on_session_click(
     tmp_path: Path,
 ) -> None:
@@ -4544,6 +4659,9 @@ function createContainerElement() {
         className: "",
         style: {},
         children: [],
+        scrollTop: 0,
+        scrollHeight: 0,
+        clientHeight: 0,
         matches(selector) {
             return selector === ":hover" ? !!globalThis.__projectsListHover : false;
         },
@@ -4554,6 +4672,7 @@ function createContainerElement() {
             html = String(value);
             if (!html) {
                 this.children = [];
+                this.scrollTop = 0;
             }
         },
         appendChild(child) {


### PR DESCRIPTION
## Summary
- Preserve the visible round anchor during lightweight current-session timeline rerenders.
- Keep explicit session-load navigation following the latest round for session switches.
- Add a browser regression for click-triggered rerenders and explicit session-load behavior.

## Tests
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_round_scroll_controller_ui.py tests/integration_tests/browser/test_message_copy_actions.py
- uv run --extra dev ruff check tests/integration_tests/browser/test_message_copy_actions.py tests/unit_tests/frontend/test_round_scroll_controller_ui.py
- uv run --extra dev ruff format --check tests/integration_tests/browser/test_message_copy_actions.py
- git diff --check

Fixes #880