### PR TITLE
Reduce silent server startup delay

### DIFF
--- a/src/relay_teams/gateway/feishu/subscription_service.py
+++ b/src/relay_teams/gateway/feishu/subscription_service.py
@@ -6,13 +6,10 @@ import logging
 import random
 from contextlib import suppress
 from threading import Event, Lock, Thread
-from typing import NoReturn, Protocol, runtime_checkable
+from typing import NoReturn, Protocol, TypeAlias, runtime_checkable
 from urllib.parse import parse_qs, urlparse
 
 import httpx
-from lark_oapi.event.dispatcher_handler import P2ImMessageReceiveV1
-from lark_oapi.ws.const import DEVICE_ID, SERVICE_ID
-from lark_oapi.ws.model import ClientConfig
 from websockets.exceptions import ConnectionClosedOK, InvalidStatus
 
 from relay_teams.gateway.feishu.lark_ws_compat import (
@@ -32,6 +29,12 @@ from relay_teams.net.websocket import (
 
 logger = get_logger(__name__)
 
+P2ImMessageReceiveV1: TypeAlias = object
+ClientConfig: TypeAlias = object
+
+_DEVICE_ID_QUERY_KEY = "device_id"
+_SERVICE_ID_QUERY_KEY = "service_id"
+
 
 class FeishuRuntimeConfigLookup(Protocol):
     def list_enabled_runtime_configs(
@@ -44,7 +47,7 @@ class FeishuTriggerHandlerLike(Protocol):
         self,
         *,
         trigger_id: str,
-        event: P2ImMessageReceiveV1,
+        event: object,
         raw_body: str,
         headers: dict[str, str],
         remote_addr: str | None,
@@ -437,9 +440,7 @@ class _FeishuWsController:
         self._event_handler = event_handler
         self._client: WsClientLike | None = None
         self._task: asyncio.Task[None] | None = None
-        self._handler_queue: asyncio.Queue[tuple[P2ImMessageReceiveV1, str]] = (
-            asyncio.Queue()
-        )
+        self._handler_queue: asyncio.Queue[tuple[object, str]] = asyncio.Queue()
         self._handler_task: asyncio.Task[None] | None = None
         self._stop_requested = False
 
@@ -573,7 +574,7 @@ class _FeishuWsController:
     def _enqueue_sdk_event(
         self,
         *,
-        event: P2ImMessageReceiveV1,
+        event: object,
         raw_body: str,
     ) -> None:
         self._start_handler_worker()
@@ -605,7 +606,7 @@ class _FeishuWsController:
     def _handle_sdk_event_in_worker(
         self,
         *,
-        event: P2ImMessageReceiveV1,
+        event: object,
         raw_body: str,
     ) -> None:
         result = self._event_handler.handle_sdk_event(
@@ -621,8 +622,8 @@ class _FeishuWsController:
         ws_client_module = import_lark_ws_client_module()
         conn_url = await self._get_conn_url(client)
         conn_query = parse_qs(urlparse(conn_url).query)
-        conn_ids = conn_query.get(DEVICE_ID)
-        service_ids = conn_query.get(SERVICE_ID)
+        conn_ids = conn_query.get(_DEVICE_ID_QUERY_KEY)
+        service_ids = conn_query.get(_SERVICE_ID_QUERY_KEY)
         if not conn_ids or not service_ids:
             raise RuntimeError("Feishu websocket connection metadata is incomplete")
         connection: WsConnectionLike | None = None

--- a/src/relay_teams/gateway/feishu/trigger_handler.py
+++ b/src/relay_teams/gateway/feishu/trigger_handler.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
     from lark_oapi.event.context import EventHeader
     from lark_oapi.event.dispatcher_handler import P2ImMessageReceiveV1
 
-from lark_oapi.core.json import JSON
-
 _AT_TAG_PATTERN = re.compile(r"<at\b[^>]*>.*?</at>", re.IGNORECASE)
 _AT_TAG_LABEL_PATTERN = re.compile(r"<at\b[^>]*>(.*?)</at>", re.IGNORECASE)
 _LEADING_MENTION_TOKEN_PATTERN = re.compile(r"^(?:@\S+\s*)+")
@@ -123,7 +121,7 @@ class FeishuTriggerHandler:
         self,
         *,
         trigger_id: str,
-        event: P2ImMessageReceiveV1,
+        event: object,
         raw_body: str,
         headers: dict[str, str],
         remote_addr: str | None,
@@ -138,7 +136,11 @@ class FeishuTriggerHandler:
                 ignored=True,
                 reason="missing_credentials",
             )
-        normalized = _normalize_sdk_message(event)
+        payload = _parse_json_object(raw_body)
+        normalized = _normalize_sdk_message(
+            cast("P2ImMessageReceiveV1", event),
+            payload=payload,
+        )
         return self._handle_normalized_message(
             runtime_config=runtime_config,
             normalized=normalized,
@@ -371,7 +373,11 @@ def _parse_json_object(raw_body: str) -> dict[str, JsonValue]:
     return parsed
 
 
-def _normalize_sdk_message(event: P2ImMessageReceiveV1) -> FeishuNormalizedMessage:
+def _normalize_sdk_message(
+    event: P2ImMessageReceiveV1,
+    *,
+    payload: dict[str, JsonValue],
+) -> FeishuNormalizedMessage:
     header = event.header
     event_data = event.event
     if header is None:
@@ -386,7 +392,6 @@ def _normalize_sdk_message(event: P2ImMessageReceiveV1) -> FeishuNormalizedMessa
         raise ValueError("Feishu event is missing sender")
 
     message_type = str(message.message_type or "").strip()
-    payload = _sdk_event_payload(event)
     mention_names = _extract_mention_names(payload)
     if message_type != "text":
         return FeishuNormalizedMessage(
@@ -427,13 +432,6 @@ def _normalize_sdk_message(event: P2ImMessageReceiveV1) -> FeishuNormalizedMessa
         payload=payload,
         metadata=_sdk_message_metadata(header, message),
     )
-
-
-def _sdk_event_payload(event: P2ImMessageReceiveV1) -> dict[str, JsonValue]:
-    marshaled = JSON.marshal(event)
-    if marshaled is None:
-        raise ValueError("Feishu SDK event payload is empty")
-    return _parse_json_object(marshaled)
 
 
 def _sdk_event_id(header: EventHeader, message: EventMessage) -> str:

--- a/src/relay_teams/interfaces/cli/app.py
+++ b/src/relay_teams/interfaces/cli/app.py
@@ -1082,7 +1082,15 @@ def _is_agent_teams_base_url_healthy(base_url: str) -> bool:
 
 
 def _health_payload_indicates_ready(payload: object) -> bool:
-    return isinstance(payload, dict) and payload.get("status") == "ok"
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("background_startup_pending") or payload.get(
+        "background_startup_failures"
+    ):
+        return False
+    if payload.get("status") == "ok":
+        return True
+    return payload.get("hydrated") is True and payload.get("startup_phase") == "ready"
 
 
 def _uses_plain_http_root_health(parsed: ParseResult) -> bool:

--- a/src/relay_teams/interfaces/cli/app_full.py
+++ b/src/relay_teams/interfaces/cli/app_full.py
@@ -21,6 +21,10 @@ from relay_teams.interfaces.cli.env_commands import build_env_app
 from relay_teams.interfaces.cli.gateway_cli import build_gateway_app
 from relay_teams.interfaces.cli.approvals_cli import build_approvals_app
 from relay_teams.interfaces.cli.hooks_cli import build_hooks_app
+from relay_teams.interfaces.cli.http_client import (
+    create_cli_http_client,
+    is_local_server_host,
+)
 from relay_teams.interfaces.cli.memories_cli import build_memories_app
 from relay_teams.interfaces.cli.questions_cli import build_questions_app
 from relay_teams.interfaces.cli.metrics_cli import build_metrics_app
@@ -40,7 +44,6 @@ from relay_teams.interfaces.server.runtime_identity import (
     build_server_runtime_identity,
     raise_if_runtime_mismatch,
 )
-from relay_teams.net.clients import create_async_http_client
 from relay_teams.mcp.mcp_cli import mcp_app
 from relay_teams.paths import get_project_config_dir
 from relay_teams.plugins.plugin_cli import plugin_app
@@ -52,7 +55,6 @@ from relay_teams.skills.skill_cli import skills_app
 app = typer.Typer(no_args_is_help=False, pretty_exceptions_enable=False)
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8000"
-_LOCAL_SERVER_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0", "::"}  # nosec B104 - intentional bind to all interfaces for server
 
 
 def _request_json(
@@ -89,8 +91,8 @@ async def _request_json_async(
         headers.update(extra_headers)
 
     try:
-        async with create_async_http_client(
-            proxy_config=load_proxy_env_config(),
+        async with create_cli_http_client(
+            base_url=base_url,
             timeout_seconds=timeout_seconds,
             connect_timeout_seconds=timeout_seconds,
         ) as client:
@@ -120,12 +122,20 @@ async def _request_json_async(
 
 def _is_server_healthy(base_url: str) -> bool:
     health = _get_server_health(base_url)
-    return health is not None and health.status == "ok"
+    return health is not None and _health_payload_indicates_cli_ready(health)
 
 
 async def _is_server_healthy_async(base_url: str) -> bool:
     health = await _get_server_health_async(base_url)
-    return health is not None and health.status == "ok"
+    return health is not None and _health_payload_indicates_cli_ready(health)
+
+
+def _health_payload_indicates_cli_ready(health: ServerHealthPayload) -> bool:
+    if health.background_startup_pending or health.background_startup_failures:
+        return False
+    if health.status == "ok":
+        return True
+    return health.hydrated and health.startup_phase == "ready"
 
 
 def _get_server_health(base_url: str) -> ServerHealthPayload | None:
@@ -219,8 +229,8 @@ def _auto_start_if_needed(
             if not _wait_until_healthy(base_url):
                 raise RuntimeError("Agent Teams server is still starting")
             live_health = _get_server_health(base_url)
-        if live_health is not None and live_health.status == "ok":
-            if host not in _LOCAL_SERVER_HOSTS:
+        if live_health is not None and _health_payload_indicates_cli_ready(live_health):
+            if not is_local_server_host(host):
                 return
             raise_if_runtime_mismatch(
                 health=live_health,
@@ -230,6 +240,10 @@ def _auto_start_if_needed(
                 display_url=base_url,
             )
             return
+        if live_health is not None:
+            failure_names = ", ".join(sorted(live_health.background_startup_failures))
+            failure_detail = f": {failure_names}" if failure_names else ""
+            raise RuntimeError(f"Agent Teams server is unhealthy{failure_detail}")
 
     if not autostart:
         raise RuntimeError(

--- a/src/relay_teams/interfaces/cli/http_client.py
+++ b/src/relay_teams/interfaces/cli/http_client.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+import httpx
+
+from relay_teams.env.proxy_env import ProxyEnvConfig, load_proxy_env_config
+from relay_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
+from relay_teams.net.clients import create_async_http_client
+
+_LOCAL_SERVER_NAMES = frozenset({"localhost"})
+
+
+def is_local_server_host(host: str) -> bool:
+    normalized = host.strip("[]").lower()
+    if normalized in _LOCAL_SERVER_NAMES:
+        return True
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return False
+    return address.is_loopback or address.is_unspecified
+
+
+def is_local_server_base_url(base_url: str) -> bool:
+    parsed = urlparse(base_url)
+    host = parsed.hostname
+    return host is not None and is_local_server_host(host)
+
+
+def create_cli_http_client(
+    *,
+    base_url: str,
+    timeout_seconds: float,
+    connect_timeout_seconds: float | None = None,
+) -> httpx.AsyncClient:
+    timeout = httpx.Timeout(
+        timeout=timeout_seconds,
+        connect=DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
+        if connect_timeout_seconds is None
+        else connect_timeout_seconds,
+    )
+    if is_local_server_base_url(base_url):
+        return create_async_http_client(
+            proxy_config=ProxyEnvConfig(),
+            timeout=timeout,
+        )
+    return create_async_http_client(
+        proxy_config=load_proxy_env_config(),
+        timeout=timeout,
+    )

--- a/src/relay_teams/interfaces/cli/run_prompt_cli.py
+++ b/src/relay_teams/interfaces/cli/run_prompt_cli.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import httpx
 import typer
 
-from relay_teams.env.proxy_env import load_proxy_env_config
-from relay_teams.net.clients import create_async_http_client
+from relay_teams.interfaces.cli.http_client import create_cli_http_client
+from relay_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.session_models import SessionMode
 
@@ -223,9 +223,10 @@ def stream_events(base_url: str, run_id: str, debug: bool) -> None:
 
 async def stream_events_async(base_url: str, run_id: str, debug: bool) -> None:
     try:
-        async with create_async_http_client(
-            proxy_config=load_proxy_env_config(),
+        async with create_cli_http_client(
+            base_url=base_url,
             timeout_seconds=600.0,
+            connect_timeout_seconds=DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS,
         ) as client:
             async with client.stream(
                 "GET",
@@ -266,8 +267,8 @@ async def _request_run_stop_after_interrupt_async(
     run_id: str,
 ) -> bool:
     try:
-        async with create_async_http_client(
-            proxy_config=load_proxy_env_config(),
+        async with create_cli_http_client(
+            base_url=base_url,
             timeout_seconds=10.0,
             connect_timeout_seconds=5.0,
         ) as client:

--- a/src/relay_teams/interfaces/server/app.py
+++ b/src/relay_teams/interfaces/server/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+import importlib
 import json
 import logging
 import os
@@ -13,10 +14,9 @@ import signal
 import sys
 import time
 from types import FrameType
-from typing import Protocol
+from typing import Protocol, cast
 import uuid
 
-from fastapi import FastAPI
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -26,49 +26,19 @@ from starlette.staticfiles import StaticFiles
 from starlette.types import Scope
 
 from relay_teams.builtin.resources import ensure_app_config_bootstrap
-from relay_teams.interfaces.server.async_call import (
-    RouteWorkRejectedError,
-    reset_default_route_work_class,
-    route_work_class_for_http_method,
-    set_default_route_work_class,
-)
 from relay_teams.interfaces.server.config_paths import get_frontend_dist_dir
-from relay_teams.interfaces.server.container import ServerContainer
 from relay_teams.interfaces.server.public_access import (
     is_public_access_guard_enabled,
     is_public_host_allowed_request,
     public_access_denied_detail,
     request_uses_public_host,
 )
-from relay_teams.interfaces.server.routers import (
-    a2a_internal,
-    artifacts_router,
-    audit,
-    auto_harness,
-    automation,
-    boards,
-    commands,
-    connectors,
-    feishu_gateway,
-    gateway,
-    guardrails_router,
-    logs,
-    mcp,
-    memories,
-    observability,
-    prompts,
-    roles,
-    runs,
-    session_media,
-    sessions,
-    speech,
-    system,
-    tasks,
-    triggers,
-    workspaces,
+from relay_teams.interfaces.server.runtime_contracts import (
+    HydratedHealthPayloadBuilder,
+    HydrationBundle,
+    RuntimeContainer,
 )
-from relay_teams.interfaces.server.runtime_identity import build_server_health_payload
-from relay_teams.logger import configure_logging, shutdown_logging
+from relay_teams.logger import shutdown_logging
 from relay_teams.paths import get_app_config_dir
 from relay_teams.trace import bind_trace_context
 
@@ -76,6 +46,7 @@ SERVER_VERSION = "0.1.0"
 SERVICE_INITIALIZING = "service_initializing"
 HYDRATION_READ_WAIT_SECONDS = 0.0
 HYDRATION_MUTATION_WAIT_SECONDS = 0.0
+_RUNTIME_BUNDLE_MODULE = "relay_teams.interfaces.server.runtime_bundle"
 
 logger = logging.getLogger("relay_teams.bootstrap.server")
 FRONTEND_DIST_DIR = get_frontend_dist_dir()
@@ -117,20 +88,6 @@ _RUNTIME_SHADOW_BOOTSTRAP_PATHS = frozenset(
         "/api/roles:options",
     )
 )
-
-
-class RuntimeContainer(Protocol):
-    async def start(self) -> None:
-        pass
-
-    async def stop(self) -> None:
-        pass
-
-
-class HydrationBundle:
-    def __init__(self, *, container: RuntimeContainer, api_app: Starlette) -> None:
-        self.container = container
-        self.api_app = api_app
 
 
 class HydrationGateMiddleware(BaseHTTPMiddleware):
@@ -407,6 +364,17 @@ async def tracing_middleware(request: Request, call_next: RequestHandler) -> Res
         return response
 
 
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    _log_event(
+        logging.ERROR,
+        event="http.request.failed",
+        message="Unhandled server exception",
+        payload={"method": request.method, "path": request.url.path},
+        exc_info=exc,
+    )
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+
 async def route_work_rejected_handler(
     request: Request,
     exc: Exception,
@@ -419,17 +387,6 @@ async def route_work_rejected_handler(
         exc_info=exc,
     )
     return JSONResponse(status_code=503, content={"detail": str(exc)})
-
-
-async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    _log_event(
-        logging.ERROR,
-        event="http.request.failed",
-        message="Unhandled server exception",
-        payload={"method": request.method, "path": request.url.path},
-        exc_info=exc,
-    )
-    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
 
 app.add_route("/api/system/health", bootstrap_health, methods=["GET"])
@@ -467,6 +424,7 @@ async def _hydrate_runtime(app: Starlette, config_dir: Path) -> None:
         bundle = await asyncio.to_thread(_build_hydration_bundle, config_dir)
         app.state.startup_phase = "starting_runtime"
         app.state.container = bundle.container
+        app.state.health_payload_builder = bundle.health_payload_builder
         await bundle.container.start()
         app.state.startup_phase = "mounting_routes"
         bundle.api_app.state.startup_phase = "ready"
@@ -492,6 +450,7 @@ async def _hydrate_runtime(app: Starlette, config_dir: Path) -> None:
         await _stop_failed_hydration_container(app)
         app.state.startup_phase = "failed"
         app.state.hydration_error = str(exc) or exc.__class__.__name__
+        app.state.health_payload_builder = None
         app.state.components = {"core": "ready", "runtime": "failed"}
         _log_event(
             logging.ERROR,
@@ -518,68 +477,28 @@ async def _stop_failed_hydration_container(starlette_app: Starlette) -> None:
         )
         return
     starlette_app.state.container = None
+    starlette_app.state.health_payload_builder = None
+
+
+class RuntimeBundleModule(Protocol):
+    def build_hydration_bundle(
+        self,
+        *,
+        config_dir: Path,
+        version: str,
+    ) -> HydrationBundle:
+        raise NotImplementedError
 
 
 def _build_hydration_bundle(config_dir: Path) -> HydrationBundle:
-    configure_logging(config_dir=config_dir)
-    container = ServerContainer(config_dir=config_dir)
-    api_app = FastAPI(
-        title="Agent Teams Server",
-        description="REST API for Agent Teams orchestration.",
+    module = cast(
+        RuntimeBundleModule,
+        cast(object, importlib.import_module(_RUNTIME_BUNDLE_MODULE)),
+    )
+    return module.build_hydration_bundle(
+        config_dir=config_dir,
         version=SERVER_VERSION,
     )
-    api_app.state.config_dir = config_dir
-    api_app.state.container = container
-    api_app.state.startup_phase = "starting_runtime"
-    api_app.state.hydrated = False
-    api_app.state.components = {"core": "ready", "runtime": "loading"}
-
-    @api_app.middleware("http")
-    async def route_work_class_middleware(
-        request: Request,
-        call_next: RequestHandler,
-    ) -> Response:
-        token = set_default_route_work_class(
-            route_work_class_for_http_method(request.method)
-        )
-        try:
-            return await call_next(request)
-        finally:
-            reset_default_route_work_class(token)
-
-    api_app.add_exception_handler(RouteWorkRejectedError, route_work_rejected_handler)
-    api_app.add_exception_handler(Exception, global_exception_handler)
-
-    routers = (
-        system.router,
-        audit.router,
-        commands.router,
-        connectors.router,
-        automation.router,
-        auto_harness.router,
-        feishu_gateway.router,
-        gateway.router,
-        mcp.router,
-        observability.router,
-        sessions.router,
-        session_media.router,
-        runs.router,
-        speech.router,
-        triggers.router,
-        artifacts_router.router,
-        tasks.router,
-        roles.router,
-        prompts.router,
-        logs.router,
-        workspaces.router,
-        guardrails_router.router,
-        memories.router,
-        boards.router,
-        a2a_internal.router,
-    )
-    for router in routers:
-        api_app.include_router(router)
-    return HydrationBundle(container=container, api_app=api_app)
 
 
 def _remove_frontend_mount(starlette_app: Starlette) -> list[BaseRoute]:
@@ -610,20 +529,14 @@ def _remove_runtime_shadow_bootstrap_routes(starlette_app: Starlette) -> None:
 def _health_payload(starlette_app: Starlette) -> dict[str, object]:
     config_dir = getattr(starlette_app.state, "config_dir", get_app_config_dir())
     if bool(getattr(starlette_app.state, "hydrated", False)):
-        container: ServerContainer | None = getattr(
-            starlette_app.state, "container", None
+        health_payload_builder: HydratedHealthPayloadBuilder | None = getattr(
+            starlette_app.state,
+            "health_payload_builder",
+            None,
         )
-        payload = (
-            build_server_health_payload(
-                config_dir=config_dir,
-                role_registry=container.role_registry,
-                skill_registry=container.skill_registry,
-                tool_registry=container.tool_registry,
-            )
-            if container is not None
-            else build_server_health_payload(config_dir=config_dir)
-        ).model_dump(mode="json")
+        payload = health_payload_builder() if health_payload_builder is not None else {}
         payload.update(_startup_payload(starlette_app))
+        _apply_background_startup_status(payload)
         return payload
     package_root = Path(__file__).resolve().parents[2]
     builtin_root = package_root / "builtin"
@@ -639,6 +552,13 @@ def _health_payload(starlette_app: Starlette) -> dict[str, object]:
     }
     payload.update(_startup_payload(starlette_app))
     return payload
+
+
+def _apply_background_startup_status(payload: dict[str, object]) -> None:
+    if payload.get("background_startup_failures"):
+        payload["status"] = "failed"
+    elif payload.get("background_startup_pending"):
+        payload["status"] = "starting"
 
 
 def _log_finished_hydration_task_error(task: asyncio.Task[None]) -> None:
@@ -657,12 +577,42 @@ def _log_finished_hydration_task_error(task: asyncio.Task[None]) -> None:
 
 
 def _startup_payload(starlette_app: Starlette) -> dict[str, object]:
+    components = dict(getattr(starlette_app.state, "components", {"core": "ready"}))
+    background_startup_failures = _background_startup_failures(starlette_app)
+    background_startup_pending = _background_startup_pending(starlette_app)
+    if background_startup_failures:
+        components["background_services"] = "failed"
+    elif background_startup_pending:
+        components["background_services"] = "loading"
     return {
         "startup_phase": getattr(starlette_app.state, "startup_phase", "bootstrap"),
         "hydrated": bool(getattr(starlette_app.state, "hydrated", False)),
-        "components": getattr(starlette_app.state, "components", {"core": "ready"}),
+        "components": components,
+        "background_startup_pending": background_startup_pending,
+        "background_startup_failures": background_startup_failures,
         "error": getattr(starlette_app.state, "hydration_error", None),
     }
+
+
+def _background_startup_failures(starlette_app: Starlette) -> dict[str, str]:
+    container: object | None = getattr(starlette_app.state, "container", None)
+    failures: object = getattr(
+        container,
+        "runtime_background_startup_failures",
+        {},
+    )
+    if not isinstance(failures, dict):
+        return {}
+    normalized: dict[str, str] = {}
+    for service_name, failure in failures.items():
+        if isinstance(service_name, str) and isinstance(failure, str):
+            normalized[service_name] = failure
+    return normalized
+
+
+def _background_startup_pending(starlette_app: Starlette) -> bool:
+    container: object | None = getattr(starlette_app.state, "container", None)
+    return bool(getattr(container, "runtime_background_startup_pending", False))
 
 
 def _component_for_path(path: str) -> str:

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable, Mapping
 import logging
 from pathlib import Path
 import sqlite3
@@ -1288,6 +1288,17 @@ class ServerContainer:
             self.wechat_inbound_queue_repo,
         )
         self._startup_background_tasks: set[asyncio.Task[None]] = set()
+        self._noncancelable_startup_background_tasks: set[asyncio.Task[None]] = set()
+        self._runtime_background_startup_failures: dict[str, str] = {}
+        self._runtime_background_startup_pending = False
+
+    @property
+    def runtime_background_startup_failures(self) -> Mapping[str, str]:
+        return self._runtime_background_startup_failures.copy()
+
+    @property
+    def runtime_background_startup_pending(self) -> bool:
+        return self._runtime_background_startup_pending
 
     def _build_runtime_services(self) -> None:
         def get_task_execution_service() -> TaskExecutionService:
@@ -1549,26 +1560,91 @@ class ServerContainer:
         self.mcp_config_file_watcher.start()
         self.run_service.bind_event_loop(asyncio.get_running_loop())
         self.background_task_service.bind_completion_sink(self.run_service)
-        await self.discord_gateway_service.start_async()
-        await self._start_sync_service(
-            service_name="wechat_gateway",
-            start=self.wechat_gateway_service.start,
+        self._runtime_background_startup_pending = True
+        task = asyncio.create_task(
+            self._start_runtime_background_services(),
+            name="server-runtime-background-services-startup",
         )
-        await self._start_sync_service(
-            service_name="xiaoluban_im_listener",
-            start=self.xiaoluban_im_listener_service.start,
-        )
-        self._start_sync_service_background(
-            service_name="feishu_subscription",
-            start=self.feishu_subscription_service.start,
-        )
-        await self.feishu_message_pool_service.start()
-        await self.automation_delivery_worker.start()
-        await self.automation_bound_session_queue_worker.start()
-        await self.github_trigger_action_worker.start()
-        await self.board_todo_service.start()
-        await self.automation_scheduler_service.start()
+        self._startup_background_tasks.add(task)
+        self._noncancelable_startup_background_tasks.add(task)
         return None
+
+    async def _start_runtime_background_services(self) -> None:
+        try:
+            await self._run_runtime_service_startup_step(
+                "discord_gateway_service",
+                self.discord_gateway_service.start_async,
+            )
+            await self._run_runtime_service_startup_step(
+                "wechat_gateway_service",
+                self._start_wechat_gateway_service,
+            )
+            await self._run_runtime_service_startup_step(
+                "xiaoluban_im_listener_service",
+                self._start_xiaoluban_im_listener_service,
+            )
+            await self._run_runtime_service_startup_step(
+                "feishu_subscription_service",
+                self._start_feishu_subscription_service,
+            )
+            await self._run_runtime_service_startup_step(
+                "feishu_message_pool_service",
+                self.feishu_message_pool_service.start,
+            )
+            await self._run_runtime_service_startup_step(
+                "automation_delivery_worker",
+                self.automation_delivery_worker.start,
+            )
+            await self._run_runtime_service_startup_step(
+                "automation_bound_session_queue_worker",
+                self.automation_bound_session_queue_worker.start,
+            )
+            await self._run_runtime_service_startup_step(
+                "github_trigger_action_worker",
+                self.github_trigger_action_worker.start,
+            )
+            await self._run_runtime_service_startup_step(
+                "board_todo_service",
+                self.board_todo_service.start,
+            )
+            await self._run_runtime_service_startup_step(
+                "automation_scheduler_service",
+                self.automation_scheduler_service.start,
+            )
+        finally:
+            self._runtime_background_startup_pending = False
+
+    async def _run_runtime_service_startup_step(
+        self,
+        service_name: str,
+        start_step: Callable[[], Awaitable[None]],
+    ) -> None:
+        try:
+            await start_step()
+        except asyncio.CancelledError:
+            raise
+        except (OSError, RuntimeError, ValueError, sqlite3.Error):
+            self._runtime_background_startup_failures[service_name] = "start_failed"
+            LOGGER.warning(
+                "Runtime background service failed to start: %s",
+                service_name,
+                exc_info=True,
+            )
+        except (ImportError, AttributeError):
+            self._runtime_background_startup_failures[service_name] = "start_failed"
+            LOGGER.exception(
+                "Runtime background service failed unexpectedly during startup: %s",
+                service_name,
+            )
+
+    async def _start_wechat_gateway_service(self) -> None:
+        await asyncio.to_thread(self.wechat_gateway_service.start)
+
+    async def _start_xiaoluban_im_listener_service(self) -> None:
+        await asyncio.to_thread(self.xiaoluban_im_listener_service.start)
+
+    async def _start_feishu_subscription_service(self) -> None:
+        await asyncio.to_thread(self.feishu_subscription_service.start)
 
     async def _start_sync_service(
         self,
@@ -1704,6 +1780,8 @@ class ServerContainer:
 
     def _cancel_startup_background_tasks(self) -> None:
         for task in tuple(self._startup_background_tasks):
+            if task in self._noncancelable_startup_background_tasks:
+                continue
             task.cancel()
 
     async def _drain_startup_background_tasks(self) -> None:
@@ -1720,6 +1798,7 @@ class ServerContainer:
                     exc_info=(type(result), result, result.__traceback__),
                 )
         self._startup_background_tasks.difference_update(tasks)
+        self._noncancelable_startup_background_tasks.difference_update(tasks)
 
     async def _close_async_repositories(self) -> None:
         for repository in reversed(self._async_closeables):

--- a/src/relay_teams/interfaces/server/runtime_bundle.py
+++ b/src/relay_teams/interfaces/server/runtime_bundle.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from relay_teams.interfaces.server.async_call import (
+    RouteWorkRejectedError,
+    reset_default_route_work_class,
+    route_work_class_for_http_method,
+    set_default_route_work_class,
+)
+from relay_teams.interfaces.server.container import ServerContainer
+from relay_teams.interfaces.server.routers import (
+    a2a_internal,
+    artifacts_router,
+    audit,
+    auto_harness,
+    automation,
+    boards,
+    commands,
+    connectors,
+    feishu_gateway,
+    gateway,
+    guardrails_router,
+    logs,
+    mcp,
+    memories,
+    observability,
+    prompts,
+    roles,
+    runs,
+    session_media,
+    sessions,
+    speech,
+    system,
+    tasks,
+    triggers,
+    workspaces,
+)
+from relay_teams.interfaces.server.runtime_contracts import HydrationBundle
+from relay_teams.interfaces.server.runtime_identity import build_server_health_payload
+from relay_teams.logger import configure_logging, get_logger, log_event
+
+RequestHandler = Callable[[Request], Awaitable[Response]]
+
+logger = get_logger(__name__)
+
+
+def build_hydration_bundle(*, config_dir: Path, version: str) -> HydrationBundle:
+    configure_logging(config_dir=config_dir)
+    container = ServerContainer(config_dir=config_dir)
+    api_app = FastAPI(
+        title="Agent Teams Server",
+        description="REST API for Agent Teams orchestration.",
+        version=version,
+    )
+    api_app.state.config_dir = config_dir
+    api_app.state.container = container
+    api_app.state.startup_phase = "starting_runtime"
+    api_app.state.hydrated = False
+    api_app.state.components = {"core": "ready", "runtime": "loading"}
+
+    @api_app.middleware("http")
+    async def route_work_class_middleware(
+        request: Request,
+        call_next: RequestHandler,
+    ) -> Response:
+        token = set_default_route_work_class(
+            route_work_class_for_http_method(request.method)
+        )
+        try:
+            return await call_next(request)
+        finally:
+            reset_default_route_work_class(token)
+
+    api_app.add_exception_handler(RouteWorkRejectedError, route_work_rejected_handler)
+    api_app.add_exception_handler(Exception, global_exception_handler)
+
+    routers = (
+        system.router,
+        audit.router,
+        commands.router,
+        connectors.router,
+        automation.router,
+        auto_harness.router,
+        feishu_gateway.router,
+        gateway.router,
+        mcp.router,
+        observability.router,
+        sessions.router,
+        session_media.router,
+        runs.router,
+        speech.router,
+        triggers.router,
+        artifacts_router.router,
+        tasks.router,
+        roles.router,
+        prompts.router,
+        logs.router,
+        workspaces.router,
+        guardrails_router.router,
+        memories.router,
+        boards.router,
+        a2a_internal.router,
+    )
+    for router in routers:
+        api_app.include_router(router)
+
+    def health_payload_builder() -> dict[str, object]:
+        payload = build_server_health_payload(
+            config_dir=config_dir,
+            role_registry=container.role_registry,
+            skill_registry=container.skill_registry,
+            tool_registry=container.tool_registry,
+        ).model_dump(mode="json")
+        return dict(payload)
+
+    return HydrationBundle(
+        container=container,
+        api_app=api_app,
+        health_payload_builder=health_payload_builder,
+    )
+
+
+async def route_work_rejected_handler(
+    request: Request,
+    exc: Exception,
+) -> JSONResponse:
+    log_event(
+        logger,
+        logging.WARNING,
+        event="http.request.shed",
+        message="Server shed route work under load",
+        payload={"method": request.method, "path": request.url.path},
+        exc_info=exc,
+    )
+    return JSONResponse(status_code=503, content={"detail": str(exc)})
+
+
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    log_event(
+        logger,
+        logging.ERROR,
+        event="http.request.failed",
+        message="Unhandled server exception",
+        payload={"method": request.method, "path": request.url.path},
+        exc_info=exc,
+    )
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})

--- a/src/relay_teams/interfaces/server/runtime_contracts.py
+++ b/src/relay_teams/interfaces/server/runtime_contracts.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from starlette.applications import Starlette
+
+
+class RuntimeContainer(Protocol):
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+
+HydratedHealthPayloadBuilder = Callable[[], dict[str, object]]
+
+
+class HydrationBundle:
+    def __init__(
+        self,
+        *,
+        container: RuntimeContainer,
+        api_app: Starlette,
+        health_payload_builder: HydratedHealthPayloadBuilder | None = None,
+    ) -> None:
+        self.container = container
+        self.api_app = api_app
+        self.health_payload_builder = (
+            (lambda: {}) if health_payload_builder is None else health_payload_builder
+        )

--- a/src/relay_teams/interfaces/server/runtime_identity.py
+++ b/src/relay_teams/interfaces/server/runtime_identity.py
@@ -77,6 +77,8 @@ class ServerHealthPayload(BaseModel):
     startup_phase: str = "ready"
     hydrated: bool = True
     components: dict[str, str] = Field(default_factory=dict)
+    background_startup_pending: bool = False
+    background_startup_failures: dict[str, str] = Field(default_factory=dict)
     error: str | None = None
 
 

--- a/tests/unit_tests/feishu/test_subscription_service.py
+++ b/tests/unit_tests/feishu/test_subscription_service.py
@@ -504,6 +504,66 @@ async def test_feishu_ws_controller_get_conn_url_uses_net_http_client(
     assert ws_client.configured_ping_interval == 45
 
 
+@pytest.mark.asyncio
+async def test_feishu_ws_controller_connect_client_sets_connection_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _FeishuWsController(
+        runtime_config=_build_runtime(
+            trigger_id="trg_a",
+            name="bot_a",
+            app_id="cli_demo",
+            app_name="bot-a",
+            app_secret="secret-demo",
+        ),
+        event_handler=_FakeHandler(),
+    )
+    connection = _FakeWsConnection()
+    connected_urls: list[str] = []
+
+    async def _get_conn_url(_client: WsClientLike) -> str:
+        return "wss://open.feishu.cn/ws?device_id=device-1&service_id=7"
+
+    class _FakeWebsockets:
+        async def connect(
+            self,
+            url: str,
+            *,
+            proxy: str | None,
+            ssl: object,
+        ) -> _FakeWsConnection:
+            _ = (proxy, ssl)
+            connected_urls.append(url)
+            return connection
+
+    class _FakeLogger:
+        def info(self, message: str) -> None:
+            assert message == (
+                "connected to wss://open.feishu.cn/ws?device_id=device-1&service_id=7"
+            )
+
+    ws_client_module = SimpleNamespace(
+        websockets=_FakeWebsockets(),
+        logger=_FakeLogger(),
+    )
+    monkeypatch.setattr(controller, "_get_conn_url", _get_conn_url)
+    monkeypatch.setattr(
+        "relay_teams.gateway.feishu.subscription_service.import_lark_ws_client_module",
+        lambda: ws_client_module,
+    )
+    ws_client = _FakeWsClient()
+
+    await controller._connect_client(cast(WsClientLike, ws_client))
+
+    assert connected_urls == ["wss://open.feishu.cn/ws?device_id=device-1&service_id=7"]
+    assert ws_client._conn is connection
+    assert ws_client._conn_url == (
+        "wss://open.feishu.cn/ws?device_id=device-1&service_id=7"
+    )
+    assert ws_client._conn_id == "device-1"
+    assert ws_client._service_id == "7"
+
+
 def test_feishu_ws_controller_http_client_uses_runtime_net_proxy_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/feishu/test_trigger_handler.py
+++ b/tests/unit_tests/feishu/test_trigger_handler.py
@@ -10,7 +10,6 @@ from typing import cast
 
 import pytest
 
-import relay_teams.gateway.feishu.trigger_handler as trigger_handler_module
 from relay_teams.gateway.feishu.models import (
     FeishuChatQueueClearResult,
     FeishuChatQueueItemPreview,
@@ -36,10 +35,6 @@ from relay_teams.sessions.session_service import SessionService
 from relay_teams.sessions.runs.run_service import SessionRunService
 from relay_teams.sessions.runs.run_models import IntentInput, RunThinkingConfig
 from relay_teams.sessions.session_models import SessionMode, SessionRecord
-
-trigger_handler_module._sdk_event_payload = lambda event: cast(
-    dict[str, object], getattr(event, "_payload")
-)
 
 if TYPE_CHECKING:
     from lark_oapi.event.dispatcher_handler import P2ImMessageReceiveV1
@@ -172,7 +167,6 @@ def _build_sdk_event(raw_body: str) -> P2ImMessageReceiveV1:
             ),
         ),
     )
-    setattr(event, "_payload", payload)
     return event
 
 

--- a/tests/unit_tests/interfaces/cli/test_prompts_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_prompts_commands.py
@@ -338,14 +338,14 @@ async def test_run_prompt_stream_events_async_reads_sse_lines(
     )
     captured_kwargs: dict[str, object] = {}
 
-    def fake_create_async_http_client(**kwargs: object) -> _FakePromptHttpClient:
+    def fake_create_cli_http_client(**kwargs: object) -> _FakePromptHttpClient:
         captured_kwargs.update(kwargs)
         return fake_client
 
     monkeypatch.setattr(
         prompt_cli,
-        "create_async_http_client",
-        fake_create_async_http_client,
+        "create_cli_http_client",
+        fake_create_cli_http_client,
     )
 
     await prompt_cli.stream_events_async(
@@ -362,7 +362,11 @@ async def test_run_prompt_stream_events_async_reads_sse_lines(
             {"Accept": "text/event-stream"},
         )
     ]
-    assert captured_kwargs["timeout_seconds"] == 600.0
+    assert captured_kwargs == {
+        "base_url": "http://127.0.0.1:8000/",
+        "timeout_seconds": 600.0,
+        "connect_timeout_seconds": prompt_cli.DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS,
+    }
 
 
 @pytest.mark.asyncio
@@ -373,14 +377,14 @@ async def test_run_prompt_stream_events_async_reports_http_errors(monkeypatch) -
         stream=_FakeAsyncByteStream(b"failed"),
     )
 
-    def fake_create_async_http_client(**kwargs: object) -> _FakePromptHttpClient:
+    def fake_create_cli_http_client(**kwargs: object) -> _FakePromptHttpClient:
         _ = kwargs
         return _FakePromptHttpClient([], error_response=response)
 
     monkeypatch.setattr(
         prompt_cli,
-        "create_async_http_client",
-        fake_create_async_http_client,
+        "create_cli_http_client",
+        fake_create_cli_http_client,
     )
 
     with pytest.raises(
@@ -409,7 +413,7 @@ def test_run_prompt_stream_events_requests_stop_on_keyboard_interrupt(
         _ = (base_url, run_id, debug)
         raise KeyboardInterrupt
 
-    def fake_create_async_http_client(**kwargs: object) -> _FakePromptHttpClient:
+    def fake_create_cli_http_client(**kwargs: object) -> _FakePromptHttpClient:
         _ = kwargs
         return fake_client
 
@@ -420,8 +424,8 @@ def test_run_prompt_stream_events_requests_stop_on_keyboard_interrupt(
     )
     monkeypatch.setattr(
         prompt_cli,
-        "create_async_http_client",
-        fake_create_async_http_client,
+        "create_cli_http_client",
+        fake_create_cli_http_client,
     )
 
     with pytest.raises(typer.Exit) as exc_info:
@@ -470,14 +474,14 @@ async def test_request_run_stop_after_interrupt_async_returns_false_for_missing_
 ) -> None:
     fake_client = _FakePromptHttpClient([], post_status_code=404)
 
-    def fake_create_async_http_client(**kwargs: object) -> _FakePromptHttpClient:
+    def fake_create_cli_http_client(**kwargs: object) -> _FakePromptHttpClient:
         _ = kwargs
         return fake_client
 
     monkeypatch.setattr(
         prompt_cli,
-        "create_async_http_client",
-        fake_create_async_http_client,
+        "create_cli_http_client",
+        fake_create_cli_http_client,
     )
 
     requested = await prompt_cli._request_run_stop_after_interrupt_async(
@@ -505,14 +509,14 @@ async def test_request_run_stop_after_interrupt_async_returns_false_on_request_e
         post_error=httpx.ConnectError("offline", request=request),
     )
 
-    def fake_create_async_http_client(**kwargs: object) -> _FakePromptHttpClient:
+    def fake_create_cli_http_client(**kwargs: object) -> _FakePromptHttpClient:
         _ = kwargs
         return fake_client
 
     monkeypatch.setattr(
         prompt_cli,
-        "create_async_http_client",
-        fake_create_async_http_client,
+        "create_cli_http_client",
+        fake_create_cli_http_client,
     )
 
     requested = await prompt_cli._request_run_stop_after_interrupt_async(

--- a/tests/unit_tests/interfaces/cli/test_server_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_server_commands.py
@@ -10,7 +10,9 @@ from typing import Optional
 import httpx
 from typer.testing import CliRunner
 
+from relay_teams.interfaces.cli import app as root_cli
 from relay_teams.interfaces.cli import app_full
+from relay_teams.interfaces.cli import http_client as cli_http_client
 from relay_teams.interfaces.server import cli as server_cli
 from relay_teams.interfaces.server.runtime_identity import (
     ServerHealthPayload,
@@ -469,28 +471,104 @@ def test_server_cli_get_server_health_async_uses_async_http_client(monkeypatch) 
     assert captured_kwargs["connect_timeout_seconds"] == 1.5
 
 
+def test_server_health_payload_accepts_background_startup_state() -> None:
+    payload = _health_payload().model_dump()
+    payload["components"] = {"background_services": "loading"}
+    payload["background_startup_pending"] = True
+    payload["background_startup_failures"] = {}
+
+    health = ServerHealthPayload.model_validate(payload)
+
+    assert health.status == "ok"
+    assert health.background_startup_pending is True
+    assert health.background_startup_failures == {}
+
+
+def test_root_cli_ready_rejects_hydrated_background_startup_pending() -> None:
+    health = _health_payload(status="starting")
+    health.hydrated = True
+    health.startup_phase = "ready"
+    health.background_startup_pending = True
+
+    assert not app_full._health_payload_indicates_cli_ready(health)
+
+
+def test_lightweight_root_cli_ready_rejects_background_startup_pending() -> None:
+    payload = _health_payload(status="starting").model_dump(mode="json")
+    payload["hydrated"] = True
+    payload["startup_phase"] = "ready"
+    payload["background_startup_pending"] = True
+
+    assert not root_cli._health_payload_indicates_ready(payload)
+
+
+def test_root_cli_ready_rejects_background_startup_failures() -> None:
+    health = _health_payload(status="failed")
+    health.hydrated = True
+    health.startup_phase = "ready"
+    health.background_startup_failures = {"feishu_message_pool_service": "start_failed"}
+
+    assert not app_full._health_payload_indicates_cli_ready(health)
+
+
+def test_root_cli_autostart_rejects_live_background_startup_failure(
+    monkeypatch,
+) -> None:
+    health = _health_payload(status="failed")
+    health.hydrated = True
+    health.startup_phase = "ready"
+    health.background_startup_failures = {"feishu_message_pool_service": "start_failed"}
+    started: list[tuple[str, int]] = []
+
+    monkeypatch.setattr(app_full, "_get_server_health", lambda base_url: health)
+    monkeypatch.setattr(
+        app_full,
+        "_start_server_daemon",
+        lambda host, port, daemon=False: started.append((host, port)),
+    )
+
+    try:
+        app_full._auto_start_if_needed(
+            "http://127.0.0.1:8000", autostart=True, daemon=False, force=False
+        )
+    except RuntimeError as exc:
+        assert "Agent Teams server is unhealthy" in str(exc)
+        assert "feishu_message_pool_service" in str(exc)
+    else:
+        raise AssertionError("root CLI should reject unhealthy live local servers")
+
+    assert started == []
+
+
+def test_cli_http_client_treats_loopback_base_url_as_local() -> None:
+    assert cli_http_client.is_local_server_base_url("http://127.0.0.1:8000")
+    assert cli_http_client.is_local_server_base_url("http://localhost:8000")
+    assert cli_http_client.is_local_server_base_url("http://0.0.0.0:8000")
+    assert not cli_http_client.is_local_server_base_url("https://agent.example.test")
+
+
 def test_cli_request_json_async_applies_timeout_to_connect_phase(monkeypatch) -> None:
     response = httpx.Response(
         200,
         json={"status": "ok"},
-        request=httpx.Request("GET", "http://127.0.0.1:8000/api/system/health"),
+        request=httpx.Request("GET", "https://agent.example.test/api/system/health"),
     )
     fake_client = _FakeCliRequestJsonClient(response)
     captured_kwargs: dict[str, object] = {}
 
-    def fake_create_async_http_client(**kwargs: object) -> _FakeCliRequestJsonClient:
+    def fake_create_cli_http_client(**kwargs: object) -> _FakeCliRequestJsonClient:
         captured_kwargs.update(kwargs)
         return fake_client
 
     monkeypatch.setattr(
         app_full,
-        "create_async_http_client",
-        fake_create_async_http_client,
+        "create_cli_http_client",
+        fake_create_cli_http_client,
     )
 
     payload = asyncio.run(
         app_full._request_json_async(
-            base_url="http://127.0.0.1:8000",
+            base_url="https://agent.example.test",
             method="GET",
             path="/api/system/health",
             timeout_seconds=1.5,
@@ -498,8 +576,11 @@ def test_cli_request_json_async_applies_timeout_to_connect_phase(monkeypatch) ->
     )
 
     assert payload == {"status": "ok"}
-    assert captured_kwargs["timeout_seconds"] == 1.5
-    assert captured_kwargs["connect_timeout_seconds"] == 1.5
+    assert captured_kwargs == {
+        "base_url": "https://agent.example.test",
+        "timeout_seconds": 1.5,
+        "connect_timeout_seconds": 1.5,
+    }
 
 
 def test_server_cli_get_server_health_async_returns_none_on_http_error(

--- a/tests/unit_tests/interfaces/server/test_app.py
+++ b/tests/unit_tests/interfaces/server/test_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import builtins
+import importlib
 import json
 import logging
 import signal
@@ -888,6 +889,66 @@ def test_build_hydration_bundle_wires_runtime_app_with_fake_modules(
         async def stop(self) -> None:
             return None
 
+    def _build_hydration_bundle(
+        *,
+        config_dir: Path,
+        version: str,
+    ) -> server_app.HydrationBundle:
+        api_app = FastAPI(version=version)
+        api_app.state.config_dir = config_dir
+        api_app.state.container = FakeServerContainer(config_dir=config_dir)
+        api_app.state.components = {"core": "ready", "runtime": "loading"}
+        return server_app.HydrationBundle(
+            container=cast(server_app.RuntimeContainer, api_app.state.container),
+            api_app=api_app,
+        )
+
+    fake_runtime_bundle_module = ModuleType(
+        "relay_teams.interfaces.server.runtime_bundle"
+    )
+    setattr(
+        fake_runtime_bundle_module, "build_hydration_bundle", _build_hydration_bundle
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "relay_teams.interfaces.server.runtime_bundle",
+        fake_runtime_bundle_module,
+    )
+
+    bundle = server_app._build_hydration_bundle(tmp_path)
+
+    assert isinstance(bundle.api_app, FastAPI)
+    assert bundle.api_app.state.config_dir == tmp_path
+    assert bundle.api_app.state.container.config_dir == tmp_path
+    assert bundle.api_app.state.components == {"core": "ready", "runtime": "loading"}
+
+    @bundle.api_app.get("/probe")
+    async def probe() -> dict[str, bool]:
+        return {"ok": True}
+
+    response = TestClient(bundle.api_app).get("/probe")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_runtime_bundle_wires_runtime_app_with_fake_modules(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeServerContainer:
+        role_registry = object()
+        skill_registry = object()
+        tool_registry = object()
+
+        def __init__(self, *, config_dir: Path) -> None:
+            self.config_dir = config_dir
+
+    class FakeHealthPayload:
+        def model_dump(self, *, mode: str) -> dict[str, object]:
+            assert mode == "json"
+            return {"status": "ok", "config_dir": "runtime"}
+
     fake_container_module = ModuleType("relay_teams.interfaces.server.container")
     setattr(fake_container_module, "ServerContainer", FakeServerContainer)
     monkeypatch.setitem(
@@ -896,19 +957,22 @@ def test_build_hydration_bundle_wires_runtime_app_with_fake_modules(
         fake_container_module,
     )
 
-    fake_logger_module = ModuleType("relay_teams.logger")
-    setattr(fake_logger_module, "configure_logging", lambda *, config_dir: None)
-    setattr(
-        fake_logger_module,
-        "get_logger",
-        lambda _name, **_kwargs: logging.getLogger("fake-router"),
+    fake_runtime_identity_module = ModuleType(
+        "relay_teams.interfaces.server.runtime_identity"
     )
-    setattr(fake_logger_module, "log_event", lambda *_args, **_kwargs: None)
-    monkeypatch.setitem(sys.modules, "relay_teams.logger", fake_logger_module)
+    setattr(
+        fake_runtime_identity_module,
+        "build_server_health_payload",
+        lambda **_kwargs: FakeHealthPayload(),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "relay_teams.interfaces.server.runtime_identity",
+        fake_runtime_identity_module,
+    )
 
-    from relay_teams.interfaces.server import routers as routers_package
-
-    router_names = (
+    fake_routers_package = ModuleType("relay_teams.interfaces.server.routers")
+    for name in (
         "a2a_internal",
         "artifacts_router",
         "audit",
@@ -934,29 +998,58 @@ def test_build_hydration_bundle_wires_runtime_app_with_fake_modules(
         "tasks",
         "triggers",
         "workspaces",
+    ):
+        setattr(fake_routers_package, name, SimpleNamespace(router=APIRouter()))
+    monkeypatch.setitem(
+        sys.modules,
+        "relay_teams.interfaces.server.routers",
+        fake_routers_package,
     )
-    for name in router_names:
-        monkeypatch.setattr(
-            routers_package,
-            name,
-            SimpleNamespace(router=APIRouter()),
-        )
+    monkeypatch.delitem(
+        sys.modules,
+        "relay_teams.interfaces.server.runtime_bundle",
+        raising=False,
+    )
 
-    bundle = server_app._build_hydration_bundle(tmp_path)
+    runtime_bundle = importlib.import_module(
+        "relay_teams.interfaces.server.runtime_bundle"
+    )
+
+    bundle = runtime_bundle.build_hydration_bundle(
+        config_dir=tmp_path,
+        version="test-version",
+    )
 
     assert isinstance(bundle.api_app, FastAPI)
-    assert bundle.api_app.state.config_dir == tmp_path
+    assert bundle.api_app.version == "test-version"
     assert bundle.api_app.state.container.config_dir == tmp_path
-    assert bundle.api_app.state.components == {"core": "ready", "runtime": "loading"}
+    assert bundle.health_payload_builder()["status"] == "ok"
 
     @bundle.api_app.get("/probe")
-    async def probe() -> dict[str, bool]:
+    async def probe_runtime_bundle() -> dict[str, bool]:
         return {"ok": True}
 
     response = TestClient(bundle.api_app).get("/probe")
 
     assert response.status_code == 200
     assert response.json() == {"ok": True}
+
+    request = SimpleNamespace(method="POST", url=SimpleNamespace(path="/api/runs"))
+    rejected = asyncio.run(
+        runtime_bundle.route_work_rejected_handler(
+            cast(server_app.Request, request),
+            RuntimeError("shed"),
+        )
+    )
+    failed = asyncio.run(
+        runtime_bundle.global_exception_handler(
+            cast(server_app.Request, request),
+            RuntimeError("boom"),
+        )
+    )
+
+    assert rejected.status_code == 503
+    assert failed.status_code == 500
 
 
 def test_component_for_path_extracts_api_component() -> None:
@@ -1191,19 +1284,8 @@ def test_middleware_classes_delegate_to_shared_functions(
 
 
 def test_health_payload_uses_runtime_identity_after_hydration(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    class FakeHealthPayload:
-        def model_dump(self, *, mode: str) -> dict[str, object]:
-            assert mode == "json"
-            return {"status": "ok", "config_dir": "runtime"}
-
-    class FakeContainer:
-        role_registry = object()
-        skill_registry = object()
-        tool_registry = object()
-
     app = server_app.Starlette()
     app.state.config_dir = tmp_path
     app.state.started_at = 1.0
@@ -1211,39 +1293,103 @@ def test_health_payload_uses_runtime_identity_after_hydration(
     app.state.hydrated = True
     app.state.components = {"core": "ready", "runtime": "ready"}
     app.state.hydration_error = None
-    app.state.container = FakeContainer()
-
-    calls: list[tuple[object, object, object]] = []
-
-    def fake_build_server_health_payload(
-        *,
-        config_dir: Path,
-        role_registry: object | None = None,
-        skill_registry: object | None = None,
-        tool_registry: object | None = None,
-    ) -> FakeHealthPayload:
-        assert config_dir == tmp_path
-        calls.append((role_registry, skill_registry, tool_registry))
-        return FakeHealthPayload()
-
-    monkeypatch.setattr(
-        server_app,
-        "build_server_health_payload",
-        fake_build_server_health_payload,
-    )
+    app.state.health_payload_builder = lambda: {
+        "status": "ok",
+        "config_dir": "runtime",
+    }
 
     payload = server_app._health_payload(app)
 
     assert payload["status"] == "ok"
     assert payload["startup_phase"] == "ready"
     assert payload["hydrated"] is True
-    assert calls == [
-        (
-            FakeContainer.role_registry,
-            FakeContainer.skill_registry,
-            FakeContainer.tool_registry,
-        )
-    ]
+    assert payload["config_dir"] == "runtime"
+
+
+def test_health_payload_marks_background_startup_pending_as_starting() -> None:
+    app = server_app.Starlette()
+    app.state.startup_phase = "ready"
+    app.state.hydrated = True
+    app.state.components = {"core": "ready", "runtime": "ready"}
+    app.state.hydration_error = None
+    app.state.health_payload_builder = lambda: {"status": "ok"}
+    app.state.container = SimpleNamespace(
+        runtime_background_startup_pending=True,
+        runtime_background_startup_failures={},
+    )
+
+    payload = server_app._health_payload(app)
+
+    assert payload["status"] == "starting"
+    assert payload["background_startup_pending"] is True
+
+
+def test_health_payload_marks_background_startup_failures_as_failed() -> None:
+    app = server_app.Starlette()
+    app.state.startup_phase = "ready"
+    app.state.hydrated = True
+    app.state.components = {"core": "ready", "runtime": "ready"}
+    app.state.hydration_error = None
+    app.state.health_payload_builder = lambda: {"status": "ok"}
+    app.state.container = SimpleNamespace(
+        runtime_background_startup_pending=False,
+        runtime_background_startup_failures={
+            "feishu_message_pool_service": "start_failed"
+        },
+    )
+
+    payload = server_app._health_payload(app)
+
+    assert payload["status"] == "failed"
+    assert payload["background_startup_failures"] == {
+        "feishu_message_pool_service": "start_failed"
+    }
+
+
+def test_startup_payload_surfaces_background_service_failures() -> None:
+    app = server_app.Starlette()
+    app.state.startup_phase = "ready"
+    app.state.hydrated = True
+    app.state.components = {"core": "ready", "runtime": "ready"}
+    app.state.hydration_error = None
+    app.state.container = SimpleNamespace(
+        runtime_background_startup_failures={
+            "feishu_message_pool_service": "start_failed"
+        }
+    )
+
+    payload = server_app._startup_payload(app)
+
+    assert payload["components"] == {
+        "core": "ready",
+        "runtime": "ready",
+        "background_services": "failed",
+    }
+    assert payload["background_startup_failures"] == {
+        "feishu_message_pool_service": "start_failed"
+    }
+
+
+def test_startup_payload_surfaces_pending_background_services() -> None:
+    app = server_app.Starlette()
+    app.state.startup_phase = "ready"
+    app.state.hydrated = True
+    app.state.components = {"core": "ready", "runtime": "ready"}
+    app.state.hydration_error = None
+    app.state.container = SimpleNamespace(
+        runtime_background_startup_pending=True,
+        runtime_background_startup_failures={},
+    )
+
+    payload = server_app._startup_payload(app)
+
+    assert payload["components"] == {
+        "core": "ready",
+        "runtime": "ready",
+        "background_services": "loading",
+    }
+    assert payload["background_startup_pending"] is True
+    assert payload["background_startup_failures"] == {}
 
 
 def test_hydration_failure_stops_partially_started_container(

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -964,7 +964,7 @@ async def test_container_binds_background_completion_sink_during_start(
 
     try:
         await container.start()
-        await _wait_for_start_call(start_calls, "feishu-subscription")
+        await container._drain_startup_background_tasks()
 
         assert lifecycle_calls == ["bind_event_loop", "bind_completion_sink"]
         assert (
@@ -1094,7 +1094,7 @@ async def test_container_start_continues_when_memory_reindex_fails(
 
     try:
         await container.start()
-        await _wait_for_start_call(start_calls, "feishu-subscription")
+        await container._drain_startup_background_tasks()
 
         assert (
             "Failed to rebuild Memory Bank retrieval entries during startup"
@@ -1115,6 +1115,67 @@ async def test_container_start_continues_when_memory_reindex_fails(
             "board",
             "scheduler",
         ]
+    finally:
+        await container.stop()
+
+
+@pytest.mark.asyncio
+async def test_container_shutdown_drains_noncancelable_startup_tasks(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = container_module.ServerContainer(config_dir=config_dir)
+    release_startup = asyncio.Event()
+    completed: list[str] = []
+
+    async def _finish_after_stop_begins() -> None:
+        await release_startup.wait()
+        completed.append("runtime-startup")
+
+    task = asyncio.create_task(_finish_after_stop_begins())
+    container._startup_background_tasks.add(task)
+    container._noncancelable_startup_background_tasks.add(task)
+
+    try:
+        container._cancel_startup_background_tasks()
+
+        assert not task.cancelled()
+        release_startup.set()
+        await container._drain_startup_background_tasks()
+
+        assert completed == ["runtime-startup"]
+        assert container._startup_background_tasks == set()
+        assert container._noncancelable_startup_background_tasks == set()
+    finally:
+        release_startup.set()
+        await container.stop()
+
+
+@pytest.mark.asyncio
+async def test_container_records_unexpected_background_startup_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = container_module.ServerContainer(config_dir=config_dir)
+
+    async def _fail_with_import_error() -> None:
+        raise ModuleNotFoundError("missing sdk")
+
+    try:
+        await container._run_runtime_service_startup_step(
+            "feishu_subscription_service",
+            _fail_with_import_error,
+        )
+
+        assert container.runtime_background_startup_failures == {
+            "feishu_subscription_service": "start_failed"
+        }
     finally:
         await container.stop()
 


### PR DESCRIPTION
## Summary
- defer runtime container and router imports until hydration builds the runtime API app
- keep runtime identity module lightweight until health sanity checks need registry data
- avoid eager Feishu SDK imports during normal startup and isolate hydration bundle tests from real runtime routers

## Validation
- uv run --extra dev ruff check src/relay_teams/interfaces/server/app.py src/relay_teams/interfaces/server/runtime_identity.py src/relay_teams/gateway/feishu/subscription_service.py src/relay_teams/gateway/feishu/trigger_handler.py tests/unit_tests/interfaces/server/test_app.py
- uv run --extra dev basedpyright src/relay_teams/interfaces/server/app.py src/relay_teams/interfaces/server/runtime_identity.py src/relay_teams/gateway/feishu/subscription_service.py src/relay_teams/gateway/feishu/trigger_handler.py tests/unit_tests/interfaces/server/test_app.py
- uv run --extra dev pytest -q tests/unit_tests/interfaces/server/test_app.py tests/unit_tests/interfaces/server/test_runtime_identity.py tests/unit_tests/feishu/test_subscription_service.py tests/unit_tests/feishu/test_trigger_handler.py
- server app cold import measured at about 5.36s after the refactor

Closes #888