### PR TITLE
Fix stream scroll reading mode

### DIFF
--- a/frontend/dist/js/components/messageRenderer/helpers/block.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/block.js
@@ -17,6 +17,10 @@ import {
     normalizePromptContentPart,
     updatePromptContentBlock,
 } from './prompt.js';
+import {
+    clearProgressiveState,
+    renderProgressivePlainText,
+} from './progressiveText.js';
 
 const STREAMING_CURSOR_CLASS = 'streaming-cursor';
 const LARGE_STREAM_TEXT_THRESHOLD = 12000;
@@ -292,6 +296,18 @@ function shouldRenderPlainText(textEl, source, options = {}) {
 
 function renderPlainTextContent(textEl, source, options = {}) {
     const state = ensurePlainTextRenderState(textEl);
+    if (options.appendDelta === true && textEl.__progressiveTextState) {
+        const progressiveSource = String(textEl.__progressiveTextState.source || '') + source;
+        if (renderProgressivePlainText(textEl, progressiveSource)) {
+            state.renderedLength = progressiveSource.length;
+            return;
+        }
+    }
+    if (options.appendDelta !== true && renderProgressivePlainText(textEl, source)) {
+        state.renderedLength = source.length;
+        return;
+    }
+    clearProgressiveState(textEl);
     if (options.appendDelta === true) {
         appendPlainText(textEl, source, state);
         return;
@@ -504,7 +520,8 @@ function bindThinkingOpenState(block, options = {}) {
     }
     block.dataset.thinkingOpenBound = 'true';
     const captureToggleAnchor = () => {
-        const container = block.closest?.('.chat-scroll');
+        dispatchReadingIntent(block);
+        const container = block.closest?.('.chat-scroll, .subagent-session-body');
         if (!container || !block.getBoundingClientRect) return;
         block.__thinkingToggleAnchor = {
             container,
@@ -527,6 +544,13 @@ function bindThinkingOpenState(block, options = {}) {
         thinkingOpenState.set(stateKey, block.open === true);
         restoreThinkingToggleAnchor(block);
     });
+}
+
+function dispatchReadingIntent(block) {
+    if (!block || typeof CustomEvent !== 'function') {
+        return;
+    }
+    block.dispatchEvent(new CustomEvent('relayTeamsReadingIntent', { bubbles: true }));
 }
 
 function restoreThinkingToggleAnchor(block) {

--- a/frontend/dist/js/components/messageRenderer/helpers/progressiveText.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/progressiveText.js
@@ -1,0 +1,234 @@
+/**
+ * components/messageRenderer/helpers/progressiveText.js
+ * Frame-budgeted rendering for very large plain text and line blocks.
+ */
+
+export const PROGRESSIVE_TEXT_THRESHOLD = 24000;
+export const PROGRESSIVE_LINE_THRESHOLD = 240;
+
+const DEFAULT_TEXT_CHUNK_CHARS = 12000;
+const DEFAULT_LINE_BATCH_SIZE = 80;
+const DEFAULT_FRAME_BUDGET_MS = 8;
+
+export function shouldRenderTextProgressively(text, threshold = PROGRESSIVE_TEXT_THRESHOLD) {
+    return String(text || '').length > threshold;
+}
+
+export function renderProgressivePlainText(targetEl, text, options = {}) {
+    if (!targetEl) {
+        return false;
+    }
+    const source = String(text || '');
+    const threshold = Number(options.threshold || PROGRESSIVE_TEXT_THRESHOLD);
+    if (!shouldRenderTextProgressively(source, threshold)) {
+        clearProgressiveState(targetEl);
+        return false;
+    }
+
+    const existing = targetEl.__progressiveTextState || null;
+    if (
+        existing
+        && isProgressiveTextStateAttached(targetEl, existing)
+        && source.startsWith(existing.source.slice(0, existing.offset))
+    ) {
+        existing.source = source;
+        scheduleTextFrame(targetEl, existing);
+        return true;
+    }
+
+    const state = {
+        source,
+        offset: 0,
+        version: 1,
+        frame: 0,
+        tailNode: null,
+        chunkChars: Math.max(1024, Number(options.chunkChars || DEFAULT_TEXT_CHUNK_CHARS)),
+        frameBudgetMs: Math.max(1, Number(options.frameBudgetMs || DEFAULT_FRAME_BUDGET_MS)),
+    };
+    targetEl.__progressiveTextState = state;
+    if (typeof targetEl.replaceChildren === 'function') {
+        targetEl.replaceChildren();
+    } else {
+        targetEl.textContent = '';
+    }
+    renderTextBudget(targetEl, state);
+    scheduleTextFrame(targetEl, state);
+    return true;
+}
+
+export function renderProgressiveHtmlBatches(targetEl, totalItems, renderBatch, options = {}) {
+    if (!targetEl || typeof renderBatch !== 'function') {
+        return false;
+    }
+    const total = Math.max(0, Number(totalItems || 0));
+    const threshold = Math.max(1, Number(options.threshold || PROGRESSIVE_LINE_THRESHOLD));
+    if (total <= threshold) {
+        clearProgressiveState(targetEl);
+        return false;
+    }
+    const state = {
+        total,
+        offset: 0,
+        version: 1,
+        frame: 0,
+        renderBatch,
+        batchSize: Math.max(1, Number(options.batchSize || DEFAULT_LINE_BATCH_SIZE)),
+        batchesPerFrame: Math.max(1, Number(options.batchesPerFrame || 1)),
+        frameBudgetMs: Math.max(1, Number(options.frameBudgetMs || DEFAULT_FRAME_BUDGET_MS)),
+    };
+    targetEl.__progressiveHtmlState = state;
+    if (typeof targetEl.replaceChildren === 'function') {
+        targetEl.replaceChildren();
+    } else {
+        targetEl.innerHTML = '';
+    }
+    renderHtmlBudget(targetEl, state);
+    scheduleHtmlFrame(targetEl, state);
+    return true;
+}
+
+export function clearProgressiveState(targetEl) {
+    if (!targetEl) {
+        return;
+    }
+    if (targetEl.__progressiveTextState) {
+        targetEl.__progressiveTextState.version += 1;
+        delete targetEl.__progressiveTextState;
+    }
+    if (targetEl.__progressiveHtmlState) {
+        targetEl.__progressiveHtmlState.version += 1;
+        delete targetEl.__progressiveHtmlState;
+    }
+}
+
+function scheduleTextFrame(targetEl, state) {
+    if (!state || state.frame || state.offset >= state.source.length) {
+        return;
+    }
+    const version = state.version;
+    state.frame = requestNextFrame(() => {
+        state.frame = 0;
+        if (targetEl.__progressiveTextState !== state || state.version !== version) {
+            return;
+        }
+        renderTextBudget(targetEl, state);
+        scheduleTextFrame(targetEl, state);
+    });
+}
+
+function renderTextBudget(targetEl, state) {
+    const startedAt = nowMs();
+    let renderedChars = 0;
+    while (state.offset < state.source.length) {
+        const remainingFrameChars = state.chunkChars - renderedChars;
+        if (remainingFrameChars <= 0) {
+            break;
+        }
+        const next = state.source.slice(
+            state.offset,
+            Math.min(state.source.length, state.offset + remainingFrameChars),
+        );
+        appendTextChunk(targetEl, state, next);
+        state.offset += next.length;
+        renderedChars += next.length;
+        if (renderedChars >= state.chunkChars || nowMs() - startedAt >= state.frameBudgetMs) {
+            break;
+        }
+    }
+}
+
+function appendTextChunk(targetEl, state, text) {
+    if (!text) {
+        return;
+    }
+    if (!state.tailNode) {
+        state.tailNode = createTextNode('');
+        appendBeforeStreamingCursor(targetEl, state.tailNode);
+    }
+    state.tailNode.textContent = String(state.tailNode.textContent || '') + text;
+}
+
+function scheduleHtmlFrame(targetEl, state) {
+    if (!state || state.frame || state.offset >= state.total) {
+        return;
+    }
+    const version = state.version;
+    state.frame = requestNextFrame(() => {
+        state.frame = 0;
+        if (targetEl.__progressiveHtmlState !== state || state.version !== version) {
+            return;
+        }
+        renderHtmlBudget(targetEl, state);
+        scheduleHtmlFrame(targetEl, state);
+    });
+}
+
+function renderHtmlBudget(targetEl, state) {
+    const startedAt = nowMs();
+    let renderedBatches = 0;
+    while (state.offset < state.total) {
+        const end = Math.min(state.total, state.offset + state.batchSize);
+        appendHtml(targetEl, state.renderBatch(state.offset, end));
+        state.offset = end;
+        renderedBatches += 1;
+        if (
+            renderedBatches >= state.batchesPerFrame
+            || nowMs() - startedAt >= state.frameBudgetMs
+        ) {
+            break;
+        }
+    }
+}
+
+function appendHtml(targetEl, html) {
+    const source = String(html || '');
+    if (!source) {
+        return;
+    }
+    if (typeof targetEl.insertAdjacentHTML === 'function') {
+        targetEl.insertAdjacentHTML('beforeend', source);
+        return;
+    }
+    targetEl.innerHTML = String(targetEl.innerHTML || '') + source;
+}
+
+function appendBeforeStreamingCursor(targetEl, node) {
+    const cursor = targetEl.querySelector?.('.streaming-cursor') || null;
+    if (cursor?.parentNode === targetEl && typeof targetEl.insertBefore === 'function') {
+        targetEl.insertBefore(node, cursor);
+        return;
+    }
+    targetEl.appendChild(node);
+}
+
+function isProgressiveTextStateAttached(targetEl, state) {
+    if (!state?.tailNode) {
+        return true;
+    }
+    return state.tailNode.parentNode === targetEl;
+}
+
+function createTextNode(text) {
+    if (typeof document !== 'undefined' && typeof document.createTextNode === 'function') {
+        return document.createTextNode(text);
+    }
+    return {
+        nodeType: 3,
+        textContent: String(text || ''),
+    };
+}
+
+function requestNextFrame(callback) {
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        return window.requestAnimationFrame(callback);
+    }
+    if (typeof globalThis.setTimeout === 'function') {
+        return globalThis.setTimeout(callback, 16);
+    }
+    callback();
+    return 0;
+}
+
+function nowMs() {
+    return globalThis.performance?.now?.() || Date.now();
+}

--- a/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
@@ -4,6 +4,10 @@
  */
 import { syncApprovalStateFromEnvelope } from './approval.js';
 import { appendStructuredContentPart, renderRichContent } from './content.js';
+import {
+    renderProgressiveHtmlBatches,
+    renderProgressivePlainText,
+} from './progressiveText.js';
 import { normalizeToolArgs } from './toolArgs.js';
 import { t, formatMessage } from '../../../utils/i18n.js';
 
@@ -133,8 +137,12 @@ function renderLinedContent(text, startLine = 1) {
     const lines = String(text).split('\n');
     const endLine = startLine + lines.length - 1;
     const padWidth = String(endLine).length;
-    return lines.map((line, i) => {
-        const no = String(startLine + i).padStart(padWidth, '\u00a0');
+    return renderLinedLinesBatch(lines, startLine, padWidth, 0, lines.length);
+}
+
+function renderLinedLinesBatch(lines, startLine, padWidth, start, end) {
+    return lines.slice(start, end).map((line, i) => {
+        const no = String(startLine + start + i).padStart(padWidth, '\u00a0');
         return `<div class="tool-line"><span class="tool-line-no">${no}</span><span class="tool-line-text">${escapeHtmlInline(line) || '\u00a0'}</span></div>`;
     }).join('');
 }
@@ -145,11 +153,20 @@ function renderTaggedLineContent(text, fallbackStartLine = 1) {
     if (numberedLines.length === 0) {
         return renderLinedContent(text, fallbackStartLine);
     }
-    const padWidth = Math.max(
+    const padWidth = taggedLinePadWidth(parsedLines, fallbackStartLine);
+    return renderTaggedLineBatch(parsedLines, padWidth, 0, parsedLines.length);
+}
+
+function taggedLinePadWidth(parsedLines, fallbackStartLine = 1) {
+    const numberedLines = parsedLines.filter(line => line.lineNo != null);
+    return Math.max(
         String(fallbackStartLine).length,
         ...numberedLines.map(line => String(line.lineNo).length),
     );
-    return parsedLines.map(line => {
+}
+
+function renderTaggedLineBatch(parsedLines, padWidth, start, end) {
+    return parsedLines.slice(start, end).map(line => {
         const lineNo = line.lineNo != null
             ? String(line.lineNo).padStart(padWidth, '\u00a0')
             : ''.padStart(padWidth, '\u00a0');
@@ -207,6 +224,7 @@ export function buildToolBlock(toolName, args, toolCallId = null) {
     if (copyBtn) {
         copyBtn.addEventListener('click', handleCopyClick);
     }
+    bindToolToggleAnchor(tb);
 
     tb.dataset.status = 'completed';
     return tb;
@@ -251,6 +269,7 @@ export function buildPendingToolBlock(toolName, args, toolCallId = null) {
     if (copyBtn) {
         copyBtn.addEventListener('click', handleCopyClick);
     }
+    bindToolToggleAnchor(tb);
 
     tb.dataset.status = 'running';
     return tb;
@@ -447,6 +466,7 @@ export function applyToolReturn(toolBlock, content, options = {}) {
     }
 
     if (outputEl) {
+        outputEl.__fullToolText = '';
         renderToolResultContent(outputEl, content, toolBlock.dataset.toolName);
     }
     syncApprovalStateFromEnvelope(toolBlock, content);
@@ -544,7 +564,7 @@ function renderToolResultContent(targetEl, content, toolName) {
         return;
     }
     const val = typeof content === 'object' ? JSON.stringify(content, null, 2) : String(content);
-    targetEl.textContent = val;
+    renderToolOutputText(targetEl, val);
 }
 
 export function isToolResultError(result, options = {}) {
@@ -610,7 +630,7 @@ function renderEnvelopeResult(targetEl, envelope, toolName) {
             || data.stderr
             || '',
         );
-        targetEl.textContent = output || JSON.stringify(data, null, 2);
+        renderToolOutputText(targetEl, output || JSON.stringify(data, null, 2));
         return;
     }
 
@@ -628,11 +648,12 @@ function renderEnvelopeResult(targetEl, envelope, toolName) {
     const val = typeof data === 'object'
         ? JSON.stringify(data, null, 2)
         : String(data ?? '');
-    targetEl.textContent = val;
+    renderToolOutputText(targetEl, val);
 }
 
 function renderReadOutput(targetEl, data) {
     const text = getReadOutputText(data);
+    targetEl.__fullToolText = String(text);
     const toolBlock = targetEl.closest('.tool-block');
     const startLine = Math.max(1, Number(toolBlock?.dataset?.readOffset || 1));
     const container = document.createElement('div');
@@ -645,13 +666,52 @@ function renderReadOutput(targetEl, data) {
         targetEl.appendChild(instructionsEl);
     }
     if (parsed?.content) {
-        container.innerHTML = renderTaggedLineContent(parsed.content, startLine);
+        renderReadLines(container, parsed.content, startLine, { tagged: true });
     } else if (parsed?.entries) {
-        container.innerHTML = renderLinedContent(parsed.entries, startLine);
+        renderReadLines(container, parsed.entries, startLine);
     } else {
-        container.innerHTML = renderLinedContent(String(text), startLine);
+        renderReadLines(container, String(text), startLine);
     }
     targetEl.appendChild(container);
+}
+
+function renderToolOutputText(targetEl, text) {
+    const source = String(text ?? '');
+    targetEl.__fullToolText = source;
+    if (renderProgressivePlainText(targetEl, source)) {
+        return;
+    }
+    targetEl.textContent = source;
+}
+
+function renderReadLines(container, text, startLine = 1, options = {}) {
+    const lines = String(text).split('\n');
+    if (options.tagged === true) {
+        const parsedLines = lines.map(parseTaggedLine);
+        const numberedLines = parsedLines.filter(line => line.lineNo != null);
+        if (numberedLines.length > 0) {
+            const padWidth = taggedLinePadWidth(parsedLines, startLine);
+            if (renderProgressiveHtmlBatches(
+                container,
+                parsedLines.length,
+                (start, end) => renderTaggedLineBatch(parsedLines, padWidth, start, end),
+            )) {
+                return;
+            }
+            container.innerHTML = renderTaggedLineBatch(parsedLines, padWidth, 0, parsedLines.length);
+            return;
+        }
+    }
+    const endLine = startLine + lines.length - 1;
+    const padWidth = String(endLine).length;
+    if (renderProgressiveHtmlBatches(
+        container,
+        lines.length,
+        (start, end) => renderLinedLinesBatch(lines, startLine, padWidth, start, end),
+    )) {
+        return;
+    }
+    container.innerHTML = renderLinedLinesBatch(lines, startLine, padWidth, 0, lines.length);
 }
 
 function getReadOutputText(data) {
@@ -817,7 +877,7 @@ function handleCopyClick(event) {
         || toolBlock.querySelector('.tool-args');
     const parts = [];
     if (commandEl) parts.push(commandEl.textContent || '');
-    if (outputEl) parts.push(outputEl.textContent || '');
+    if (outputEl) parts.push(outputEl.__fullToolText || outputEl.textContent || '');
     const textToCopy = parts.filter(Boolean).join('\n\n');
 
     navigator.clipboard.writeText(textToCopy).then(() => {
@@ -829,6 +889,72 @@ function handleCopyClick(event) {
             btn.title = t('tool.action.copy');
         }, 1500);
     }).catch(() => {});
+}
+
+function bindToolToggleAnchor(toolBlock) {
+    if (!toolBlock || toolBlock.dataset?.toolToggleAnchorBound === 'true') {
+        return;
+    }
+    if (toolBlock.dataset) {
+        toolBlock.dataset.toolToggleAnchorBound = 'true';
+    }
+    const captureToggleAnchor = () => {
+        dispatchReadingIntent(toolBlock);
+        const container = findToolScrollContainer(toolBlock);
+        if (!container || !toolBlock.getBoundingClientRect) return;
+        toolBlock.__toolToggleAnchor = {
+            container,
+            top: toolBlock.getBoundingClientRect().top,
+        };
+    };
+    const summary = toolBlock.querySelector?.('.tool-summary') || null;
+    summary?.addEventListener?.('pointerdown', captureToggleAnchor, { passive: true });
+    summary?.addEventListener?.('keydown', event => {
+        const key = String(event?.key || '');
+        if (key === 'Enter' || key === ' ') {
+            captureToggleAnchor();
+        }
+    });
+    toolBlock.addEventListener?.('toggle', () => {
+        restoreToolToggleAnchor(toolBlock);
+    });
+}
+
+function findToolScrollContainer(toolBlock) {
+    return toolBlock?.closest?.('.chat-scroll, .subagent-session-body') || null;
+}
+
+function dispatchReadingIntent(toolBlock) {
+    if (!toolBlock || typeof CustomEvent !== 'function') {
+        return;
+    }
+    toolBlock.dispatchEvent(new CustomEvent('relayTeamsReadingIntent', { bubbles: true }));
+}
+
+function restoreToolToggleAnchor(toolBlock) {
+    const anchor = toolBlock?.__toolToggleAnchor || null;
+    delete toolBlock.__toolToggleAnchor;
+    if (!anchor?.container || typeof window === 'undefined') {
+        return;
+    }
+    const restore = () => {
+        if (!anchor.container?.isConnected || !toolBlock?.isConnected || !toolBlock.getBoundingClientRect) {
+            return;
+        }
+        const nextTop = toolBlock.getBoundingClientRect().top;
+        const delta = nextTop - Number(anchor.top || 0);
+        if (Math.abs(delta) > 0.5) {
+            anchor.container.scrollTop += delta;
+        }
+    };
+    if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(() => {
+            restore();
+            window.requestAnimationFrame(restore);
+        });
+        return;
+    }
+    restore();
 }
 
 function pendingToolKey(toolName, toolCallId) {

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -813,14 +813,13 @@ export function appendThinkingChunk(instanceId, partIndex, text, options = {}) {
     const entry = resolveThinkingEntry(st, partIndex);
     const delta = String(text || '');
     entry.raw += delta;
-    updateThinkingText(entry.textEl, delta, {
+    scheduleRichTextUpdate(entry.textEl, entry.raw, {
         streaming: true,
         runId: st.runId || runId,
         instanceId: st.instanceId || instanceId,
         streamKey: st.streamKey,
         partIndex: entry.key,
-        appendDelta: true,
-    });
+    }, updateThinkingText);
     applyTimelineAction({
         type: 'thinking_delta',
         scope: streamScope(st, {
@@ -3016,18 +3015,18 @@ function captureStreamFollow(container) {
     }
     const state = ensureStreamFollowState(container);
     const nearBottom = isStreamNearBottom(container);
+    if (isStreamUserScrollLocked(state)) {
+        return {
+            shouldFollow: false,
+            wasNearBottom: nearBottom,
+        };
+    }
     if (nearBottom) {
         state.sticky = true;
         state.userScrollLockUntil = 0;
         return {
             shouldFollow: true,
             wasNearBottom: true,
-        };
-    }
-    if (isStreamUserScrollLocked(state)) {
-        return {
-            shouldFollow: false,
-            wasNearBottom: false,
         };
     }
     return {
@@ -3070,12 +3069,12 @@ function bindHeightObserver(container, target = container) {
     if (!state.resizeObserver) {
         state.resizeObserver = new ResizeObserver(() => {
             const nearBottom = isStreamNearBottom(container);
+            if (isStreamUserScrollLocked(state)) {
+                return;
+            }
             if (nearBottom) {
                 state.sticky = true;
                 state.userScrollLockUntil = 0;
-            }
-            if (isStreamUserScrollLocked(state)) {
-                return;
             }
             if (state.sticky === true || nearBottom) {
                 scheduleStreamScrollBottom(container, { shouldFollow: true });
@@ -3093,19 +3092,27 @@ function applyStreamFollowBottom(container, follow = null) {
     if (!container) return;
     const state = ensureStreamFollowState(container);
     const nearBottom = isStreamNearBottom(container);
+    if (isStreamUserScrollLocked(state)) {
+        return;
+    }
     if (nearBottom) {
         state.sticky = true;
         state.userScrollLockUntil = 0;
-    }
-    if (isStreamUserScrollLocked(state)) {
-        return;
     }
     const shouldFollow = follow?.shouldFollow === true
         || state.sticky === true
         || nearBottom;
     if (!shouldFollow) return;
     state.sticky = true;
-    const scroll = () => scrollStreamToBottom(container);
+    const scroll = () => {
+        const currentState = ensureStreamFollowState(container);
+        if (isStreamUserScrollLocked(currentState)) {
+            return;
+        }
+        if (currentState.sticky === true || isStreamNearBottom(container)) {
+            scrollStreamToBottom(container);
+        }
+    };
     if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
         window.requestAnimationFrame(() => {
             scroll();
@@ -3161,6 +3168,16 @@ function bindStreamUserScrollIntent(container, followState) {
         if (target?.closest?.('summary, .thinking-summary, .tool-summary')) {
             pauseStreamAutoFollow(container, followState);
         }
+    }, { passive: true });
+    container.addEventListener?.('keydown', event => {
+        const key = String(event?.key || '');
+        const target = event?.target;
+        if ((key === 'Enter' || key === ' ') && target?.closest?.('summary, .thinking-summary, .tool-summary')) {
+            pauseStreamAutoFollow(container, followState);
+        }
+    }, { passive: true });
+    container.addEventListener?.('relayTeamsReadingIntent', () => {
+        pauseStreamAutoFollow(container, followState);
     }, { passive: true });
     container.addEventListener?.('scroll', () => {
         if (nowMs() < Number(followState.programmaticUntil || 0)) return;

--- a/frontend/dist/js/components/messageTimeline/scrollController.js
+++ b/frontend/dist/js/components/messageTimeline/scrollController.js
@@ -4,6 +4,7 @@
  */
 
 export const BOTTOM_FOLLOW_THRESHOLD_PX = 96;
+const USER_SCROLL_LOCK_MS = 1800;
 
 const followState = new WeakMap();
 
@@ -41,8 +42,18 @@ export function captureBottomIntent(container) {
     }
     const state = ensureFollowState(container);
     const nearBottom = isNearBottom(container);
+    if (isUserScrollLocked(state)) {
+        return {
+            shouldFollow: false,
+            wasNearBottom: nearBottom,
+            scrollHeight: Number(container.scrollHeight || 0),
+            scrollTop: Number(container.scrollTop || 0),
+            clientHeight: Number(container.clientHeight || 0),
+        };
+    }
     if (nearBottom) {
         state.sticky = true;
+        state.userScrollLockUntil = 0;
     }
     return {
         shouldFollow: nearBottom || state.sticky === true,
@@ -57,10 +68,18 @@ export function scheduleFollowBottom(container, options = {}) {
     if (!container) return;
     const state = ensureFollowState(container);
     const follow = options.follow || null;
+    const nearBottom = isNearBottom(container);
+    if (isUserScrollLocked(state) && options.force !== true) {
+        return;
+    }
+    if (nearBottom) {
+        state.sticky = true;
+        state.userScrollLockUntil = 0;
+    }
     const shouldFollow = options.force === true
         || follow?.shouldFollow === true
         || state.sticky === true
-        || isNearBottom(container);
+        || nearBottom;
     if (!shouldFollow) return;
 
     state.sticky = true;
@@ -69,10 +88,12 @@ export function scheduleFollowBottom(container, options = {}) {
     const schedule = resolveAnimationFrameScheduler();
     state.frame = schedule(() => {
         state.frame = 0;
-        scrollToBottom(container);
+        if (shouldApplyScheduledFollow(container, state)) {
+            scrollToBottom(container);
+        }
         state.secondFrame = schedule(() => {
             state.secondFrame = 0;
-            if (state.sticky === true || isNearBottom(container)) {
+            if (shouldApplyScheduledFollow(container, state)) {
                 scrollToBottom(container);
             }
         });
@@ -118,6 +139,7 @@ function ensureFollowState(container) {
         frame: 0,
         secondFrame: 0,
         programmaticUntil: 0,
+        userScrollLockUntil: 0,
         resizeObserver: null,
         observedTargets: null,
     };
@@ -132,16 +154,48 @@ function bindUserScrollIntent(container, state) {
         container.dataset.bottomFollowBound = 'true';
     }
     container.addEventListener('wheel', event => {
-        if (Number(event?.deltaY || 0) < -1) {
-            state.sticky = false;
+        const deltaY = Number(event?.deltaY || 0);
+        if (Math.abs(deltaY) <= 1) {
+            return;
         }
+        if (deltaY > 0 && isNearBottom(container)) {
+            state.sticky = true;
+            state.userScrollLockUntil = 0;
+            return;
+        }
+        pauseAutoFollow(state);
     }, { passive: true });
     container.addEventListener('touchstart', () => {
-        state.sticky = isNearBottom(container);
+        if (isNearBottom(container)) {
+            state.sticky = true;
+            state.userScrollLockUntil = 0;
+            return;
+        }
+        pauseAutoFollow(state);
+    }, { passive: true });
+    container.addEventListener('pointerdown', event => {
+        if (isExpandableSummaryTarget(event?.target)) {
+            pauseAutoFollow(state);
+        }
+    }, { passive: true });
+    container.addEventListener('keydown', event => {
+        const key = String(event?.key || '');
+        if ((key === 'Enter' || key === ' ') && isExpandableSummaryTarget(event?.target)) {
+            pauseAutoFollow(state);
+        }
+    }, { passive: true });
+    container.addEventListener('relayTeamsReadingIntent', () => {
+        pauseAutoFollow(state);
     }, { passive: true });
     container.addEventListener('scroll', () => {
         if (isProgrammaticScroll(state)) return;
-        state.sticky = isNearBottom(container);
+        const nearBottom = isNearBottom(container);
+        state.sticky = nearBottom;
+        if (nearBottom) {
+            state.userScrollLockUntil = 0;
+        } else {
+            pauseAutoFollow(state);
+        }
     }, { passive: true });
 }
 
@@ -156,6 +210,26 @@ function scrollToBottom(container) {
 
 function isProgrammaticScroll(state) {
     return nowMs() < Number(state.programmaticUntil || 0);
+}
+
+function isUserScrollLocked(state) {
+    return nowMs() < Number(state?.userScrollLockUntil || 0);
+}
+
+function pauseAutoFollow(state) {
+    state.sticky = false;
+    state.userScrollLockUntil = nowMs() + USER_SCROLL_LOCK_MS;
+}
+
+function shouldApplyScheduledFollow(container, state) {
+    if (isUserScrollLocked(state)) {
+        return false;
+    }
+    return state.sticky === true || isNearBottom(container);
+}
+
+function isExpandableSummaryTarget(target) {
+    return !!target?.closest?.('summary, .thinking-summary, .tool-summary');
 }
 
 function nowMs() {

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -105,6 +105,48 @@ def test_main_history_overlay_dedupes_primary_alias_in_browser(
     assert payload["overlayAfterPersist"] is None
 
 
+def test_streaming_thinking_reading_position_is_not_stolen_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderThinkingReadingScroll()
+        """
+    )
+
+    assert payload["initialFitsOnePage"] is True
+    assert payload["readingTop"] == 12
+    assert payload["afterMoreTop"] == 12
+    assert payload["afterMoreBottomDistance"] > 96
+    assert payload["renderedFullThought"] is True
+    assert payload["maxFrameGap"] < 250
+
+
+def test_expanded_tool_reading_position_is_not_stolen_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderToolExpansionReadingScroll()
+        """
+    )
+
+    assert payload["toolOpen"] is True
+    assert payload["afterOpenTop"] == 12
+    assert payload["afterStreamTop"] == 12
+    assert payload["afterStreamBottomDistance"] > 96
+    assert payload["renderedFullToolOutput"] is True
+    assert payload["maxFrameGap"] < 250
+
+
 def test_repeated_session_switch_stress_does_not_duplicate_stream_blocks_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -660,6 +702,34 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
       return new Promise(resolve => {{
         window.requestAnimationFrame(() => window.requestAnimationFrame(resolve));
       }});
+    }}
+
+    async function waitForCondition(predicate, timeoutMs = 4000) {{
+      const deadline = performance.now() + timeoutMs;
+      while (performance.now() < deadline) {{
+        if (predicate()) return true;
+        await new Promise(resolve => window.requestAnimationFrame(resolve));
+      }}
+      return predicate();
+    }}
+
+    async function measureFramesDuring(work) {{
+      let running = true;
+      let maxFrameGap = 0;
+      let lastFrame = performance.now();
+      function frame(now) {{
+        maxFrameGap = Math.max(maxFrameGap, now - lastFrame);
+        lastFrame = now;
+        if (running) window.requestAnimationFrame(frame);
+      }}
+      window.requestAnimationFrame(frame);
+      const result = await work();
+      running = false;
+      await waitForAnimationFrame();
+      return {{
+        ...result,
+        maxFrameGap: Math.round(maxFrameGap),
+      }};
     }}
 
     window.__streamTimelineHarness = {{
@@ -2169,6 +2239,115 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
           cancelledFinalText: cancelledFinal.text,
           completedNoFinalText: completedNoFinal.text,
         }};
+      }},
+
+      async renderThinkingReadingScroll() {{
+        clearAllStreamState();
+        const scroll = document.createElement('section');
+        scroll.className = 'chat-scroll';
+        scroll.style.width = '560px';
+        scroll.style.height = '180px';
+        scroll.style.overflow = 'auto';
+        document.body.appendChild(scroll);
+        getOrCreateStreamBlock(scroll, 'primary', 'MainAgent', 'Main Agent', 'run-thinking-scroll');
+        const initialFitsOnePage = scroll.scrollHeight <= scroll.clientHeight;
+        startThinkingBlock(scroll, 'primary', 0, {{
+          runId: 'run-thinking-scroll',
+          roleId: 'MainAgent',
+          label: 'Main Agent',
+        }});
+        const thoughtLines = Array.from(
+          {{ length: 1800 }},
+          (_, index) => `thought line ${{index}} ${{'x'.repeat(96)}}`,
+        );
+        const thoughtText = thoughtLines.join('\\n');
+        return await measureFramesDuring(async () => {{
+          appendThinkingChunk('primary', 0, thoughtText, {{
+            runId: 'run-thinking-scroll',
+            roleId: 'MainAgent',
+            label: 'Main Agent',
+          }});
+          await waitForAnimationFrame();
+          scroll.dispatchEvent(new WheelEvent('wheel', {{ deltaY: -80, bubbles: true }}));
+          scroll.scrollTop = 12;
+          scroll.dispatchEvent(new Event('scroll', {{ bubbles: true }}));
+          const readingTop = Math.round(scroll.scrollTop);
+          const renderedFullThought = await waitForCondition(() => (
+            scroll.textContent.includes('thought line 1799')
+          ));
+          return {{
+            initialFitsOnePage,
+            readingTop,
+            renderedFullThought,
+            afterMoreTop: Math.round(scroll.scrollTop),
+            afterMoreBottomDistance: Math.round(scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight),
+          }};
+        }});
+      }},
+
+      async renderToolExpansionReadingScroll() {{
+        clearAllStreamState();
+        const scroll = document.createElement('section');
+        scroll.className = 'chat-scroll';
+        scroll.style.width = '560px';
+        scroll.style.height = '180px';
+        scroll.style.overflow = 'auto';
+        document.body.appendChild(scroll);
+        getOrCreateStreamBlock(scroll, 'primary', 'MainAgent', 'Main Agent', 'run-tool-scroll');
+        appendToolCallBlock(
+          scroll,
+          'primary',
+          'shell',
+          {{ command: 'printf long-output' }},
+          'call-long-tool',
+          {{
+            runId: 'run-tool-scroll',
+            roleId: 'MainAgent',
+            label: 'Main Agent',
+          }},
+        );
+        const output = Array.from(
+          {{ length: 1600 }},
+          (_, index) => `output line ${{index}} ${{'y'.repeat(96)}}`,
+        ).join('\\n');
+        return await measureFramesDuring(async () => {{
+          updateToolResult(
+            'primary',
+            'shell',
+            {{ ok: true, data: {{ output }} }},
+            false,
+            'call-long-tool',
+            {{
+              runId: 'run-tool-scroll',
+              roleId: 'MainAgent',
+              label: 'Main Agent',
+              container: scroll,
+            }},
+          );
+          await waitForAnimationFrame();
+          const tool = scroll.querySelector('.tool-block');
+          const summary = tool?.querySelector('.tool-summary');
+          summary?.dispatchEvent(new PointerEvent('pointerdown', {{ bubbles: true }}));
+          if (tool) {{
+            tool.open = true;
+            tool.dispatchEvent(new Event('toggle', {{ bubbles: true }}));
+          }}
+          await waitForAnimationFrame();
+          scroll.scrollTop = 12;
+          scroll.dispatchEvent(new Event('scroll', {{ bubbles: true }}));
+          const afterOpenTop = Math.round(scroll.scrollTop);
+          appendStreamChunk('primary', 'final answer text after tool expansion', 'run-tool-scroll', 'MainAgent', 'Main Agent');
+          const renderedFullToolOutput = await waitForCondition(() => (
+            scroll.textContent.includes('output line 1599')
+          ));
+          return {{
+            toolOpen: tool?.open === true,
+            afterOpenTop,
+            renderedFullToolOutput,
+            afterStreamTop: Math.round(scroll.scrollTop),
+            afterStreamBottomDistance: Math.round(scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight),
+          }};
+        }});
       }},
 
       measureSubagentSessionWidth() {{

--- a/tests/unit_tests/frontend/test_long_stream_rendering_ui.py
+++ b/tests/unit_tests/frontend/test_long_stream_rendering_ui.py
@@ -20,18 +20,26 @@ const longText = 'x'.repeat(13000);
 updateMessageText(longEl, longText, { streaming: true });
 updateMessageText(longEl, `${longText}y`, { streaming: true });
 syncTextContent(longEl);
+const longTextLengthBeforeFlush = longEl.textContent.length;
+flushFrames();
+syncTextContent(longEl);
 
 const thinkingEl = document.createElement('div');
 const thinkingText = 'z'.repeat(100000);
 updateThinkingText(thinkingEl, thinkingText, { streaming: true });
 syncTextContent(thinkingEl);
+const thinkingTextLengthBeforeFlush = thinkingEl.textContent.length;
+flushFrames();
+syncTextContent(thinkingEl);
 
 console.log(JSON.stringify({
     richCalls: globalThis.__richCalls,
     longMode: longEl.dataset.renderMode,
+    longTextLengthBeforeFlush,
     longTextLength: longEl.textContent.length,
     longTextNodes: countTextNodes(longEl),
     thinkingMode: thinkingEl.dataset.renderMode,
+    thinkingTextLengthBeforeFlush,
     thinkingTextLength: thinkingEl.textContent.length,
     thinkingTextNodes: countTextNodes(thinkingEl),
 }));
@@ -41,11 +49,52 @@ console.log(JSON.stringify({
     assert payload == {
         "richCalls": [18],
         "longMode": "plain-stream",
+        "longTextLengthBeforeFlush": 13001,
         "longTextLength": 13001,
         "longTextNodes": 1,
         "thinkingMode": "plain-stream",
+        "thinkingTextLengthBeforeFlush": 12000,
         "thinkingTextLength": 100000,
-        "thinkingTextNodes": 7,
+        "thinkingTextNodes": 1,
+    }
+
+
+def test_progressive_text_append_delta_preserves_unflushed_source(
+    tmp_path: Path,
+) -> None:
+    payload = _run_block_helper_script(
+        tmp_path,
+        """
+const { updateMessageText } = await import('./block.mjs');
+
+const textEl = document.createElement('div');
+const initial = 'a'.repeat(50000);
+const delta = 'b'.repeat(5000);
+updateMessageText(textEl, initial, { streaming: true });
+syncTextContent(textEl);
+const beforeDeltaLength = textEl.textContent.length;
+updateMessageText(textEl, delta, { streaming: true, appendDelta: true });
+syncTextContent(textEl);
+const afterDeltaLength = textEl.textContent.length;
+flushFrames();
+syncTextContent(textEl);
+
+console.log(JSON.stringify({
+    beforeDeltaLength,
+    afterDeltaLength,
+    finalLength: textEl.textContent.length,
+    startsWithInitial: textEl.textContent.startsWith('a'.repeat(50000)),
+    endsWithDelta: textEl.textContent.endsWith(delta),
+}));
+""",
+    )
+
+    assert payload == {
+        "beforeDeltaLength": 12000,
+        "afterDeltaLength": 12000,
+        "finalLength": 55000,
+        "startsWithInitial": True,
+        "endsWithDelta": True,
     }
 
 
@@ -177,6 +226,320 @@ console.log(JSON.stringify(globalThis.__textUpdates));
     ]
 
 
+def test_streaming_thinking_chunks_are_frame_batched(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "stream.js"
+    ).read_text(encoding="utf-8")
+    (tmp_path / "stream.mjs").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() { return ""; }
+export function isPrimaryRoleId() { return false; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(key) { return key; }
+export function t(key) { return key; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockHelpers.mjs").write_text(
+        """
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return { textContent: "" }; }
+export function buildPendingToolBlock() { return {}; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock(container, _role, _label, _parts = [], options = {}) {
+  const contentEl = document.createElement("div");
+  const wrapper = document.createElement("div");
+  wrapper.dataset = {
+    runId: String(options.runId || ""),
+    roleId: String(options.roleId || ""),
+    instanceId: String(options.instanceId || ""),
+    streamKey: String(options.streamKey || ""),
+  };
+  wrapper.querySelector = selector => selector === ".msg-content" ? contentEl : null;
+  container.appendChild(wrapper);
+  return { wrapper, contentEl };
+}
+export function resolvePendingToolBlock() { return null; }
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor() {}
+export function updateMessageText() {}
+export function updateThinkingText(textEl, text, options = {}) {
+  globalThis.__thinkingUpdates.push({
+    text: String(text || ""),
+    streaming: options.streaming === true,
+    appendDelta: options.appendDelta === true,
+  });
+  textEl.textContent = String(text || "");
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "runner.mjs").write_text(
+        """
+const frames = [];
+globalThis.window = {
+  requestAnimationFrame(callback) {
+    frames.push(callback);
+    return frames.length;
+  },
+  cancelAnimationFrame() {},
+};
+globalThis.performance = { now: () => 1000 };
+globalThis.__thinkingUpdates = [];
+globalThis.document = {
+  createElement() {
+    return {
+      className: "",
+      dataset: {},
+      textContent: "",
+      children: [],
+      appendChild(child) {
+        this.children.push(child);
+        child.parentNode = this;
+        return child;
+      },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      closest() { return null; },
+    };
+  },
+};
+
+function flushFrames() {
+  while (frames.length) {
+    frames.shift()(1000);
+  }
+}
+
+const {
+  appendThinkingChunk,
+  getOrCreateStreamBlock,
+} = await import("./stream.mjs");
+
+const container = document.createElement("div");
+container.scrollHeight = 1000;
+container.clientHeight = 500;
+container.scrollTop = 500;
+container.addEventListener = () => {};
+
+getOrCreateStreamBlock(container, "inst-1", "Writer", "Writer", "run-1");
+appendThinkingChunk("inst-1", 0, "first", {
+  runId: "run-1",
+  roleId: "Writer",
+  label: "Writer",
+});
+appendThinkingChunk("inst-1", 0, "second", {
+  runId: "run-1",
+  roleId: "Writer",
+  label: "Writer",
+});
+
+const beforeFlush = globalThis.__thinkingUpdates.length;
+flushFrames();
+
+console.log(JSON.stringify({
+  beforeFlush,
+  updates: globalThis.__thinkingUpdates,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(tmp_path / "runner.mjs")],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"Node runner failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+
+    assert json.loads(result.stdout) == {
+        "beforeFlush": 0,
+        "updates": [{"text": "firstsecond", "streaming": True, "appendDelta": False}],
+    }
+
+
+def test_progressive_helper_splits_large_text_and_line_batches(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "progressiveText.js"
+    ).read_text(encoding="utf-8")
+    (tmp_path / "progressiveText.mjs").write_text(source, encoding="utf-8")
+    (tmp_path / "runner.mjs").write_text(
+        """
+const frames = [];
+globalThis.window = {
+  requestAnimationFrame(callback) {
+    frames.push(callback);
+    return frames.length;
+  },
+};
+globalThis.performance = { now: () => 1000 };
+
+class FakeText {
+  constructor(text = "") {
+    this.nodeType = 3;
+    this.textContent = String(text || "");
+    this.parentNode = null;
+  }
+}
+
+class FakeElement {
+  constructor() {
+    this.children = [];
+    this.childNodes = this.children;
+    this.textContent = "";
+    this.innerHTML = "";
+    this.dataset = {};
+    this.className = "";
+  }
+  appendChild(node) {
+    node.parentNode = this;
+    this.children.push(node);
+    this.childNodes = this.children;
+    this.syncText();
+    return node;
+  }
+  replaceChildren() {
+    this.children.forEach(child => { child.parentNode = null; });
+    this.children = [];
+    this.childNodes = this.children;
+    this.textContent = "";
+    this.innerHTML = "";
+  }
+  querySelector() { return null; }
+  insertAdjacentHTML(_position, html) {
+    this.innerHTML += String(html || "");
+  }
+  syncText() {
+    this.textContent = this.children.map(child => String(child.textContent || "")).join("");
+  }
+}
+
+function flushOneFrame() {
+  if (frames.length) frames.shift()(1000);
+}
+
+function flushAllFrames() {
+  while (frames.length) flushOneFrame();
+}
+
+globalThis.document = {
+  createTextNode(text) { return new FakeText(text); },
+};
+
+const {
+  renderProgressiveHtmlBatches,
+  renderProgressivePlainText,
+} = await import("./progressiveText.mjs");
+
+const textTarget = new FakeElement();
+const source = "x".repeat(50000);
+renderProgressivePlainText(textTarget, source, { chunkChars: 10000 });
+renderProgressivePlainText(textTarget, source + "y".repeat(20000), { chunkChars: 10000 });
+textTarget.syncText();
+const textAfterSync = textTarget.textContent.length;
+flushOneFrame();
+textTarget.syncText();
+const textAfterOneFrame = textTarget.textContent.length;
+flushAllFrames();
+textTarget.syncText();
+
+const resetTarget = new FakeElement();
+renderProgressivePlainText(resetTarget, source, { chunkChars: 10000 });
+resetTarget.replaceChildren();
+renderProgressivePlainText(resetTarget, source + "z".repeat(1000), { chunkChars: 10000 });
+flushAllFrames();
+resetTarget.syncText();
+
+const htmlTarget = new FakeElement();
+renderProgressiveHtmlBatches(
+  htmlTarget,
+  300,
+  (start, end) => Array.from({ length: end - start }, (_, index) => `<i>${start + index}</i>`).join(""),
+  { batchSize: 50 },
+);
+const htmlAfterSync = (htmlTarget.innerHTML.match(/<i>/g) || []).length;
+flushOneFrame();
+const htmlAfterOneFrame = (htmlTarget.innerHTML.match(/<i>/g) || []).length;
+flushAllFrames();
+
+console.log(JSON.stringify({
+  textAfterSync,
+  textAfterOneFrame,
+  textFinal: textTarget.textContent.length,
+  resetFinal: resetTarget.textContent.length,
+  resetEndsWith: resetTarget.textContent.endsWith("z".repeat(1000)),
+  htmlAfterSync,
+  htmlAfterOneFrame,
+  htmlFinal: (htmlTarget.innerHTML.match(/<i>/g) || []).length,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(tmp_path / "runner.mjs")],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"Node runner failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+
+    assert json.loads(result.stdout) == {
+        "textAfterSync": 10000,
+        "textAfterOneFrame": 20000,
+        "textFinal": 70000,
+        "resetFinal": 51000,
+        "resetEndsWith": True,
+        "htmlAfterSync": 50,
+        "htmlAfterOneFrame": 100,
+        "htmlFinal": 300,
+    }
+
+
 def _run_block_helper_script(tmp_path: Path, runner_source: str) -> dict[str, object]:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = (
@@ -196,6 +559,7 @@ def _run_block_helper_script(tmp_path: Path, runner_source: str) -> dict[str, ob
         .replace("./toolBlocks.js", "./mockToolBlocks.mjs")
         .replace("./content.js", "./mockContent.mjs")
         .replace("./prompt.js", "./mockPrompt.mjs")
+        .replace("./progressiveText.js", "./progressiveText.mjs")
     )
     (tmp_path / "block.mjs").write_text(source, encoding="utf-8")
     (tmp_path / "mockState.mjs").write_text(
@@ -241,11 +605,32 @@ export function updatePromptContentBlock() { return null; }
 """.strip(),
         encoding="utf-8",
     )
+    (tmp_path / "progressiveText.mjs").write_text(
+        (
+            repo_root
+            / "frontend"
+            / "dist"
+            / "js"
+            / "components"
+            / "messageRenderer"
+            / "helpers"
+            / "progressiveText.js"
+        ).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
     runner_path = tmp_path / "runner.mjs"
     runner_path.write_text(
         f"""
 globalThis.__richCalls = [];
 globalThis.Node = {{ TEXT_NODE: 3, ELEMENT_NODE: 1 }};
+globalThis.__frames = [];
+globalThis.performance = {{ now: () => 1000 }};
+globalThis.window = {{
+    requestAnimationFrame(callback) {{
+        globalThis.__frames.push(callback);
+        return globalThis.__frames.length;
+    }},
+}};
 
 class FakeClassList {{
     constructor(owner) {{ this.owner = owner; }}
@@ -353,6 +738,15 @@ function syncTextContent(root) {{
         syncTextContent(child);
         return String(child.textContent || '');
     }}).join('');
+}}
+
+function flushFrames(limit = 1000) {{
+    let count = 0;
+    while (globalThis.__frames.length && count < limit) {{
+        const frame = globalThis.__frames.shift();
+        frame(1000 + count);
+        count += 1;
+    }}
 }}
 
 globalThis.document = {{

--- a/tests/unit_tests/frontend/test_message_rich_content_ui.py
+++ b/tests/unit_tests/frontend/test_message_rich_content_ui.py
@@ -325,6 +325,19 @@ def test_read_tool_return_renders_media_ref_preview(tmp_path: Path) -> None:
         ).read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    (tmp_path / "progressiveText.js").write_text(
+        (
+            repo_root
+            / "frontend"
+            / "dist"
+            / "js"
+            / "components"
+            / "messageRenderer"
+            / "helpers"
+            / "progressiveText.js"
+        ).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
 
     (tmp_path / "mockApproval.mjs").write_text(
         """

--- a/tests/unit_tests/frontend/test_message_scroll_controller_ui.py
+++ b/tests/unit_tests/frontend/test_message_scroll_controller_ui.py
@@ -107,3 +107,193 @@ console.log(JSON.stringify({
         "preservedAfterUserScroll": 900,
         "forcedBottom": 1700,
     }
+
+
+def test_reading_intent_pauses_follow_until_user_returns_to_bottom(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageTimeline"
+        / "scrollController.js"
+    )
+    module_path = tmp_path / "scrollController.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    runner_path = tmp_path / "runner.mjs"
+    runner_path.write_text(
+        """
+const frames = [];
+globalThis.window = {
+  requestAnimationFrame(callback) {
+    frames.push(callback);
+    return frames.length;
+  },
+};
+globalThis.performance = { now: () => 1000 };
+
+class FakeContainer {
+  constructor() {
+    this.dataset = {};
+    this.scrollHeight = 400;
+    this.clientHeight = 400;
+    this.scrollTop = 0;
+    this.listeners = {};
+  }
+
+  addEventListener(type, listener) {
+    this.listeners[type] = listener;
+  }
+
+  dispatch(type, event = {}) {
+    this.listeners[type]?.(event);
+  }
+}
+
+function flushFrames() {
+  while (frames.length) {
+    frames.shift()(1000);
+  }
+}
+
+const {
+  captureBottomIntent,
+  scheduleFollowBottom,
+} = await import('./scrollController.mjs');
+
+const container = new FakeContainer();
+captureBottomIntent(container);
+container.dispatch('relayTeamsReadingIntent');
+
+const lockedFollow = captureBottomIntent(container);
+container.scrollHeight = 900;
+scheduleFollowBottom(container, { follow: lockedFollow });
+flushFrames();
+const preservedDuringReading = container.scrollTop;
+
+container.scrollTop = 500;
+container.dispatch('scroll');
+const resumedFollow = captureBottomIntent(container);
+container.scrollHeight = 1000;
+scheduleFollowBottom(container, { follow: resumedFollow });
+flushFrames();
+
+console.log(JSON.stringify({
+  lockedShouldFollow: lockedFollow.shouldFollow,
+  preservedDuringReading,
+  resumedBottom: container.scrollTop,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=10,
+    )
+
+    assert json.loads(completed.stdout) == {
+        "lockedShouldFollow": False,
+        "preservedDuringReading": 0,
+        "resumedBottom": 600,
+    }
+
+
+def test_scheduled_follow_is_cancelled_when_user_scrolls_before_frame(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageTimeline"
+        / "scrollController.js"
+    )
+    module_path = tmp_path / "scrollController.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    runner_path = tmp_path / "runner.mjs"
+    runner_path.write_text(
+        """
+const frames = [];
+globalThis.window = {
+  requestAnimationFrame(callback) {
+    frames.push(callback);
+    return frames.length;
+  },
+};
+globalThis.performance = { now: () => 1000 };
+
+class FakeContainer {
+  constructor() {
+    this.dataset = {};
+    this.scrollHeight = 500;
+    this.clientHeight = 400;
+    this.scrollTop = 100;
+    this.listeners = {};
+  }
+
+  addEventListener(type, listener) {
+    this.listeners[type] = listener;
+  }
+
+  dispatch(type, event = {}) {
+    this.listeners[type]?.(event);
+  }
+}
+
+function flushFrames() {
+  while (frames.length) {
+    frames.shift()(1000);
+  }
+}
+
+const {
+  captureBottomIntent,
+  scheduleFollowBottom,
+} = await import('./scrollController.mjs');
+
+const container = new FakeContainer();
+const follow = captureBottomIntent(container);
+container.scrollHeight = 1800;
+scheduleFollowBottom(container, { follow });
+container.dispatch('wheel', { deltaY: -80 });
+container.scrollTop = 12;
+container.dispatch('scroll');
+flushFrames();
+
+console.log(JSON.stringify({
+  shouldFollowBeforeScroll: follow.shouldFollow,
+  topAfterPendingFrame: container.scrollTop,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=10,
+    )
+
+    assert json.loads(completed.stdout) == {
+        "shouldFollowBeforeScroll": True,
+        "topAfterPendingFrame": 12,
+    }

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -474,6 +474,12 @@ def test_pending_tool_block_name_fallback_does_not_merge_parallel_calls(
         ).read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    (temp_dir / "progressiveText.js").write_text(
+        Path(
+            "frontend/dist/js/components/messageRenderer/helpers/progressiveText.js"
+        ).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
 
     runner = """
 import {
@@ -598,6 +604,12 @@ def test_tool_blocks_parse_tagged_read_payloads_and_cap_large_diffs() -> None:
     assert (
         "function renderTaggedLineContent(text, fallbackStartLine = 1) {"
         in tool_blocks_script
+    )
+    assert "renderProgressivePlainText" in tool_blocks_script
+    assert "renderProgressiveHtmlBatches" in tool_blocks_script
+    assert "function renderToolOutputText(targetEl, text) {" in tool_blocks_script
+    assert "function renderReadLines(container, text, startLine = 1" in (
+        tool_blocks_script
     )
     assert "const MAX_DIFF_DP_CELLS = 50000;" in tool_blocks_script
     assert "const MAX_DIFF_TOTAL_LINES = 600;" in tool_blocks_script


### PR DESCRIPTION
## Summary
- pause stream auto-follow when the user scrolls, touches, or expands thinking/tool details
- batch live thinking DOM writes per animation frame while keeping stream state current
- preserve the visible anchor when large thinking/tool details expand

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests` (8167 passed, 7 skipped)
- `uv run --extra dev pytest -q tests/integration_tests` blocked: integration_env waits for `/api/system/health` hydrated=true and times out; backend log tail only reports `gateway.xiaoluban.im_listener.port_unavailable` on port 9009