### PR TITLE
Fix tool-call process text rendering

### DIFF
--- a/frontend/dist/js/components/messageRenderer/helpers/block.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/block.js
@@ -113,6 +113,7 @@ export function renderParts(contentEl, parts, pendingToolBlocks, options = {}) {
             contentEl.appendChild(tb);
             indexPendingToolBlock(pendingToolBlocks, tb, part.tool_name, part.tool_call_id);
         } else if (kind === 'tool-return') {
+            flushText();
             const toolBlock = resolvePendingToolBlock(
                 pendingToolBlocks,
                 part.tool_name,
@@ -120,6 +121,7 @@ export function renderParts(contentEl, parts, pendingToolBlocks, options = {}) {
             );
             if (toolBlock) applyToolReturn(toolBlock, part.content);
         } else if (kind === 'retry-prompt' && part.tool_name) {
+            flushText();
             let toolBlock = resolvePendingToolBlock(
                 pendingToolBlocks,
                 part.tool_name,

--- a/frontend/dist/js/components/messageRenderer/helpers/block.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/block.js
@@ -246,6 +246,7 @@ export function updateMessageText(textEl, text, options = {}) {
     clearPlainTextRenderState(textEl);
     renderRichContent(textEl, String(text || ''), {
         enableWorkspaceImagePreview: options.enableWorkspaceImagePreview !== false,
+        preserveBoundaryWhitespace: options.preserveBoundaryWhitespace === true,
     });
     syncStreamingCursor(textEl, options.streaming === true);
     return textEl;

--- a/frontend/dist/js/components/messageRenderer/helpers/content.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/content.js
@@ -18,6 +18,13 @@ const TRAILING_PATH_PUNCTUATION_PATTERN = /[),.:;!?\\\]}>，。！？；：）�
 export function renderRichContent(targetEl, source, options = {}) {
     const text = String(source || '');
     const enableWorkspaceImagePreview = options.enableWorkspaceImagePreview !== false;
+    const preserveBoundaryWhitespace = options.preserveBoundaryWhitespace === true;
+    const leadingWhitespace = preserveBoundaryWhitespace
+        ? (text.match(/^\s+/u)?.[0] || '')
+        : '';
+    const trailingWhitespace = preserveBoundaryWhitespace
+        ? (text.match(/\s+$/u)?.[0] || '')
+        : '';
     const standaloneImageUrl = resolveStandaloneImageDataUrl(text);
     if (standaloneImageUrl) {
         targetEl.replaceChildren(buildImageFigure(standaloneImageUrl));
@@ -25,6 +32,20 @@ export function renderRichContent(targetEl, source, options = {}) {
     }
 
     targetEl.innerHTML = parseMarkdown(text);
+    if (
+        leadingWhitespace
+        && typeof document !== 'undefined'
+        && typeof document.createTextNode === 'function'
+    ) {
+        targetEl.prepend(document.createTextNode(leadingWhitespace));
+    }
+    if (
+        trailingWhitespace
+        && typeof document !== 'undefined'
+        && typeof document.createTextNode === 'function'
+    ) {
+        targetEl.appendChild(document.createTextNode(trailingWhitespace));
+    }
     if (enableWorkspaceImagePreview) {
         const previewUrls = resolveWorkspaceImagePreviewUrls(
             text,

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -859,6 +859,9 @@ function renderStreamOverlayEntry(
         if (!part || typeof part !== 'object') return;
         if (part.kind === 'text') {
             combinedText += String(part.content || '');
+            if (part.closed === true) {
+                flushText(false);
+            }
             return;
         }
         if (part.kind === 'media_ref') {

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -455,7 +455,7 @@ function buildPersistedOverlayIndex(historyMessages, runId, options = {}) {
         }
         if (messageText.size > 0) {
             index.textTailByStream.set(streamKey, messageText);
-            replaceOverlayTextList(index.textByStream, streamKey, messageTextList);
+            mergeOverlayTextList(index.textByStream, streamKey, messageTextList);
         }
         index.mediaTailByStream.set(streamKey, new Set(messageMedia));
     });
@@ -485,11 +485,20 @@ function mergeOverlayTextSet(target, key, values) {
     });
 }
 
-function replaceOverlayTextList(target, key, values) {
+function mergeOverlayTextList(target, key, values) {
     if (!target || !key || !Array.isArray(values) || values.length === 0) {
         return;
     }
-    target.set(key, values.filter(Boolean));
+    const existing = target.get(key);
+    const merged = Array.isArray(existing) ? existing.slice() : [];
+    values.forEach(value => {
+        if (value) {
+            merged.push(value);
+        }
+    });
+    if (merged.length > 0) {
+        target.set(key, merged);
+    }
 }
 
 function clearOverlayTextByStreamPart(target, streamKey) {

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -857,7 +857,10 @@ function renderStreamOverlayEntry(
         const safeText = String(combinedText || '');
         if (!safeText && !streaming) return;
         if (!safeText.trim() && !streaming) return;
-        appendMessageText(ensureContentEl(), streaming ? safeText : safeText.trim(), { streaming });
+        appendMessageText(ensureContentEl(), safeText, {
+            streaming,
+            preserveBoundaryWhitespace: true,
+        });
         if (streaming) {
             renderedLiveTextTail = true;
         }

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -379,6 +379,7 @@ function buildPersistedOverlayIndex(historyMessages, runId, options = {}) {
         thinkingTailByStreamPart: new Map(),
         mediaTailByStream: new Map(),
         textTailByStream: new Map(),
+        textByStream: new Map(),
     };
     (Array.isArray(historyMessages) ? historyMessages : []).forEach(msgItem => {
         if (String(msgItem?.entry_type || '') === 'injection') {
@@ -400,6 +401,7 @@ function buildPersistedOverlayIndex(historyMessages, runId, options = {}) {
         const messageThinkingTextByPart = new Map();
         const messageMedia = new Set();
         const messageText = new Set();
+        const messageTextList = [];
         parts.forEach(part => {
             if (!part || typeof part !== 'object') return;
             const kind = String(part.part_kind || part.kind || '').trim();
@@ -424,7 +426,10 @@ function buildPersistedOverlayIndex(historyMessages, runId, options = {}) {
             }
             if (kind === 'text') {
                 const text = normalizeOverlayTextSignature(part.content || part.text);
-                if (text) messageText.add(text);
+                if (text) {
+                    messageText.add(text);
+                    messageTextList.push(text);
+                }
             }
             if (kind === 'media_ref') {
                 const mediaSignature = normalizeOverlayMediaSignature(part);
@@ -450,6 +455,7 @@ function buildPersistedOverlayIndex(historyMessages, runId, options = {}) {
         }
         if (messageText.size > 0) {
             index.textTailByStream.set(streamKey, messageText);
+            replaceOverlayTextList(index.textByStream, streamKey, messageTextList);
         }
         index.mediaTailByStream.set(streamKey, new Set(messageMedia));
     });
@@ -477,6 +483,13 @@ function mergeOverlayTextSet(target, key, values) {
             existing.add(value);
         }
     });
+}
+
+function replaceOverlayTextList(target, key, values) {
+    if (!target || !key || !Array.isArray(values) || values.length === 0) {
+        return;
+    }
+    target.set(key, values.filter(Boolean));
 }
 
 function clearOverlayTextByStreamPart(target, streamKey) {
@@ -512,6 +525,10 @@ function filterPersistedOverlayParts(streamOverlayEntry, persistedIndex, runId, 
         persistedIndex.textTailByStream,
         streamKeys,
     ) || emptySet;
+    const persistedTextCursor = createPersistedOverlayTextCursor(
+        persistedIndex.textByStream,
+        streamKeys,
+    );
     const persistedMedia = collectPersistedOverlayText(
         persistedIndex.mediaTailByStream,
         streamKeys,
@@ -546,7 +563,11 @@ function filterPersistedOverlayParts(streamOverlayEntry, persistedIndex, runId, 
             if (!text) {
                 return false;
             }
-            return !(text && persistedText.has(text));
+            return !consumePersistedOverlayText(
+                text,
+                persistedTextCursor,
+                persistedText,
+            );
         }
         if (part.kind === 'media_ref') {
             const mediaSignature = normalizeOverlayMediaSignature(part);
@@ -574,6 +595,46 @@ function filterPersistedOverlayParts(streamOverlayEntry, persistedIndex, runId, 
         idleCursor: allowIdleCursor,
         textStreaming: allowTextStreaming,
     };
+}
+
+function createPersistedOverlayTextCursor(textByStream, streamKeys) {
+    const values = [];
+    (Array.isArray(streamKeys) ? streamKeys : []).forEach(streamKey => {
+        const streamValues = textByStream?.get?.(streamKey);
+        if (!Array.isArray(streamValues)) {
+            return;
+        }
+        streamValues.forEach(value => {
+            if (value) {
+                values.push(value);
+            }
+        });
+    });
+    return {
+        values,
+        index: 0,
+    };
+}
+
+function consumePersistedOverlayText(text, cursor, fallbackTextSet) {
+    const candidate = normalizeOverlayTextSignature(text);
+    if (!candidate) {
+        return false;
+    }
+    if (cursor && Array.isArray(cursor.values) && cursor.values.length > 0) {
+        for (let index = cursor.index; index < cursor.values.length; index += 1) {
+            const persisted = normalizeOverlayTextSignature(cursor.values[index]);
+            if (!persisted) {
+                continue;
+            }
+            if (persisted === candidate) {
+                cursor.index = index + 1;
+                return true;
+            }
+        }
+        return false;
+    }
+    return !!fallbackTextSet?.has?.(candidate);
 }
 
 function normalizeOverlayTextSignature(value) {

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -1564,11 +1564,13 @@ function findReusableStreamState({
     if (!wrapper) return null;
     const contentEl = wrapper.querySelector('.msg-content');
     if (!contentEl) return null;
+    const reusableTextPart = resolveReusableTextPart(overlayEntry);
+    const canReuseText = overlayEntry?.textStreaming === true && !!reusableTextPart;
     const idleRebind = overlayEntry?.idleCursor === true && overlayEntry?.textStreaming !== true;
     const activeTextEl = idleRebind
         ? findReusableIdleCursorElement(contentEl)
-        : findLastReusableTextElement(contentEl);
-    const activeRaw = idleRebind ? '' : resolveReusableRawText(overlayEntry);
+        : (canReuseText ? findLastReusableTextElement(contentEl) : null);
+    const activeRaw = canReuseText ? String(reusableTextPart?.content || '') : '';
     if (activeTextEl) {
         syncStreamingCursor(activeTextEl, overlayEntry?.textStreaming === true);
         if (overlayEntry?.idleCursor === true && overlayEntry?.textStreaming !== true) {
@@ -1690,18 +1692,21 @@ function findReusableIdleCursorElement(contentEl) {
     return null;
 }
 
-function resolveReusableRawText(overlayEntry) {
+function resolveReusableTextPart(overlayEntry) {
     if (!overlayEntry || !Array.isArray(overlayEntry.parts)) {
-        return '';
+        return null;
     }
     for (let index = overlayEntry.parts.length - 1; index >= 0; index -= 1) {
         const part = overlayEntry.parts[index];
         if (!part || part.kind !== 'text') {
             continue;
         }
-        return String(part.content || '');
+        if (part.closed === true || part.streaming === false) {
+            return null;
+        }
+        return part;
     }
-    return '';
+    return null;
 }
 
 function bindReusableThinkingState(contentEl, overlayEntry) {

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -93,6 +93,7 @@ export function appendStreamChunk(instanceId, text, runId = '', roleId = '', lab
         st.activeRaw = '';
     }
 
+    const wasIdleTextPlaceholder = isIdleCursorPlaceholder(st.activeTextEl);
     st.raw += text;
     st.activeRaw += text;
     st.activeTextIsIdle = false;
@@ -102,7 +103,7 @@ export function appendStreamChunk(instanceId, text, runId = '', roleId = '', lab
             streaming: true,
             appendDelta: true,
         });
-    } else if (st.activeRaw.length >= LARGE_STREAM_TEXT_THRESHOLD) {
+    } else if (wasIdleTextPlaceholder || st.activeRaw.length >= LARGE_STREAM_TEXT_THRESHOLD) {
         pendingTextUpdates.delete(st.activeTextEl);
         updateMessageText(st.activeTextEl, st.activeRaw, { streaming: true });
     } else {

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -636,6 +636,9 @@ export function updateToolResult(
     const resolvedInstanceId = (st && st.instanceId) || instanceId;
     const resolvedRoleId = (st && st.roleId) || roleId;
     const resultIsError = isStreamToolResultError(result, { isError });
+    if (st) {
+        endActiveText(st);
+    }
     updateOverlayToolResult(
         resolvedRunId,
         resolvedInstanceId,
@@ -707,6 +710,9 @@ export function markToolInputValidationFailed(instanceId, payload, options = {})
     }
 
     const follow = captureStreamFollow((st && st.container) || container);
+    if (st) {
+        endActiveText(st);
+    }
     setToolValidationFailureState(toolBlock, payload);
     updateOverlayToolValidation(st.runId || runId, st.instanceId || instanceId, roleId || st.roleId, payload);
     applyTimelineAction({
@@ -924,6 +930,9 @@ export function attachToolApprovalControls(instanceId, toolName, payload, handle
     }
 
     const follow = captureStreamFollow((st && st.container) || container);
+    if (st) {
+        endActiveText(st);
+    }
     const approvalEl = ensureApprovalState(toolBlock);
 
     toolBlock.open = true;
@@ -982,6 +991,9 @@ export function markToolApprovalResolved(instanceId, payload, options = {}) {
     if (!toolCallId) return false;
 
     const follow = captureStreamFollow((st && st.container) || container);
+    if (st) {
+        endActiveText(st);
+    }
     const toolBlock = resolveToolBlockTarget(st, container, payload?.tool_name, toolCallId);
     if (!toolBlock) return false;
     toolBlock.dataset.toolCallId = toolCallId;
@@ -1806,6 +1818,7 @@ function endActiveText(st) {
     }
     setOverlayTextStreaming(st.runId, st.instanceId, st.roleId, st.label, false);
     setOverlayIdleCursor(st.runId, st.instanceId, st.roleId, st.label, false);
+    closeOverlayTextSegment(st.runId, st.instanceId, st.roleId, st.label);
     st.activeTextEl = null;
     st.activeRaw = '';
     st.activeTextIsIdle = false;
@@ -2156,11 +2169,27 @@ function updateOverlayText(runId, instanceId, roleId, label, text) {
     entry.idleCursor = false;
     if (!nextText) return;
     const lastPart = entry.parts[entry.parts.length - 1];
-    if (lastPart && lastPart.kind === 'text') {
+    if (lastPart && lastPart.kind === 'text' && lastPart.closed !== true) {
         lastPart.content = String(lastPart.content || '') + nextText;
         return;
     }
     entry.parts.push({ kind: 'text', content: nextText });
+}
+
+function closeOverlayTextSegment(runId, instanceId, roleId, label) {
+    const entry = resolveOverlayEntry(runId, instanceId, roleId, label);
+    closeOverlayTextSegmentEntry(entry);
+}
+
+function closeOverlayTextSegmentEntry(entry) {
+    if (!entry || !Array.isArray(entry.parts)) {
+        return;
+    }
+    const lastPart = entry.parts[entry.parts.length - 1];
+    if (lastPart && lastPart.kind === 'text') {
+        lastPart.closed = true;
+        lastPart.streaming = false;
+    }
 }
 
 function appendOverlayOutputParts(
@@ -2194,6 +2223,7 @@ function appendOverlayOutputParts(
             hasTextOutput = true;
             return;
         }
+        closeOverlayTextSegmentEntry(entry);
         entry.parts.push(normalizedPart);
     });
     return hasTextOutput;
@@ -2214,6 +2244,7 @@ function setOverlayIdleCursor(runId, instanceId, roleId, label, isIdle) {
 function startOverlayThinking(runId, instanceId, roleId, label, partIndex) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry) return;
+    closeOverlayTextSegmentEntry(entry);
     const safePartIndex = Number(partIndex);
     const activeKey = entry.thinkingActiveByPart?.get(String(safePartIndex));
     const activePart = activeKey ? findOverlayThinkingPartByKey(entry, activeKey) : null;
@@ -2266,6 +2297,7 @@ function finishOverlayThinking(runId, instanceId, roleId, partIndex) {
 function updateOverlayToolCall(runId, instanceId, roleId, label, toolPart) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry) return;
+    closeOverlayTextSegmentEntry(entry);
     const part = upsertOverlayToolPart(
         entry,
         toolPart.tool_name,
@@ -2286,6 +2318,7 @@ function updateOverlayToolCall(runId, instanceId, roleId, label, toolPart) {
 function updateOverlayToolResult(runId, instanceId, roleId, label, toolName, toolCallId, result, isError) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry) return;
+    closeOverlayTextSegmentEntry(entry);
     const part = upsertOverlayToolPart(entry, toolName, toolCallId);
     part.status = isError ? 'error' : 'completed';
     part.result = result;
@@ -2294,6 +2327,7 @@ function updateOverlayToolResult(runId, instanceId, roleId, label, toolName, too
 function updateOverlayToolValidation(runId, instanceId, roleId, payload) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, '');
     if (!entry) return;
+    closeOverlayTextSegmentEntry(entry);
     const part = findOverlayToolPart(
         entry,
         payload?.tool_name,
@@ -2311,6 +2345,7 @@ function updateOverlayToolValidation(runId, instanceId, roleId, payload) {
 function updateOverlayToolApproval(runId, instanceId, roleId, toolName, payload, approvalStatus) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, '');
     if (!entry) return;
+    closeOverlayTextSegmentEntry(entry);
     const part = upsertOverlayToolPart(
         entry,
         toolName,
@@ -2322,6 +2357,7 @@ function updateOverlayToolApproval(runId, instanceId, roleId, toolName, payload,
 function appendOverlayInjection(runId, instanceId, roleId, label, payload) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry || !payload || typeof payload !== 'object') return;
+    closeOverlayTextSegmentEntry(entry);
     const normalized = normalizeOverlayInjection(payload);
     if (!normalized.content) return;
     const existing = entry.parts.find(part => (

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -1154,7 +1154,8 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
         appendOverlayInjection(runId, streamKey, roleId, label, payload || {});
         return;
     }
-    if (evType === 'model_step_finished') {
+    if (evType === 'model_step_started' || evType === 'model_step_finished') {
+        closeOverlayTextSegment(runId, streamKey, roleId, label);
         setOverlayTextStreaming(runId, streamKey, roleId, label, false);
         setOverlayIdleCursor(runId, streamKey, roleId, label, false);
         return;

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -1423,19 +1423,25 @@ function materializeOverlayEntryIntoState(st, overlayEntry) {
     if (!st || !overlayEntry || !Array.isArray(overlayEntry.parts)) {
         return;
     }
+    const liveTextPart = overlayEntry.textStreaming === true
+        ? [...overlayEntry.parts]
+            .reverse()
+            .find(part => part?.kind === 'text' && part.closed !== true)
+        : null;
     overlayEntry.parts.forEach(part => {
         if (!part || typeof part !== 'object') {
             return;
         }
         if (part.kind === 'text') {
+            const textStreaming = part === liveTextPart;
             const textEl = document.createElement('div');
             textEl.className = 'msg-text';
             updateMessageText(textEl, String(part.content || ''), {
-                streaming: overlayEntry.textStreaming === true,
+                streaming: textStreaming,
             });
             st.contentEl.appendChild(textEl);
-            st.activeTextEl = overlayEntry.textStreaming === true ? textEl : st.activeTextEl;
-            st.activeRaw = overlayEntry.textStreaming === true
+            st.activeTextEl = textStreaming ? textEl : st.activeTextEl;
+            st.activeRaw = textStreaming
                 ? String(part.content || '')
                 : st.activeRaw;
             st.raw += String(part.content || '');
@@ -2190,6 +2196,7 @@ function closeOverlayTextSegmentEntry(entry) {
     if (lastPart && lastPart.kind === 'text') {
         lastPart.closed = true;
         lastPart.streaming = false;
+        entry.textStreaming = false;
     }
 }
 
@@ -2216,7 +2223,7 @@ function appendOverlayOutputParts(
                 return;
             }
             const lastPart = entry.parts[entry.parts.length - 1];
-            if (lastPart && lastPart.kind === 'text') {
+            if (lastPart && lastPart.kind === 'text' && lastPart.closed !== true) {
                 lastPart.content = String(lastPart.content || '') + normalizedPart.content;
             } else {
                 entry.parts.push(normalizedPart);

--- a/frontend/dist/js/components/messageTimeline/renderer.js
+++ b/frontend/dist/js/components/messageTimeline/renderer.js
@@ -6,6 +6,7 @@ import {
     appendMessageText,
     appendStructuredContentPart,
     appendThinkingText,
+    updateMessageText,
     updateThinkingText,
     buildToolBlock,
     applyToolReturn,
@@ -102,8 +103,10 @@ function renderPart(part, scope = {}) {
 function updatePart(partEl, part, scope = {}) {
     if (part.kind === 'text') {
         const textEl = partEl.classList?.contains('msg-text') ? partEl : partEl.querySelector('.msg-text');
-        if (textEl && textEl.textContent !== String(part.content || '')) {
-            textEl.textContent = String(part.content || '');
+        if (textEl) {
+            updateMessageText(textEl, part.content || '', {
+                streaming: part.streaming === true,
+            });
         }
         return;
     }

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -980,6 +980,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                         *buffered_messages,
                         *new_to_process,
                     ],
+                    pending_messages=new_to_process,
                 )
                 if boundary_missing_observed:
                     new_to_process.extend(boundary_missing_observed)
@@ -1337,6 +1338,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                 *buffered_messages,
                                 *to_save,
                             ],
+                            pending_messages=to_save,
                         )
                         if missing_observed:
                             to_save.extend(missing_observed)
@@ -2034,6 +2036,7 @@ def _missing_stream_observed_messages(
     observed_messages: Sequence[ModelRequest | ModelResponse],
     *,
     existing_text_messages: Sequence[ModelRequest | ModelResponse] | None = None,
+    pending_messages: list[ModelRequest | ModelResponse] | None = None,
 ) -> list[ModelRequest | ModelResponse]:
     tool_call_ids = _tool_call_ids(existing_messages)
     tool_result_ids = _tool_result_ids(existing_messages)
@@ -2057,7 +2060,15 @@ def _missing_stream_observed_messages(
                 if not isinstance(part, ToolCallPart):
                     continue
                 tool_call_id = str(part.tool_call_id or "").strip()
-                if not tool_call_id or tool_call_id in tool_call_ids:
+                if not tool_call_id:
+                    continue
+                if tool_call_id in tool_call_ids:
+                    if missing_parts and _insert_missing_response_parts_before_tool_call(
+                        pending_messages,
+                        tool_call_id=tool_call_id,
+                        missing_parts=missing_parts,
+                    ):
+                        missing_parts = []
                     continue
                 missing_parts.append(part)
                 tool_call_ids.add(tool_call_id)
@@ -2076,6 +2087,36 @@ def _missing_stream_observed_messages(
         if missing_request_parts:
             missing.append(ModelRequest(parts=missing_request_parts))
     return missing
+
+
+def _insert_missing_response_parts_before_tool_call(
+    pending_messages: list[ModelRequest | ModelResponse] | None,
+    *,
+    tool_call_id: str,
+    missing_parts: list[ModelResponsePart],
+) -> bool:
+    if pending_messages is None or not missing_parts:
+        return False
+    for index, message in enumerate(pending_messages):
+        if not isinstance(message, ModelResponse):
+            continue
+        if not _response_has_tool_call_id(message, tool_call_id):
+            continue
+        pending_messages.insert(index, ModelResponse(parts=list(missing_parts)))
+        return True
+    return False
+
+
+def _response_has_tool_call_id(
+    message: ModelResponse,
+    tool_call_id: str,
+) -> bool:
+    for part in message.parts:
+        if not isinstance(part, ToolCallPart):
+            continue
+        if str(part.tool_call_id or "").strip() == tool_call_id:
+            return True
+    return False
 
 
 def _text_part_contents(

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -643,6 +643,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                     retry_number == 0 and not skip_initial_user_prompt_persist
                 ),
             )
+            run_output_history_start_index = len(history)
             seen_count = 0
             buffered_messages: list[ModelRequest | ModelResponse] = []
             result: AgentRunResult | None = None
@@ -974,7 +975,11 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 boundary_missing_observed = _missing_stream_observed_messages(
                     [*history, *buffered_messages, *new_to_process],
                     observed_stream_messages,
-                    existing_text_messages=[*buffered_messages, *new_to_process],
+                    existing_text_messages=[
+                        *history[run_output_history_start_index:],
+                        *buffered_messages,
+                        *new_to_process,
+                    ],
                 )
                 if boundary_missing_observed:
                     new_to_process.extend(boundary_missing_observed)
@@ -1327,7 +1332,11 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                         missing_observed = _missing_stream_observed_messages(
                             [*history, *buffered_messages, *to_save],
                             observed_stream_messages,
-                            existing_text_messages=[*buffered_messages, *to_save],
+                            existing_text_messages=[
+                                *history[run_output_history_start_index:],
+                                *buffered_messages,
+                                *to_save,
+                            ],
                         )
                         if missing_observed:
                             to_save.extend(missing_observed)

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -974,6 +974,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 boundary_missing_observed = _missing_stream_observed_messages(
                     [*history, *buffered_messages, *new_to_process],
                     observed_stream_messages,
+                    existing_text_messages=[*buffered_messages, *new_to_process],
                 )
                 if boundary_missing_observed:
                     new_to_process.extend(boundary_missing_observed)
@@ -1326,6 +1327,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                         missing_observed = _missing_stream_observed_messages(
                             [*history, *buffered_messages, *to_save],
                             observed_stream_messages,
+                            existing_text_messages=[*buffered_messages, *to_save],
                         )
                         if missing_observed:
                             to_save.extend(missing_observed)
@@ -2021,10 +2023,14 @@ def _llm_stream_event_timeout_seconds(connect_timeout_seconds: float) -> float:
 def _missing_stream_observed_messages(
     existing_messages: Sequence[ModelRequest | ModelResponse],
     observed_messages: Sequence[ModelRequest | ModelResponse],
+    *,
+    existing_text_messages: Sequence[ModelRequest | ModelResponse] | None = None,
 ) -> list[ModelRequest | ModelResponse]:
     tool_call_ids = _tool_call_ids(existing_messages)
     tool_result_ids = _tool_result_ids(existing_messages)
-    text_contents = _text_part_contents(existing_messages)
+    text_contents = _text_part_contents(
+        existing_messages if existing_text_messages is None else existing_text_messages
+    )
     missing: list[ModelRequest | ModelResponse] = []
     for message in observed_messages:
         if isinstance(message, ModelResponse):

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -1145,6 +1145,16 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                                 if isinstance(
                                                     stream_event, PartEndEvent
                                                 ) and isinstance(
+                                                    stream_event.part, TextPart
+                                                ):
+                                                    observed_stream_messages.append(
+                                                        ModelResponse(
+                                                            parts=[stream_event.part]
+                                                        )
+                                                    )
+                                                if isinstance(
+                                                    stream_event, PartEndEvent
+                                                ) and isinstance(
                                                     stream_event.part, ToolCallPart
                                                 ):
                                                     observed_stream_messages.append(
@@ -2014,11 +2024,21 @@ def _missing_stream_observed_messages(
 ) -> list[ModelRequest | ModelResponse]:
     tool_call_ids = _tool_call_ids(existing_messages)
     tool_result_ids = _tool_result_ids(existing_messages)
+    text_contents = _text_part_contents(existing_messages)
     missing: list[ModelRequest | ModelResponse] = []
     for message in observed_messages:
         if isinstance(message, ModelResponse):
             missing_parts: list[ModelResponsePart] = []
             for part in message.parts:
+                if isinstance(part, TextPart):
+                    content = str(part.content or "")
+                    if not content or _consume_existing_text_content(
+                        text_contents,
+                        content,
+                    ):
+                        continue
+                    missing_parts.append(part)
+                    continue
                 if not isinstance(part, ToolCallPart):
                     continue
                 tool_call_id = str(part.tool_call_id or "").strip()
@@ -2041,6 +2061,37 @@ def _missing_stream_observed_messages(
         if missing_request_parts:
             missing.append(ModelRequest(parts=missing_request_parts))
     return missing
+
+
+def _text_part_contents(
+    messages: Sequence[ModelRequest | ModelResponse],
+) -> dict[str, int]:
+    contents: dict[str, int] = {}
+    for message in messages:
+        if not isinstance(message, ModelResponse):
+            continue
+        for part in message.parts:
+            if not isinstance(part, TextPart):
+                continue
+            content = str(part.content or "")
+            if not content:
+                continue
+            contents[content] = contents.get(content, 0) + 1
+    return contents
+
+
+def _consume_existing_text_content(
+    contents: dict[str, int],
+    content: str,
+) -> bool:
+    count = contents.get(content, 0)
+    if count <= 0:
+        return False
+    if count == 1:
+        contents.pop(content, None)
+        return True
+    contents[content] = count - 1
+    return True
 
 
 def _tool_call_ids(

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -2063,10 +2063,13 @@ def _missing_stream_observed_messages(
                 if not tool_call_id:
                     continue
                 if tool_call_id in tool_call_ids:
-                    if missing_parts and _insert_missing_response_parts_before_tool_call(
-                        pending_messages,
-                        tool_call_id=tool_call_id,
-                        missing_parts=missing_parts,
+                    if (
+                        missing_parts
+                        and _insert_missing_response_parts_before_tool_call(
+                            pending_messages,
+                            tool_call_id=tool_call_id,
+                            missing_parts=missing_parts,
+                        )
                     ):
                         missing_parts = []
                     continue

--- a/src/relay_teams/gateway/feishu/message_pool_service.py
+++ b/src/relay_teams/gateway/feishu/message_pool_service.py
@@ -144,9 +144,11 @@ class FeishuMessagePoolService:
         self._pause_notice_keys: set[str] = set()
 
     async def start(self) -> None:
-        self._message_pool_repo.recover_stale_claims(
-            claimed_before=datetime.now(tz=timezone.utc)
-            - timedelta(seconds=_STALE_CLAIM_SECONDS)
+        await asyncio.to_thread(
+            self._message_pool_repo.recover_stale_claims,
+            claimed_before=(
+                datetime.now(tz=timezone.utc) - timedelta(seconds=_STALE_CLAIM_SECONDS)
+            ),
         )
         if self._task is not None and not self._task.done():
             return

--- a/src/relay_teams/gateway/feishu/message_pool_service.py
+++ b/src/relay_teams/gateway/feishu/message_pool_service.py
@@ -144,8 +144,7 @@ class FeishuMessagePoolService:
         self._pause_notice_keys: set[str] = set()
 
     async def start(self) -> None:
-        await asyncio.to_thread(
-            self._message_pool_repo.recover_stale_claims,
+        await self._message_pool_repo.recover_stale_claims_async(
             claimed_before=(
                 datetime.now(tz=timezone.utc) - timedelta(seconds=_STALE_CLAIM_SECONDS)
             ),

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -1570,8 +1570,8 @@ class ServerContainer:
         await self.automation_scheduler_service.start()
         return None
 
+    @staticmethod
     async def _start_sync_service(
-        self,
         *,
         service_name: str,
         start: Callable[[], None],

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -1576,9 +1576,15 @@ class ServerContainer:
         service_name: str,
         start: Callable[[], None],
     ) -> None:
+        start_task = asyncio.create_task(
+            asyncio.to_thread(start),
+            name=f"{service_name}-sync-start",
+        )
         try:
-            async with asyncio.timeout(SYNC_SERVICE_START_TIMEOUT_SECONDS):
-                await asyncio.to_thread(start)
+            await asyncio.wait_for(
+                asyncio.shield(start_task),
+                timeout=SYNC_SERVICE_START_TIMEOUT_SECONDS,
+            )
         except TimeoutError:
             log_event(
                 LOGGER,
@@ -1590,6 +1596,7 @@ class ServerContainer:
                     "timeout_seconds": SYNC_SERVICE_START_TIMEOUT_SECONDS,
                 },
             )
+            await start_task
 
     def _start_sync_service_background(
         self,
@@ -1602,6 +1609,34 @@ class ServerContainer:
             name=f"{service_name}-startup",
         )
         self._startup_background_tasks.add(task)
+        task.add_done_callback(
+            lambda completed: self._handle_startup_background_task_done(
+                completed,
+                service_name=service_name,
+            )
+        )
+
+    def _handle_startup_background_task_done(
+        self,
+        task: asyncio.Task[None],
+        *,
+        service_name: str,
+    ) -> None:
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is None:
+            self._startup_background_tasks.discard(task)
+            return
+        self._startup_background_tasks.discard(task)
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="app.startup.background_task_failed",
+            message="Startup background task failed",
+            payload={"service": service_name},
+            exc_info=exception,
+        )
 
     async def stop(self) -> None:
         self._cancel_startup_background_tasks()

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -1570,8 +1570,8 @@ class ServerContainer:
         await self.automation_scheduler_service.start()
         return None
 
-    @staticmethod
     async def _start_sync_service(
+        self,
         *,
         service_name: str,
         start: Callable[[], None],
@@ -1596,7 +1596,14 @@ class ServerContainer:
                     "timeout_seconds": SYNC_SERVICE_START_TIMEOUT_SECONDS,
                 },
             )
-            await start_task
+            self._startup_background_tasks.add(start_task)
+            start_task.add_done_callback(
+                lambda completed: self._handle_startup_background_task_done(
+                    completed,
+                    service_name=service_name,
+                )
+            )
+            return
 
     def _start_sync_service_background(
         self,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -281,6 +281,7 @@ from relay_teams.workspace import (
 
 
 LOGGER = get_logger(__name__)
+SYNC_SERVICE_START_TIMEOUT_SECONDS = 5.0
 
 
 class AsyncCloseableRepository(Protocol):
@@ -1549,9 +1550,18 @@ class ServerContainer:
         self.run_service.bind_event_loop(asyncio.get_running_loop())
         self.background_task_service.bind_completion_sink(self.run_service)
         await self.discord_gateway_service.start_async()
-        self.wechat_gateway_service.start()
-        self.xiaoluban_im_listener_service.start()
-        self.feishu_subscription_service.start()
+        await self._start_sync_service(
+            service_name="wechat_gateway",
+            start=self.wechat_gateway_service.start,
+        )
+        await self._start_sync_service(
+            service_name="xiaoluban_im_listener",
+            start=self.xiaoluban_im_listener_service.start,
+        )
+        self._start_sync_service_background(
+            service_name="feishu_subscription",
+            start=self.feishu_subscription_service.start,
+        )
         await self.feishu_message_pool_service.start()
         await self.automation_delivery_worker.start()
         await self.automation_bound_session_queue_worker.start()
@@ -1559,6 +1569,39 @@ class ServerContainer:
         await self.board_todo_service.start()
         await self.automation_scheduler_service.start()
         return None
+
+    async def _start_sync_service(
+        self,
+        *,
+        service_name: str,
+        start: Callable[[], None],
+    ) -> None:
+        try:
+            async with asyncio.timeout(SYNC_SERVICE_START_TIMEOUT_SECONDS):
+                await asyncio.to_thread(start)
+        except TimeoutError:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="app.startup.sync_service_timeout",
+                message="Timed out while starting optional sync service",
+                payload={
+                    "service": service_name,
+                    "timeout_seconds": SYNC_SERVICE_START_TIMEOUT_SECONDS,
+                },
+            )
+
+    def _start_sync_service_background(
+        self,
+        *,
+        service_name: str,
+        start: Callable[[], None],
+    ) -> None:
+        task = asyncio.create_task(
+            self._start_sync_service(service_name=service_name, start=start),
+            name=f"{service_name}-startup",
+        )
+        self._startup_background_tasks.add(task)
 
     async def stop(self) -> None:
         self._cancel_startup_background_tasks()

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -12,6 +12,7 @@ from relay_teams.agent_runtimes.instances.instance_repository import (
 )
 from relay_teams.media import ContentPart
 from relay_teams.media import ContentPartAdapter
+from relay_teams.media import TextContentPart
 from relay_teams.media import content_parts_from_text
 from relay_teams.media import content_parts_to_text
 from relay_teams.media import normalize_user_prompt_content
@@ -47,6 +48,7 @@ ROUND_PROJECTION_EVENT_TYPES = (
 DETAILED_ROUND_PROJECTION_EVENT_TYPES = (
     *ROUND_PROJECTION_EVENT_TYPES,
     RunEventType.TEXT_DELTA.value,
+    RunEventType.OUTPUT_DELTA.value,
 )
 
 
@@ -764,30 +766,40 @@ def _project_text_messages_from_events(
         )
         if not run_id:
             continue
-        if event_type == RunEventType.TEXT_DELTA.value:
-            text = str(payload.get("text") or "")
-            if not text:
-                continue
+        if event_type in {
+            RunEventType.TEXT_DELTA.value,
+            RunEventType.OUTPUT_DELTA.value,
+        }:
             role_id = str(payload.get("role_id") or event.get("role_id") or "")
             instance_id = str(
                 payload.get("instance_id") or event.get("instance_id") or ""
             )
             key = (run_id, instance_id, role_id)
-            segment = active_segments.get(key)
-            if segment is None:
-                segment = {
-                    "run_id": run_id,
-                    "role_id": role_id,
-                    "instance_id": instance_id,
-                    "task_id": str(event.get("task_id") or ""),
-                    "occurred_at": str(event.get("occurred_at") or ""),
-                    "chunks": [],
-                }
-                active_segments[key] = segment
-            chunks = segment.get("chunks")
-            if isinstance(chunks, list):
-                chunks.append(text)
-            segment["occurred_at"] = str(event.get("occurred_at") or "")
+            for text_chunk in _event_text_chunks(event_type, payload):
+                if text_chunk is None:
+                    _flush_event_text_segments(
+                        active_segments,
+                        projected_by_run=projected_by_run,
+                        run_id=run_id,
+                    )
+                    continue
+                if text_chunk == "":
+                    continue
+                segment = active_segments.get(key)
+                if segment is None:
+                    segment = {
+                        "run_id": run_id,
+                        "role_id": role_id,
+                        "instance_id": instance_id,
+                        "task_id": str(event.get("task_id") or ""),
+                        "occurred_at": str(event.get("occurred_at") or ""),
+                        "chunks": [],
+                    }
+                    active_segments[key] = segment
+                chunks = segment.get("chunks")
+                if isinstance(chunks, list):
+                    chunks.append(text_chunk)
+                segment["occurred_at"] = str(event.get("occurred_at") or "")
             continue
         if event_type in {
             RunEventType.INJECTION_ENQUEUED.value,
@@ -814,6 +826,31 @@ def _project_text_messages_from_events(
     return dict(projected_by_run)
 
 
+def _event_text_chunks(
+    event_type: str,
+    payload: dict[str, object],
+) -> list[str | None]:
+    if event_type == RunEventType.TEXT_DELTA.value:
+        return [str(payload.get("text") or "")]
+    if event_type != RunEventType.OUTPUT_DELTA.value:
+        return []
+    output = payload.get("output")
+    if not isinstance(output, list):
+        return []
+    chunks: list[str | None] = []
+    for item in output:
+        try:
+            part = ContentPartAdapter.validate_python(item)
+        except Exception:
+            chunks.append(None)
+            continue
+        if isinstance(part, TextContentPart):
+            chunks.append(part.text)
+            continue
+        chunks.append(None)
+    return chunks
+
+
 def _flush_event_text_segments(
     active_segments: dict[tuple[str, str, str], dict[str, object]],
     *,
@@ -832,8 +869,8 @@ def _event_text_message(segment: dict[str, object]) -> dict[str, object] | None:
     chunks = segment.get("chunks")
     if not isinstance(chunks, list):
         return None
-    content = "".join(str(chunk) for chunk in chunks).strip()
-    if not content:
+    content = "".join(str(chunk) for chunk in chunks)
+    if not content.strip():
         return None
     run_id = str(segment.get("run_id") or "")
     role_id = str(segment.get("role_id") or "")

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -813,7 +813,6 @@ def _project_text_messages_from_events(
                 segment["occurred_at"] = str(event.get("occurred_at") or "")
             continue
         if event_type in {
-            RunEventType.INJECTION_ENQUEUED.value,
             RunEventType.INJECTION_APPLIED.value,
             RunEventType.TOOL_CALL.value,
             RunEventType.TOOL_RESULT.value,

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -1160,11 +1160,17 @@ def _merge_event_text_messages(
         return coordinator_messages
     existing_text_occurrences = _ordered_message_text_occurrences(coordinator_messages)
     missing: list[dict[str, object]] = []
-    for message in sorted(
+    ordered_event_messages = sorted(
         event_text_messages,
         key=lambda item: str(item.get("created_at") or ""),
-    ):
+    )
+    for index, message in enumerate(ordered_event_messages):
         event_time = str(message.get("created_at") or "")
+        latest_created_at = _next_later_event_text_created_at(
+            ordered_event_messages,
+            index,
+            event_time,
+        )
         include_message = False
         for text in _message_text_parts(message):
             normalized = _normalize_projected_text(text)
@@ -1182,6 +1188,7 @@ def _merge_event_text_messages(
             match_index = _matching_text_occurrence_index(
                 existing_text_occurrences,
                 earliest_created_at=earliest_created_at,
+                latest_created_at=latest_created_at,
                 normalized=normalized,
             )
             if match_index is None:
@@ -1199,6 +1206,18 @@ def _merge_event_text_messages(
             1 if str(item.get("role") or "") == "user" else 0,
         ),
     )
+
+
+def _next_later_event_text_created_at(
+    messages: list[dict[str, object]],
+    start_index: int,
+    event_time: str,
+) -> str | None:
+    for message in messages[start_index + 1 :]:
+        created_at = str(message.get("created_at") or "")
+        if created_at > event_time:
+            return created_at
+    return None
 
 
 def _ordered_message_text_occurrences(
@@ -1221,10 +1240,13 @@ def _matching_text_occurrence_index(
     occurrences: list[tuple[str, str]],
     *,
     earliest_created_at: str,
+    latest_created_at: str | None,
     normalized: str,
 ) -> int | None:
     for index, (created_at, text) in enumerate(occurrences):
         if created_at < earliest_created_at:
+            continue
+        if latest_created_at is not None and created_at >= latest_created_at:
             continue
         if text == normalized:
             return index

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -783,6 +783,8 @@ def _project_text_messages_from_events(
                         active_segments,
                         projected_by_run=projected_by_run,
                         run_id=run_id,
+                        instance_id=instance_id or None,
+                        role_id=role_id or None,
                     )
                     continue
                 if text_chunk == "":
@@ -796,11 +798,18 @@ def _project_text_messages_from_events(
                         "task_id": str(event.get("task_id") or ""),
                         "occurred_at": str(event.get("occurred_at") or ""),
                         "chunks": [],
+                        "source_event_types": [],
                     }
                     active_segments[key] = segment
                 chunks = segment.get("chunks")
                 if isinstance(chunks, list):
                     chunks.append(text_chunk)
+                source_event_types = segment.get("source_event_types")
+                if (
+                    isinstance(source_event_types, list)
+                    and event_type not in source_event_types
+                ):
+                    source_event_types.append(event_type)
                 segment["occurred_at"] = str(event.get("occurred_at") or "")
             continue
         if event_type in {
@@ -810,6 +819,20 @@ def _project_text_messages_from_events(
             RunEventType.TOOL_RESULT.value,
             RunEventType.MODEL_STEP_STARTED.value,
             RunEventType.MODEL_STEP_FINISHED.value,
+        }:
+            role_id = str(payload.get("role_id") or event.get("role_id") or "")
+            instance_id = str(
+                payload.get("instance_id") or event.get("instance_id") or ""
+            )
+            _flush_event_text_segments(
+                active_segments,
+                projected_by_run=projected_by_run,
+                run_id=run_id,
+                instance_id=instance_id or None,
+                role_id=role_id or None,
+            )
+            continue
+        if event_type in {
             RunEventType.RUN_COMPLETED.value,
             RunEventType.RUN_FAILED.value,
             RunEventType.RUN_STOPPED.value,
@@ -858,8 +881,18 @@ def _flush_event_text_segments(
     *,
     projected_by_run: dict[str, list[dict[str, object]]],
     run_id: str,
+    instance_id: str | None = None,
+    role_id: str | None = None,
 ) -> None:
-    keys = [key for key in active_segments if key[0] == run_id]
+    safe_instance_id = None if instance_id is None else str(instance_id)
+    safe_role_id = None if role_id is None else str(role_id)
+    keys = [
+        key
+        for key in active_segments
+        if key[0] == run_id
+        and (safe_instance_id is None or key[1] == safe_instance_id)
+        and (safe_role_id is None or key[2] == safe_role_id)
+    ]
     for key in keys:
         segment = active_segments.pop(key)
         message = _event_text_message(segment)
@@ -877,6 +910,12 @@ def _event_text_message(segment: dict[str, object]) -> dict[str, object] | None:
     run_id = str(segment.get("run_id") or "")
     role_id = str(segment.get("role_id") or "")
     instance_id = str(segment.get("instance_id") or "")
+    source_event_types = segment.get("source_event_types")
+    source_events = (
+        [str(event_type) for event_type in source_event_types]
+        if isinstance(source_event_types, list)
+        else []
+    )
     return {
         "conversation_id": "",
         "agent_role_id": role_id,
@@ -887,6 +926,7 @@ def _event_text_message(segment: dict[str, object]) -> dict[str, object] | None:
         "role_id": role_id,
         "created_at": str(segment.get("occurred_at") or ""),
         "reconstructed": True,
+        "reconstructed_source_event_types": source_events,
         "message": {
             "parts": [
                 {
@@ -1131,9 +1171,18 @@ def _merge_event_text_messages(
             normalized = _normalize_projected_text(text)
             if not normalized:
                 continue
+            source_event_types = message.get("reconstructed_source_event_types")
+            earliest_created_at = (
+                ""
+                if (
+                    isinstance(source_event_types, list)
+                    and RunEventType.OUTPUT_DELTA.value in source_event_types
+                )
+                else event_time
+            )
             match_index = _matching_text_occurrence_index(
                 existing_text_occurrences,
-                earliest_created_at=event_time,
+                earliest_created_at=earliest_created_at,
                 normalized=normalized,
             )
             if match_index is None:

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -790,6 +790,8 @@ def _project_text_messages_from_events(
             segment["occurred_at"] = str(event.get("occurred_at") or "")
             continue
         if event_type in {
+            RunEventType.INJECTION_ENQUEUED.value,
+            RunEventType.INJECTION_APPLIED.value,
             RunEventType.TOOL_CALL.value,
             RunEventType.TOOL_RESULT.value,
             RunEventType.MODEL_STEP_STARTED.value,
@@ -1078,18 +1080,27 @@ def _merge_event_text_messages(
 ) -> list[dict[str, object]]:
     if not event_text_messages:
         return coordinator_messages
-    existing_text_counts = _message_text_part_counts(coordinator_messages)
-    event_text_counts: Counter[str] = Counter()
+    existing_text_occurrences = _ordered_message_text_occurrences(coordinator_messages)
     missing: list[dict[str, object]] = []
-    for message in event_text_messages:
+    for message in sorted(
+        event_text_messages,
+        key=lambda item: str(item.get("created_at") or ""),
+    ):
+        event_time = str(message.get("created_at") or "")
         include_message = False
         for text in _message_text_parts(message):
             normalized = _normalize_projected_text(text)
             if not normalized:
                 continue
-            event_text_counts[normalized] += 1
-            if event_text_counts[normalized] > existing_text_counts[normalized]:
+            match_index = _matching_text_occurrence_index(
+                existing_text_occurrences,
+                earliest_created_at=event_time,
+                normalized=normalized,
+            )
+            if match_index is None:
                 include_message = True
+            else:
+                existing_text_occurrences.pop(match_index)
         if include_message:
             missing.append(message)
     if not missing:
@@ -1101,6 +1112,36 @@ def _merge_event_text_messages(
             1 if str(item.get("role") or "") == "user" else 0,
         ),
     )
+
+
+def _ordered_message_text_occurrences(
+    messages: list[dict[str, object]],
+) -> list[tuple[str, str]]:
+    occurrences: list[tuple[str, str]] = []
+    for message in sorted(
+        messages,
+        key=lambda item: str(item.get("created_at") or ""),
+    ):
+        created_at = str(message.get("created_at") or "")
+        for text in _message_text_parts(message):
+            normalized = _normalize_projected_text(text)
+            if normalized:
+                occurrences.append((created_at, normalized))
+    return occurrences
+
+
+def _matching_text_occurrence_index(
+    occurrences: list[tuple[str, str]],
+    *,
+    earliest_created_at: str,
+    normalized: str,
+) -> int | None:
+    for index, (created_at, text) in enumerate(occurrences):
+        if created_at < earliest_created_at:
+            continue
+        if text == normalized:
+            return index
+    return None
 
 
 def _merge_event_tool_messages(

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -7,6 +7,8 @@ from datetime import datetime
 import json
 from typing import cast
 
+from pydantic import ValidationError
+
 from relay_teams.agent_runtimes.instances.instance_repository import (
     AgentInstanceRepository,
 )
@@ -841,7 +843,7 @@ def _event_text_chunks(
     for item in output:
         try:
             part = ContentPartAdapter.validate_python(item)
-        except Exception:
+        except ValidationError:
             chunks.append(None)
             continue
         if isinstance(part, TextContentPart):
@@ -1571,7 +1573,7 @@ def _coerce_user_prompt_content_projection_item(
             return _binary_prompt_payload_projection(raw_item)
     try:
         validated = ContentPartAdapter.validate_python(item)
-    except Exception:
+    except ValidationError:
         pass
     else:
         return cast(dict[str, object], validated.model_dump(mode="json"))
@@ -1642,7 +1644,7 @@ def _intent_parts_to_text(intent_parts: list[dict[str, object]]) -> str | None:
     for item in intent_parts:
         try:
             part = ContentPartAdapter.validate_python(item)
-        except Exception:
+        except ValidationError:
             fragment = user_prompt_content_to_text(item)
         else:
             fragment = content_parts_to_text((part,))

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -36,7 +36,6 @@ ROUND_PROJECTION_EVENT_TYPES = (
     RunEventType.LLM_FALLBACK_EXHAUSTED.value,
     RunEventType.INJECTION_ENQUEUED.value,
     RunEventType.INJECTION_APPLIED.value,
-    RunEventType.TEXT_DELTA.value,
     RunEventType.TOOL_CALL.value,
     RunEventType.TOOL_RESULT.value,
     RunEventType.MODEL_STEP_STARTED.value,
@@ -44,6 +43,10 @@ ROUND_PROJECTION_EVENT_TYPES = (
     RunEventType.RUN_COMPLETED.value,
     RunEventType.RUN_FAILED.value,
     RunEventType.RUN_STOPPED.value,
+)
+DETAILED_ROUND_PROJECTION_EVENT_TYPES = (
+    *ROUND_PROJECTION_EVENT_TYPES,
+    RunEventType.TEXT_DELTA.value,
 )
 
 

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -36,6 +36,7 @@ ROUND_PROJECTION_EVENT_TYPES = (
     RunEventType.LLM_FALLBACK_EXHAUSTED.value,
     RunEventType.INJECTION_ENQUEUED.value,
     RunEventType.INJECTION_APPLIED.value,
+    RunEventType.TEXT_DELTA.value,
     RunEventType.TOOL_CALL.value,
     RunEventType.TOOL_RESULT.value,
     RunEventType.MODEL_STEP_STARTED.value,
@@ -142,6 +143,7 @@ def build_session_rounds(
     retry_events_by_run: dict[str, list[dict[str, object]]] = defaultdict(list)
     fallback_events_by_run: dict[str, list[dict[str, object]]] = defaultdict(list)
     injection_messages_by_run = _project_injection_messages(session_events)
+    text_messages_by_run = _project_text_messages_from_events(session_events)
     tool_messages_by_run = _project_tool_messages_from_events(session_events)
     final_output_by_run = _project_terminal_final_outputs(session_events)
     microcompact_by_run: dict[str, dict[str, object]] = {}
@@ -272,6 +274,7 @@ def build_session_rounds(
     run_ids.update(messages_by_run.keys())
     run_ids.update(retry_events_by_run.keys())
     run_ids.update(injection_messages_by_run.keys())
+    run_ids.update(text_messages_by_run.keys())
     run_ids.update(tool_messages_by_run.keys())
     run_ids.update(final_output_by_run.keys())
     run_ids.update(delegated_tasks_by_run.keys())
@@ -315,9 +318,17 @@ def build_session_rounds(
             )
             is not None
         ]
+        coordinator_messages = _merge_event_text_messages(
+            coordinator_messages,
+            _coordinator_event_messages(
+                text_messages_by_run.get(run_id, []),
+                coordinator_role_id=coordinator_role_id,
+                coordinator_instance_id=coordinator_instance_id,
+            ),
+        )
         coordinator_messages = _merge_event_tool_messages(
             coordinator_messages,
-            _coordinator_event_tool_messages(
+            _coordinator_event_messages(
                 tool_messages_by_run.get(run_id, []),
                 coordinator_role_id=coordinator_role_id,
                 coordinator_instance_id=coordinator_instance_id,
@@ -733,6 +744,116 @@ def _is_public_injection_payload(payload: dict[str, object]) -> bool:
     return source in {"user", "subagent"}
 
 
+def _project_text_messages_from_events(
+    session_events: list[dict[str, object]],
+) -> dict[str, list[dict[str, object]]]:
+    active_segments: dict[tuple[str, str, str], dict[str, object]] = {}
+    projected_by_run: dict[str, list[dict[str, object]]] = defaultdict(list)
+    sorted_session_events = sorted(
+        session_events,
+        key=lambda item: str(item.get("occurred_at") or ""),
+    )
+    for event in sorted_session_events:
+        event_type = str(event.get("event_type") or "")
+        payload = _parse_event_payload(event.get("payload_json"))
+        run_id = str(
+            event.get("trace_id") or payload.get("run_id") or event.get("run_id") or ""
+        )
+        if not run_id:
+            continue
+        if event_type == RunEventType.TEXT_DELTA.value:
+            text = str(payload.get("text") or "")
+            if not text:
+                continue
+            role_id = str(payload.get("role_id") or event.get("role_id") or "")
+            instance_id = str(
+                payload.get("instance_id") or event.get("instance_id") or ""
+            )
+            key = (run_id, instance_id, role_id)
+            segment = active_segments.get(key)
+            if segment is None:
+                segment = {
+                    "run_id": run_id,
+                    "role_id": role_id,
+                    "instance_id": instance_id,
+                    "task_id": str(event.get("task_id") or ""),
+                    "occurred_at": str(event.get("occurred_at") or ""),
+                    "chunks": [],
+                }
+                active_segments[key] = segment
+            chunks = segment.get("chunks")
+            if isinstance(chunks, list):
+                chunks.append(text)
+            segment["occurred_at"] = str(event.get("occurred_at") or "")
+            continue
+        if event_type in {
+            RunEventType.TOOL_CALL.value,
+            RunEventType.TOOL_RESULT.value,
+            RunEventType.MODEL_STEP_STARTED.value,
+            RunEventType.MODEL_STEP_FINISHED.value,
+            RunEventType.RUN_COMPLETED.value,
+            RunEventType.RUN_FAILED.value,
+            RunEventType.RUN_STOPPED.value,
+        }:
+            _flush_event_text_segments(
+                active_segments,
+                projected_by_run=projected_by_run,
+                run_id=run_id,
+            )
+    for run_id in tuple({key[0] for key in active_segments}):
+        _flush_event_text_segments(
+            active_segments,
+            projected_by_run=projected_by_run,
+            run_id=run_id,
+        )
+    return dict(projected_by_run)
+
+
+def _flush_event_text_segments(
+    active_segments: dict[tuple[str, str, str], dict[str, object]],
+    *,
+    projected_by_run: dict[str, list[dict[str, object]]],
+    run_id: str,
+) -> None:
+    keys = [key for key in active_segments if key[0] == run_id]
+    for key in keys:
+        segment = active_segments.pop(key)
+        message = _event_text_message(segment)
+        if message is not None:
+            projected_by_run[run_id].append(message)
+
+
+def _event_text_message(segment: dict[str, object]) -> dict[str, object] | None:
+    chunks = segment.get("chunks")
+    if not isinstance(chunks, list):
+        return None
+    content = "".join(str(chunk) for chunk in chunks).strip()
+    if not content:
+        return None
+    run_id = str(segment.get("run_id") or "")
+    role_id = str(segment.get("role_id") or "")
+    instance_id = str(segment.get("instance_id") or "")
+    return {
+        "conversation_id": "",
+        "agent_role_id": role_id,
+        "instance_id": instance_id,
+        "task_id": str(segment.get("task_id") or ""),
+        "trace_id": run_id,
+        "role": "assistant",
+        "role_id": role_id,
+        "created_at": str(segment.get("occurred_at") or ""),
+        "reconstructed": True,
+        "message": {
+            "parts": [
+                {
+                    "part_kind": "text",
+                    "content": content,
+                }
+            ]
+        },
+    }
+
+
 def _project_tool_messages_from_events(
     session_events: list[dict[str, object]],
 ) -> dict[str, list[dict[str, object]]]:
@@ -908,7 +1029,7 @@ def _event_tool_result_message(record: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _coordinator_event_tool_messages(
+def _coordinator_event_messages(
     messages: list[dict[str, object]],
     *,
     coordinator_role_id: str | None,
@@ -933,6 +1054,50 @@ def _coordinator_event_tool_messages(
         if coordinator_role_id is not None and role_id == coordinator_role_id:
             filtered.append(message)
     return filtered
+
+
+def _coordinator_event_tool_messages(
+    messages: list[dict[str, object]],
+    *,
+    coordinator_role_id: str | None,
+    coordinator_instance_id: str | None,
+) -> list[dict[str, object]]:
+    return _coordinator_event_messages(
+        messages,
+        coordinator_role_id=coordinator_role_id,
+        coordinator_instance_id=coordinator_instance_id,
+    )
+
+
+def _merge_event_text_messages(
+    coordinator_messages: list[dict[str, object]],
+    event_text_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    if not event_text_messages:
+        return coordinator_messages
+    existing_text_counts = _message_text_part_counts(coordinator_messages)
+    event_text_counts: Counter[str] = Counter()
+    missing: list[dict[str, object]] = []
+    for message in event_text_messages:
+        include_message = False
+        for text in _message_text_parts(message):
+            normalized = _normalize_projected_text(text)
+            if not normalized:
+                continue
+            event_text_counts[normalized] += 1
+            if event_text_counts[normalized] > existing_text_counts[normalized]:
+                include_message = True
+        if include_message:
+            missing.append(message)
+    if not missing:
+        return coordinator_messages
+    return sorted(
+        [*coordinator_messages, *missing],
+        key=lambda item: (
+            str(item.get("created_at") or ""),
+            1 if str(item.get("role") or "") == "user" else 0,
+        ),
+    )
 
 
 def _merge_event_tool_messages(
@@ -980,6 +1145,18 @@ def _message_tool_part_keys(message: dict[str, object]) -> list[tuple[str, str]]
         if part_kind and tool_call_id:
             tool_part_keys.append((part_kind, tool_call_id))
     return tool_part_keys
+
+
+def _message_text_part_counts(
+    messages: list[dict[str, object]],
+) -> Counter[str]:
+    text_part_counts: Counter[str] = Counter()
+    for message in messages:
+        for text in _message_text_parts(message):
+            normalized = _normalize_projected_text(text)
+            if normalized:
+                text_part_counts[normalized] += 1
+    return text_part_counts
 
 
 def _message_parts(message: dict[str, object]) -> list[dict[str, object]]:

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -155,7 +155,7 @@ class _SessionDeleteContext(NamedTuple):
 
 _SNAPSHOT_DIRTY_EVENT_TYPES = frozenset(
     {
-        *(RunEventType(event_type) for event_type in ROUND_PROJECTION_EVENT_TYPES),
+        *(RunEventType(event_type) for event_type in DETAILED_ROUND_PROJECTION_EVENT_TYPES),
         RunEventType.RUN_STARTED,
         RunEventType.RUN_PAUSED,
         RunEventType.RUN_RESUMED,

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -155,7 +155,10 @@ class _SessionDeleteContext(NamedTuple):
 
 _SNAPSHOT_DIRTY_EVENT_TYPES = frozenset(
     {
-        *(RunEventType(event_type) for event_type in DETAILED_ROUND_PROJECTION_EVENT_TYPES),
+        *(
+            RunEventType(event_type)
+            for event_type in DETAILED_ROUND_PROJECTION_EVENT_TYPES
+        ),
         RunEventType.RUN_STARTED,
         RunEventType.RUN_PAUSED,
         RunEventType.RUN_RESUMED,

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -155,10 +155,7 @@ class _SessionDeleteContext(NamedTuple):
 
 _SNAPSHOT_DIRTY_EVENT_TYPES = frozenset(
     {
-        *(
-            RunEventType(event_type)
-            for event_type in DETAILED_ROUND_PROJECTION_EVENT_TYPES
-        ),
+        *(RunEventType(event_type) for event_type in ROUND_PROJECTION_EVENT_TYPES),
         RunEventType.RUN_STARTED,
         RunEventType.RUN_PAUSED,
         RunEventType.RUN_RESUMED,
@@ -180,6 +177,12 @@ _SNAPSHOT_DIRTY_EVENT_TYPES = frozenset(
         RunEventType.BACKGROUND_TASK_COMPLETED,
         RunEventType.BACKGROUND_TASK_STOPPED,
         RunEventType.TOKEN_USAGE,
+    }
+)
+_DETAILED_ROUND_DIRTY_EVENT_TYPES = frozenset(
+    {
+        RunEventType.TEXT_DELTA,
+        RunEventType.OUTPUT_DELTA,
     }
 )
 _LIST_DIRTY_EVENT_TYPES = frozenset(
@@ -382,6 +385,13 @@ class SessionService:
                 and not self._is_running_async_publish_listener()
             ):
                 self._merge_terminal_session_projection_into_list_cache(safe_session_id)
+        if event.event_type in _DETAILED_ROUND_DIRTY_EVENT_TYPES:
+            self._session_snapshot_cache.mark_session_dirty(
+                safe_session_id,
+                section=SessionSnapshotSection.ROUNDS,
+                cache_key_predicate=self._is_detailed_rounds_cache_key,
+            )
+            return
         if (
             event.event_type not in _SNAPSHOT_DIRTY_EVENT_TYPES
             and not spawn_subagent_dirty
@@ -404,6 +414,10 @@ class SessionService:
             return False
         tool_name = payload.get("tool_name")
         return isinstance(tool_name, str) and tool_name.strip() == "spawn_subagent"
+
+    @staticmethod
+    def _is_detailed_rounds_cache_key(cache_key: str) -> bool:
+        return "timeline=False" in cache_key and "summary=False" in cache_key
 
     def _merge_terminal_session_projection_into_list_cache(
         self,

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -38,6 +38,7 @@ from relay_teams.sessions.runs.active_run_registry import ActiveSessionRunRegist
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.runtime_config import RuntimeConfig
 from relay_teams.sessions.session_rounds_projection import (
+    DETAILED_ROUND_PROJECTION_EVENT_TYPES,
     ROUND_PROJECTION_EVENT_TYPES,
     approvals_to_projection,
     build_session_rounds,
@@ -1744,6 +1745,31 @@ class SessionService:
         )
         return cast(list[dict[str, object]], list(events))
 
+    def _get_detailed_round_projection_events(
+        self, session_id: str
+    ) -> list[dict[str, object]]:
+        if self._event_log is None:
+            return []
+        events = self._event_log.list_by_session_event_types(
+            session_id,
+            DETAILED_ROUND_PROJECTION_EVENT_TYPES,
+        )
+        return cast(list[dict[str, object]], list(events))
+
+    def _get_detailed_round_projection_events_for_runs(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+    ) -> list[dict[str, object]]:
+        if self._event_log is None:
+            return []
+        events = self._event_log.list_by_session_run_ids_event_types(
+            session_id,
+            run_ids,
+            DETAILED_ROUND_PROJECTION_EVENT_TYPES,
+        )
+        return cast(list[dict[str, object]], list(events))
+
     def get_session_messages(self, session_id: str) -> list[dict[str, object]]:
         return cast(
             list[dict[str, object]],
@@ -1875,10 +1901,10 @@ class SessionService:
                 self._get_session_history_markers if include_history_markers else None
             ),
             get_session_events=(
-                self._get_round_projection_events
+                self._get_detailed_round_projection_events
                 if selected_run_ids is None
                 else lambda current_session_id: (
-                    self._get_round_projection_events_for_runs(
+                    self._get_detailed_round_projection_events_for_runs(
                         current_session_id,
                         selected_run_ids,
                     )

--- a/src/relay_teams/sessions/session_snapshot_cache.py
+++ b/src/relay_teams/sessions/session_snapshot_cache.py
@@ -514,6 +514,8 @@ class SessionSnapshotCache:
         session_id: str,
         *,
         requires_fresh_read: bool = False,
+        section: SessionSnapshotSection | None = None,
+        cache_key_predicate: Callable[[str], bool] | None = None,
     ) -> None:
         safe_session_id = str(session_id or "").strip()
         if not safe_session_id:
@@ -522,7 +524,13 @@ class SessionSnapshotCache:
             matching_caches = [
                 cache
                 for key, cache in self._entries.items()
-                if key[0] == safe_session_id and isinstance(cache, StaleFirstCache)
+                if key[0] == safe_session_id
+                and (section is None or key[1] == section.value)
+                and (
+                    cache_key_predicate is None
+                    or cache_key_predicate(str(key[2] or ""))
+                )
+                and isinstance(cache, StaleFirstCache)
             ]
         for cache in matching_caches:
             cache.mark_dirty(requires_fresh_read=requires_fresh_read)

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -117,6 +117,30 @@ def test_overlay_replay_text_around_model_step_boundary_stays_segmented_in_brows
     ]
 
 
+def test_overlay_replay_text_around_model_step_boundary_preserves_whitespace_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderOverlayReplayTextAroundModelStepBoundaryWhitespace()
+        """
+    )
+
+    assert payload["rawTextBlocks"] == ["before retry ", "\n after retry"]
+    assert [
+        [part["content"], part["closed"]]
+        for part in payload["overlayParts"]
+        if part["kind"] == "text"
+    ] == [
+        ["before retry ", True],
+        ["\n after retry", False],
+    ]
+
+
 def test_output_delta_text_around_tool_calls_stays_segmented_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -999,6 +1023,44 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
               closed: part.closed === true,
             }})),
           cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderOverlayReplayTextAroundModelStepBoundaryWhitespace() {{
+        clearAllStreamState();
+        const container = makeContainer('overlay-text-around-model-step-whitespace');
+        const runId = 'run-overlay-text-around-model-step-whitespace';
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'before retry ' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-step-whitespace-text-1' }},
+        );
+        applyStreamOverlayEvent(
+          'model_step_finished',
+          {{ role_id: 'Coordinator', instance_id: 'primary' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-step-whitespace-finished-1' }},
+        );
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: '\\n after retry' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-step-whitespace-text-2' }},
+        );
+        renderHistory(container, [], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          rawTextBlocks: Array.from(container.querySelectorAll('.msg-text'))
+            .map(item => item.textContent),
+          overlayParts: (getCoordinatorStreamOverlay(runId)?.parts || [])
+            .map(part => ({{
+              kind: part.kind,
+              content: part.content || '',
+              closed: part.closed === true,
+            }})),
         }};
       }},
 

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -92,6 +92,24 @@ def test_overlay_replay_text_around_tool_calls_stays_visible_in_browser(
     assert payload["cursorCount"] == 1
 
 
+def test_output_delta_text_around_tool_calls_stays_segmented_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderOutputDeltaTextAroundToolCalls()
+        """
+    )
+
+    assert payload["textBlocks"] == ["before tool", "during tool", "after result"]
+    assert payload["toolBlockCount"] == 1
+    assert payload["cursorCount"] == 1
+
+
 def test_partial_persisted_repeated_text_after_tool_is_preserved_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -848,6 +866,51 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
               toolCallId: part.tool_call_id || '',
               status: part.status || '',
             }})),
+          cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderOutputDeltaTextAroundToolCalls() {{
+        clearAllStreamState();
+        const container = makeContainer('output-delta-text-around-tools');
+        const runId = 'run-output-delta-text-around-tools';
+        applyStreamOverlayEvent(
+          'output_delta',
+          {{ output: [{{ kind: 'text', text: 'before tool' }}] }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'output-text-1' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{ tool_name: 'shell', tool_call_id: 'call-output-text', args: {{ command: 'date' }} }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'output-tool-1' }},
+        );
+        applyStreamOverlayEvent(
+          'output_delta',
+          {{ output: [{{ kind: 'text', text: 'during tool' }}] }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'output-text-2' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_result',
+          {{ tool_name: 'shell', tool_call_id: 'call-output-text', result: {{ ok: true, output: 'tool done' }} }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'output-tool-2' }},
+        );
+        applyStreamOverlayEvent(
+          'output_delta',
+          {{ output: [{{ kind: 'text', text: 'after result' }}] }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'output-text-3' }},
+        );
+        renderHistory(container, [], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          textBlocks: Array.from(container.querySelectorAll('.msg-text'))
+            .map(item => item.textContent.replace(/\\s+/g, ' ').trim())
+            .filter(Boolean),
+          toolBlockCount: container.querySelectorAll('.tool-block').length,
           cursorCount: container.querySelectorAll('.streaming-cursor').length,
         }};
       }},

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -92,6 +92,31 @@ def test_overlay_replay_text_around_tool_calls_stays_visible_in_browser(
     assert payload["cursorCount"] == 1
 
 
+def test_overlay_replay_text_around_model_step_boundary_stays_segmented_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderOverlayReplayTextAroundModelStepBoundary()
+        """
+    )
+
+    assert payload["textBlocks"] == ["before retry", "after retry"]
+    assert payload["cursorCount"] == 1
+    assert [
+        [part["kind"], part["content"], part["closed"]]
+        for part in payload["overlayParts"]
+        if part["kind"] == "text"
+    ] == [
+        ["text", "before retry", True],
+        ["text", "after retry", False],
+    ]
+
+
 def test_output_delta_text_around_tool_calls_stays_segmented_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -928,6 +953,51 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
             .map(item => item.textContent.replace(/\\s+/g, ' ').trim())
             .filter(Boolean),
           toolBlockCount: container.querySelectorAll('.tool-block').length,
+          cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderOverlayReplayTextAroundModelStepBoundary() {{
+        clearAllStreamState();
+        const container = makeContainer('overlay-text-around-model-step');
+        const runId = 'run-overlay-text-around-model-step';
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'before retry' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-step-text-1' }},
+        );
+        applyStreamOverlayEvent(
+          'model_step_finished',
+          {{ role_id: 'Coordinator', instance_id: 'primary' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-step-finished-1' }},
+        );
+        applyStreamOverlayEvent(
+          'model_step_started',
+          {{ role_id: 'Coordinator', instance_id: 'primary' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-step-started-1' }},
+        );
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'after retry' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-step-text-2' }},
+        );
+        renderHistory(container, [], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          textBlocks: Array.from(container.querySelectorAll('.msg-text'))
+            .map(item => item.textContent.replace(/\\s+/g, ' ').trim())
+            .filter(Boolean),
+          overlayParts: (getCoordinatorStreamOverlay(runId)?.parts || [])
+            .map(part => ({{
+              kind: part.kind,
+              content: part.content || '',
+              closed: part.closed === true,
+            }})),
           cursorCount: container.querySelectorAll('.streaming-cursor').length,
         }};
       }},

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -47,6 +47,86 @@ def browser_page() -> Iterator[Page]:
             os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous_browser_root
 
 
+def test_live_text_around_tool_calls_stays_visible_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderLiveTextAroundToolCalls()
+        """
+    )
+
+    assert payload["textBlocks"] == ["before tool", "during tool", "after result"]
+    assert payload["toolBlockCount"] == 1
+    assert payload["cursorCount"] == 1
+    assert [
+        [part["kind"], part["content"], part["closed"]]
+        for part in payload["overlayParts"]
+        if part["kind"] == "text"
+    ] == [
+        ["text", "before tool", True],
+        ["text", "during tool", True],
+        ["text", "after result", False],
+    ]
+
+
+def test_overlay_replay_text_around_tool_calls_stays_visible_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderOverlayReplayTextAroundToolCalls()
+        """
+    )
+
+    assert payload["textBlocks"] == ["before tool", "during tool", "after result"]
+    assert payload["toolBlockCount"] == 1
+    assert payload["cursorCount"] == 1
+
+
+def test_partial_persisted_repeated_text_after_tool_is_preserved_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderPartialPersistedRepeatedTextAroundTool()
+        """
+    )
+
+    assert payload["occurrences"] == 2
+    assert payload["toolBlockCount"] == 1
+
+
+def test_timeline_text_update_keeps_rich_content_and_cursor_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderTimelineTextUpdateKeepsRichContent()
+        """
+    )
+
+    assert "hello bold" in payload["text"]
+    assert payload["strongText"] == "bold"
+    assert payload["cursorCount"] == 1
+
+
 def test_streamed_tool_args_match_persisted_history_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -588,6 +668,12 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
         history_module = (
             f"{base_url}/frontend/dist/js/components/messageRenderer/history.js"
         )
+        timeline_renderer_module = (
+            f"{base_url}/frontend/dist/js/components/messageTimeline/renderer.js"
+        )
+        timeline_store_module = (
+            f"{base_url}/frontend/dist/js/components/messageTimeline/store.js"
+        )
         event_router_module = f"{base_url}/frontend/dist/js/core/eventRouter/index.js"
         html_path.write_text(
             f"""
@@ -620,6 +706,13 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
     import {{
       renderHistoricalMessageList,
     }} from {json.dumps(history_module)};
+    import {{
+      renderTimelineStream,
+    }} from {json.dumps(timeline_renderer_module)};
+    import {{
+      applyTimelineAction,
+      clearTimelineState,
+    }} from {json.dumps(timeline_store_module)};
     import {{
       routeEvent,
     }} from {json.dumps(event_router_module)};
@@ -663,6 +756,172 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
     }}
 
     window.__streamTimelineHarness = {{
+      renderLiveTextAroundToolCalls() {{
+        clearAllStreamState();
+        const container = makeContainer('live-text-around-tools');
+        const runId = 'run-live-text-around-tools';
+        getOrCreateStreamBlock(container, 'primary', 'Coordinator', 'Main Agent', runId);
+        appendStreamChunk('primary', 'before tool', runId, 'Coordinator', 'Main Agent');
+        appendToolCallBlock(
+          container,
+          'primary',
+          'shell',
+          {{ command: 'date' }},
+          'call-live-text',
+          {{ runId, roleId: 'Coordinator', label: 'Main Agent' }},
+        );
+        appendStreamChunk('primary', 'during tool', runId, 'Coordinator', 'Main Agent');
+        updateToolResult(
+          'primary',
+          'shell',
+          {{ ok: true, output: 'tool done' }},
+          false,
+          'call-live-text',
+          {{ runId, roleId: 'Coordinator', label: 'Main Agent', container }},
+        );
+        appendStreamChunk('primary', 'after result', runId, 'Coordinator', 'Main Agent');
+        const textBlocks = Array.from(container.querySelectorAll('.msg-text'))
+          .map(item => item.textContent.replace(/\\s+/g, ' ').trim())
+          .filter(Boolean);
+        const overlayParts = (getCoordinatorStreamOverlay(runId)?.parts || [])
+          .map(part => ({{
+            kind: part.kind,
+            content: part.content || '',
+            closed: part.closed === true,
+            toolCallId: part.tool_call_id || '',
+            status: part.status || '',
+          }}));
+        return {{
+          textBlocks,
+          toolBlockCount: container.querySelectorAll('.tool-block').length,
+          overlayParts,
+          cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderOverlayReplayTextAroundToolCalls() {{
+        clearAllStreamState();
+        const container = makeContainer('overlay-text-around-tools');
+        const runId = 'run-overlay-text-around-tools';
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'before tool' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-text-1' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{ tool_name: 'shell', tool_call_id: 'call-overlay-text', args: {{ command: 'date' }} }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-tool-1' }},
+        );
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'during tool' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-text-2' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_result',
+          {{ tool_name: 'shell', tool_call_id: 'call-overlay-text', result: {{ ok: true, output: 'tool done' }} }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-tool-2' }},
+        );
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'after result' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'overlay-text-3' }},
+        );
+        renderHistory(container, [], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          textBlocks: Array.from(container.querySelectorAll('.msg-text'))
+            .map(item => item.textContent.replace(/\\s+/g, ' ').trim())
+            .filter(Boolean),
+          toolBlockCount: container.querySelectorAll('.tool-block').length,
+          overlayParts: (getCoordinatorStreamOverlay(runId)?.parts || [])
+            .map(part => ({{
+              kind: part.kind,
+              content: part.content || '',
+              closed: part.closed === true,
+              toolCallId: part.tool_call_id || '',
+              status: part.status || '',
+            }})),
+          cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderPartialPersistedRepeatedTextAroundTool() {{
+        clearAllStreamState();
+        const container = makeContainer('partial-persisted-repeated-text');
+        const runId = 'run-partial-persisted-repeated-text';
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'same process text' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-text-1' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{ tool_name: 'shell', tool_call_id: 'call-partial-text', args: {{ command: 'date' }} }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-tool-1' }},
+        );
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'same process text' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-text-2' }},
+        );
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: 'primary',
+          created_at: '2026-04-25T12:00:01Z',
+          message: {{
+            parts: [{{ part_kind: 'text', content: 'same process text' }}],
+          }},
+        }}], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          text: container.textContent || '',
+          occurrences: countSubstring(container.textContent || '', 'same process text'),
+          toolBlockCount: container.querySelectorAll('.tool-block').length,
+        }};
+      }},
+
+      renderTimelineTextUpdateKeepsRichContent() {{
+        clearTimelineState();
+        const container = makeContainer('timeline-rich-text-update');
+        const scope = {{
+          runId: 'run-timeline-rich-text-update',
+          instanceId: 'primary',
+          roleId: 'Coordinator',
+          streamKey: 'primary',
+          view: 'main',
+        }};
+        let stream = applyTimelineAction({{
+          type: 'text_delta',
+          scope,
+          text: 'hello **bo',
+        }});
+        renderTimelineStream(container, stream, {{ label: 'Main Agent' }});
+        stream = applyTimelineAction({{
+          type: 'text_delta',
+          scope,
+          text: 'ld**',
+        }});
+        renderTimelineStream(container, stream, {{ label: 'Main Agent' }});
+        return {{
+          text: container.textContent || '',
+          strongText: container.querySelector('strong')?.textContent || '',
+          cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
       renderToolArgsParity() {{
         clearAllStreamState();
         const container = makeContainer('tool-args');

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -110,6 +110,23 @@ def test_output_delta_text_around_tool_calls_stays_segmented_in_browser(
     assert payload["cursorCount"] == 1
 
 
+def test_persisted_history_text_around_tool_calls_stays_segmented_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderPersistedHistoryTextAroundToolCalls()
+        """
+    )
+
+    assert payload["textBlocks"] == ["before tool", "during tool", "after result"]
+    assert payload["toolBlockCount"] == 1
+
+
 def test_partial_persisted_repeated_text_after_tool_is_preserved_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -912,6 +929,48 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
             .filter(Boolean),
           toolBlockCount: container.querySelectorAll('.tool-block').length,
           cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderPersistedHistoryTextAroundToolCalls() {{
+        clearAllStreamState();
+        const container = makeContainer('persisted-history-text-around-tools');
+        const runId = 'run-persisted-history-text-around-tools';
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: 'primary',
+          message: {{
+            parts: [
+              {{ part_kind: 'text', content: 'before tool' }},
+              {{
+                part_kind: 'tool-call',
+                tool_name: 'shell',
+                tool_call_id: 'call-history-text',
+                args: {{ command: 'date' }},
+              }},
+              {{ part_kind: 'text', content: 'during tool' }},
+              {{
+                part_kind: 'tool-return',
+                tool_name: 'shell',
+                tool_call_id: 'call-history-text',
+                content: {{ ok: true, output: 'tool done' }},
+              }},
+              {{ part_kind: 'text', content: 'after result' }},
+            ],
+          }},
+        }}], {{
+          runId,
+          runStatus: 'completed',
+          streamOverlayEntry: null,
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          textBlocks: Array.from(container.querySelectorAll('.msg-text'))
+            .map(item => item.textContent.replace(/\\s+/g, ' ').trim())
+            .filter(Boolean),
+          toolBlockCount: container.querySelectorAll('.tool-block').length,
         }};
       }},
 

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -258,7 +258,19 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
         in renderer_stream_script
     )
     assert "function findLastReusableTextElement(contentEl) {" in renderer_stream_script
-    assert "function resolveReusableRawText(overlayEntry) {" in renderer_stream_script
+    assert "function resolveReusableTextPart(overlayEntry) {" in renderer_stream_script
+    assert (
+        "const reusableTextPart = resolveReusableTextPart(overlayEntry);"
+        in renderer_stream_script
+    )
+    assert (
+        "const canReuseText = overlayEntry?.textStreaming === true && !!reusableTextPart;"
+        in renderer_stream_script
+    )
+    assert (
+        "if (part.closed === true || part.streaming === false) {"
+        in renderer_stream_script
+    )
     assert "let lastRenderedMessage = null;" in history_script
     assert "renderStreamOverlayEntry(" in history_script
     assert "pendingToolBlocks," in history_script

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -4477,11 +4477,90 @@ bindStreamOverlayToContainer(container, {
 });
 appendStreamChunk("inst-2", " world", "run-2", "Writer", "Writer");
 
-console.log(JSON.stringify(contentEl.children.map(child => ({
+const closedContentEl = {
+  children: [
+    globalThis.__createTextNode("before", false),
+  ],
+  appendChild(child) {
+    child.__parent = this;
+    this.children.push(child);
+  },
+  querySelector() { return null; },
+  querySelectorAll(selector) {
+    if (selector === ".msg-text") {
+      return this.children.filter(child => child?.className === "msg-text");
+    }
+    return [];
+  },
+};
+closedContentEl.children.forEach(child => {
+  child.__parent = closedContentEl;
+});
+
+const closedWrapper = {
+  dataset: {
+    runId: "run-3",
+    roleId: "Writer",
+    instanceId: "inst-3",
+    streamKey: "inst-3",
+  },
+  querySelector(selector) {
+    if (selector === ".msg-role") {
+      return { textContent: "WRITER" };
+    }
+    if (selector === ".msg-content") {
+      return closedContentEl;
+    }
+    return null;
+  },
+  closest() { return null; },
+};
+
+const closedContainer = {
+  __messages: [{ wrapper: closedWrapper, contentEl: closedContentEl }],
+  querySelectorAll() {
+    return this.__messages.map(item => item.wrapper);
+  },
+};
+
+applyStreamOverlayEvent(
+  "text_delta",
+  { text: "before" },
+  {
+    runId: "run-3",
+    instanceId: "inst-3",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+applyStreamOverlayEvent(
+  "tool_call",
+  { tool_call_id: "call-1", tool_name: "shell", args: {} },
+  {
+    runId: "run-3",
+    instanceId: "inst-3",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+bindStreamOverlayToContainer(closedContainer, {
+  instanceId: "inst-3",
+  roleId: "Writer",
+  label: "Writer",
+  runId: "run-3",
+});
+appendStreamChunk("inst-3", " after", "run-3", "Writer", "Writer");
+
+const serialize = child => ({
   text: String(child.__text || ""),
   idleCursor: String(child?.dataset?.idleCursor || ""),
   idleFlag: child.__idleCursor === true,
-}))));
+});
+
+console.log(JSON.stringify({
+  idleRebind: contentEl.children.map(serialize),
+  closedRebind: closedContentEl.children.map(serialize),
+}));
 """.strip()
 
     result = subprocess.run(
@@ -4495,7 +4574,7 @@ console.log(JSON.stringify(contentEl.children.map(child => ({
     )
 
     payload = json.loads(result.stdout)
-    assert payload == [
+    assert payload["idleRebind"] == [
         {
             "text": "hello",
             "idleCursor": "",
@@ -4503,6 +4582,18 @@ console.log(JSON.stringify(contentEl.children.map(child => ({
         },
         {
             "text": " world",
+            "idleCursor": "",
+            "idleFlag": False,
+        },
+    ]
+    assert payload["closedRebind"] == [
+        {
+            "text": "before",
+            "idleCursor": "",
+            "idleFlag": False,
+        },
+        {
+            "text": " after",
             "idleCursor": "",
             "idleFlag": False,
         },

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -4735,5 +4735,5 @@ console.log(JSON.stringify({
                 "idleCursor": "",
             }
         ],
-        "cursorStates": [True],
+        "cursorStates": [],
     }

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -721,6 +721,119 @@ console.log(JSON.stringify(container.children.map(child => {
     assert json.loads(result.stdout) == ["message:A", "marker:inj-1:改一下"]
 
 
+def test_live_tool_result_closes_text_segment_before_next_delta(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "live_tool_text_segments"
+    temp_dir.mkdir()
+    _write_live_injection_test_modules(temp_dir, source)
+
+    runner = """
+globalThis.document = {
+  createElement(tagName = "div") {
+    return {
+      tagName,
+      className: "",
+      dataset: {},
+      children: [],
+      textContent: "",
+      append(...items) { items.forEach(item => this.appendChild(item)); },
+      setAttribute(name, value) { this[name] = value; },
+      appendChild(child) { child.__parent = this; this.children.push(child); return child; },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      remove() {
+        const parent = this.__parent;
+        if (!parent?.children) return;
+        const index = parent.children.indexOf(this);
+        if (index !== -1) parent.children.splice(index, 1);
+      },
+    };
+  },
+};
+globalThis.__relayTeamsMessageTimelineApplyAction = () => {};
+
+import {
+  appendStreamChunk,
+  appendToolCallBlock,
+  getCoordinatorStreamOverlay,
+  getOrCreateStreamBlock,
+  updateToolResult,
+} from "./stream.js";
+
+const container = {
+  children: [],
+  appendChild(child) { child.__parent = this; this.children.push(child); return child; },
+  querySelectorAll(selector) {
+    if (selector !== ".message") return [];
+    return this.children.filter(child => child?.kind === "message");
+  },
+};
+
+getOrCreateStreamBlock(container, "primary", "main-role", "Main Agent", "run-primary");
+appendStreamChunk("primary", "before", "run-primary", "main-role", "Main Agent");
+appendToolCallBlock(
+  container,
+  "primary",
+  "shell",
+  { command: "date" },
+  "call-1",
+  { runId: "run-primary", roleId: "main-role", label: "Main Agent" },
+);
+appendStreamChunk("primary", "during", "run-primary", "main-role", "Main Agent");
+updateToolResult(
+  "primary",
+  "shell",
+  { ok: true, data: "done" },
+  false,
+  "call-1",
+  { runId: "run-primary", roleId: "main-role", label: "Main Agent", container },
+);
+appendStreamChunk("primary", "after", "run-primary", "main-role", "Main Agent");
+
+const contentChildren = container.children[0].contentEl.children.map(child => ({
+  className: child.className,
+  text: child.textContent || "",
+  status: child.dataset?.status || "",
+}));
+const overlayTextParts = getCoordinatorStreamOverlay("run-primary").parts
+  .filter(part => part.kind === "text")
+  .map(part => ({
+    content: part.content,
+    closed: part.closed === true,
+  }));
+
+console.log(JSON.stringify({ contentChildren, overlayTextParts }));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "contentChildren": [
+            {"className": "msg-text", "text": "before", "status": ""},
+            {"className": "tool-block", "text": "", "status": "completed"},
+            {"className": "msg-text", "text": "during", "status": ""},
+            {"className": "msg-text", "text": "after", "status": ""},
+        ],
+        "overlayTextParts": [
+            {"content": "before", "closed": True},
+            {"content": "during", "closed": True},
+            {"content": "after", "closed": False},
+        ],
+    }
+
+
 def test_live_injection_removes_superseded_tool_before_new_segment(
     tmp_path: Path,
 ) -> None:
@@ -1811,6 +1924,45 @@ renderHistoricalMessageList(tailContainer, [
   runStatus: "running",
 });
 
+const repeatedContainer = {
+  dataset: {},
+  messages: [],
+  appendChild() {},
+  querySelectorAll() {
+    return this.messages.map(item => item.wrapper);
+  },
+  querySelector() {
+    return null;
+  },
+};
+
+renderHistoricalMessageList(repeatedContainer, [
+  {
+    role: "assistant",
+    role_id: "Main Agent",
+    instance_id: "primary",
+    created_at: "2026-04-25T12:00:00",
+    message: {
+      parts: [{ part_kind: "text", content: "repeat" }],
+    },
+  },
+], {
+  runId: "run-1",
+  streamOverlayEntry: {
+    roleId: "Main Agent",
+    instanceId: "primary",
+    label: "Main Agent",
+    parts: [
+      { kind: "text", content: "repeat" },
+      { kind: "tool", tool_name: "shell", tool_call_id: "call-repeat", args: { command: "date" }, status: "pending" },
+      { kind: "text", content: "repeat" },
+    ],
+    textStreaming: true,
+  },
+  isLatestRound: true,
+  runStatus: "running",
+});
+
 const terminalContainer = {
   dataset: {},
   messages: [],
@@ -1854,6 +2006,7 @@ console.log(JSON.stringify({
   wrapperCount: container.messages.length,
   children: container.messages[0].contentEl.children,
   tailChildren: tailContainer.messages[1].contentEl.children,
+  repeatedChildren: repeatedContainer.messages[1].contentEl.children,
   terminalMessageCount: terminalContainer.messages.length,
   terminalChildren: terminalContainer.messages[terminalContainer.messages.length - 1].contentEl.children,
 }));
@@ -1899,6 +2052,16 @@ console.log(JSON.stringify({
             "parts": [{"part_kind": "text", "content": "different tail"}],
         },
         {"type": "text", "text": "done", "streaming": True},
+    ]
+    assert payload["repeatedChildren"] == [
+        {
+            "type": "tool",
+            "toolName": "shell",
+            "args": {"command": "date"},
+            "toolCallId": "call-repeat",
+            "dataset": {},
+        },
+        {"type": "text", "text": "repeat", "streaming": True},
     ]
     assert payload["terminalMessageCount"] == 2
     assert payload["terminalChildren"] == [

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -333,6 +333,7 @@ console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-primary")));
     assert payload["coordinator"]["parts"][1] == {
         "kind": "text",
         "content": "still not persisted",
+        "closed": True,
         "streaming": False,
     }
     assert payload["coordinator"]["textStreaming"] is False

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -2051,7 +2051,7 @@ console.log(JSON.stringify({
             "type": "history-parts",
             "parts": [{"part_kind": "text", "content": "different tail"}],
         },
-        {"type": "text", "text": "done", "streaming": True},
+        {"type": "text", "text": "", "streaming": True},
     ]
     assert payload["repeatedChildren"] == [
         {

--- a/tests/unit_tests/frontend/test_streaming_cursor_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_cursor_ui.py
@@ -142,8 +142,10 @@ def test_streaming_messages_render_a_terminal_cursor_until_finalize() -> None:
     )
     assert "const flushText = (streaming = false) => {" in history_script
     assert (
-        "appendMessageText(ensureContentEl(), streaming ? safeText : safeText.trim(), { streaming });"
-        in history_script
+        "appendMessageText(ensureContentEl(), safeText, {\n"
+        "            streaming,\n"
+        "            preserveBoundaryWhitespace: true,\n"
+        "        });" in history_script
     )
     assert "flushText(false);" in history_script
     assert "flushText(hasLiveTextTail && !!trailingTextPart);" in history_script

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -746,6 +746,13 @@ def test_proxy_environment_variable_change_triggers_proxy_runtime_refresh(
     assert mcp_reload_calls == ["mcp", "mcp"]
 
 
+async def _wait_for_start_call(start_calls: list[str], expected: str) -> None:
+    for _ in range(20):
+        if expected in start_calls:
+            return
+        await asyncio.sleep(0.01)
+
+
 @pytest.mark.asyncio
 async def test_container_binds_background_completion_sink_during_start(
     monkeypatch,
@@ -883,15 +890,15 @@ async def test_container_binds_background_completion_sink_during_start(
 
     try:
         await container.start()
-        await asyncio.sleep(0)
+        await _wait_for_start_call(start_calls, "feishu-subscription")
 
         assert lifecycle_calls == ["bind_event_loop", "bind_completion_sink"]
         assert (
             container.background_task_service._completion_sink is container.run_service
         )
-        assert start_calls == [
+        assert start_calls.count("feishu-subscription") == 1
+        assert [call for call in start_calls if call != "feishu-subscription"] == [
             "wechat",
-            "feishu-subscription",
             "feishu-message-pool",
             "automation-delivery",
             "automation-bound-session",
@@ -1013,20 +1020,20 @@ async def test_container_start_continues_when_memory_reindex_fails(
 
     try:
         await container.start()
-        await asyncio.sleep(0)
+        await _wait_for_start_call(start_calls, "feishu-subscription")
 
         assert (
             "Failed to rebuild Memory Bank retrieval entries during startup"
             in caplog.text
         )
-        assert start_calls == [
+        assert start_calls.count("feishu-subscription") == 1
+        assert [call for call in start_calls if call != "feishu-subscription"] == [
             "mcp-warmup",
             "app-env-watcher",
             "mcp-config-watcher",
             "discord",
             "wechat",
             "xiaoluban",
-            "feishu-subscription",
             "feishu-message-pool",
             "automation-delivery",
             "automation-bound-session",

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -14,7 +14,6 @@ from relay_teams.env.environment_variable_models import (
     EnvironmentVariableSaveRequest,
     EnvironmentVariableScope,
 )
-from relay_teams.interfaces.server.container import ServerContainer
 import relay_teams.interfaces.server.container as container_module
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.plugins.config_manager import PluginConfigManager
@@ -143,7 +142,7 @@ def test_runtime_reload_updates_run_service_provider_factory(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     previous_provider_factory = container.run_service._provider_factory
 
@@ -168,7 +167,7 @@ def test_container_loads_plugin_dirs_from_app_env_before_plugin_registry(
         encoding="utf-8",
     )
 
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     assert [plugin.name for plugin in container.plugin_registry.plugins] == ["quality"]
 
@@ -200,7 +199,7 @@ def test_app_env_plugin_dirs_change_reloads_plugin_runtime(
         '{"mcpServers": {"docs": {"command": "docs-server"}}}',
         encoding="utf-8",
     )
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     assert container.plugin_registry.plugins == ()
 
@@ -234,7 +233,7 @@ def test_container_app_env_file_watcher_refreshes_runtime_after_external_change(
     monkeypatch.delenv(key, raising=False)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     calls: list[str] = []
 
     def reload_model_config() -> None:
@@ -280,7 +279,7 @@ def test_app_env_change_callback_does_not_advance_watcher_snapshot(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     monkeypatch.setattr(
         container.model_config_service,
@@ -321,7 +320,7 @@ def test_app_env_api_save_does_not_duplicate_watcher_reload(
     monkeypatch.delenv(key, raising=False)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     calls: list[str] = []
 
     def reload_model_config() -> None:
@@ -373,7 +372,7 @@ def test_container_stop_requests_active_runs_before_background_tasks(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     calls: list[str] = []
 
     async def fake_stop_active_runs_for_shutdown_async() -> int:
@@ -431,7 +430,7 @@ def test_container_registers_discord_repositories_for_shutdown_close(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     assert container.discord_account_repository in container._async_closeables
     assert container.discord_inbound_queue_repo in container._async_closeables
@@ -445,7 +444,7 @@ def test_container_logs_finished_startup_background_task_failure(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     async def fail_reindex() -> None:
         raise TypeError("unexpected reindex failure")
@@ -472,7 +471,7 @@ def test_container_registers_all_shared_sqlite_repositories_for_shutdown_close(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     closeables = set(container._async_closeables)
     missing = [
@@ -491,7 +490,7 @@ def test_roles_reload_updates_long_lived_role_registry_references(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     container.skill_registry = SkillRegistry(
         directory=SkillsDirectory(
             sources=((SkillSource.USER_RELAY_TEAMS, tmp_path / "missing-skills"),)
@@ -539,7 +538,7 @@ def test_container_tolerates_missing_builtin_roles_on_startup(
         lambda: missing_builtin_roles_dir,
     )
 
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     assert container.role_registry.list_roles() == ()
 
@@ -566,7 +565,7 @@ def test_container_skill_registry_uses_explicit_project_start_dir_snapshot(
         classmethod(_fake_from_config_dirs),
     )
 
-    _ = ServerContainer(config_dir=config_dir)
+    _ = container_module.ServerContainer(config_dir=config_dir)
 
     assert captured_kwargs == [
         {
@@ -586,7 +585,7 @@ def test_saving_environment_variable_reloads_model_runtime(
     monkeypatch.delenv(env_key, raising=False)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key=f"${{{env_key}}}")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     monkeypatch.setattr(
         container.skills_config_reload_service,
         "reload_skills_config",
@@ -614,7 +613,7 @@ def test_saving_app_environment_variable_reloads_mcp_and_skills_runtime(
     monkeypatch.delenv(env_key, raising=False)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     plugin_reload_calls: list[str] = []
     mcp_reload_calls: list[str] = []
     skill_reload_calls: list[str] = []
@@ -685,7 +684,7 @@ def test_saving_app_environment_variable_reloads_plugin_manager_with_start_dir(
         "relay_teams.interfaces.server.container.PluginConfigManager.from_environment",
         classmethod(_fake_from_environment),
     )
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     captured_kwargs.clear()
     monkeypatch.setattr(
         container.skills_config_reload_service,
@@ -712,7 +711,7 @@ def test_proxy_environment_variable_change_triggers_proxy_runtime_refresh(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     feishu_reload_calls: list[str] = []
     wechat_reload_calls: list[str] = []
     mcp_reload_calls: list[str] = []
@@ -766,7 +765,7 @@ async def test_start_sync_service_logs_timeout(monkeypatch, caplog) -> None:
     caplog.set_level(logging.WARNING)
 
     try:
-        await ServerContainer._start_sync_service(
+        await container_module.ServerContainer._start_sync_service(
             service_name="blocked-service",
             start=_blocked_start,
         )
@@ -784,7 +783,7 @@ async def test_container_binds_background_completion_sink_during_start(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     start_calls: list[str] = []
     lifecycle_calls: list[str] = []
@@ -941,7 +940,7 @@ async def test_container_start_continues_when_memory_reindex_fails(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     start_calls: list[str] = []
 
@@ -1077,7 +1076,7 @@ async def test_container_memory_startup_continues_after_forget_failure(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
     calls: list[str] = []
 
     async def _fail_forget() -> int:
@@ -1113,7 +1112,7 @@ def test_container_wires_automation_bound_session_queue_runtime(
     _clear_proxy_env(monkeypatch)
     config_dir = tmp_path / ".agent-teams"
     _write_model_config(config_dir, api_key="initial-secret")
-    container = ServerContainer(config_dir=config_dir)
+    container = container_module.ServerContainer(config_dir=config_dir)
 
     assert container.automation_service._bound_session_queue_service is (
         container.automation_bound_session_queue_service
@@ -1175,7 +1174,7 @@ def test_container_interrupts_persisted_background_processes_before_marking_stop
         ),
     )
 
-    _ = ServerContainer(config_dir=config_dir)
+    _ = container_module.ServerContainer(config_dir=config_dir)
 
     assert lifecycle == [
         "kill:3210",
@@ -1235,7 +1234,7 @@ def test_container_preserves_background_task_rows_when_startup_kill_fails(
         ),
     )
 
-    _ = ServerContainer(config_dir=config_dir)
+    _ = container_module.ServerContainer(config_dir=config_dir)
 
     assert lifecycle == [
         "kill:3210",
@@ -1304,7 +1303,7 @@ def test_container_preserves_recoverable_foreground_subagent_records_on_startup(
         ),
     )
 
-    _ = ServerContainer(config_dir=config_dir)
+    _ = container_module.ServerContainer(config_dir=config_dir)
 
     assert lifecycle == [
         "kill:3210",

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -755,7 +755,15 @@ async def _wait_for_start_call(start_calls: list[str], expected: str) -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_sync_service_logs_timeout(monkeypatch, caplog) -> None:
+async def test_start_sync_service_logs_timeout(
+    monkeypatch,
+    tmp_path: Path,
+    caplog,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = container_module.ServerContainer(config_dir=config_dir)
     started = threading.Event()
     release = threading.Event()
     finished: list[str] = []
@@ -769,22 +777,24 @@ async def test_start_sync_service_logs_timeout(monkeypatch, caplog) -> None:
     caplog.set_level(logging.WARNING)
 
     try:
-        start_task = asyncio.create_task(
-            container_module.ServerContainer._start_sync_service(
-                service_name="blocked-service",
-                start=_blocked_start,
-            )
+        await container._start_sync_service(
+            service_name="blocked-service",
+            start=_blocked_start,
         )
         assert await asyncio.to_thread(started.wait, 1)
-        await asyncio.sleep(0.02)
-        assert start_task.done() is False
+        assert finished == []
+        assert len(container._startup_background_tasks) == 1
         release.set()
-        await start_task
+        for _ in range(20):
+            if finished == ["done"] and not container._startup_background_tasks:
+                break
+            await asyncio.sleep(0.01)
     finally:
         release.set()
 
     assert "Timed out while starting optional sync service" in caplog.text
     assert finished == ["done"]
+    assert container._startup_background_tasks == set()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
 
 import pytest
 from pathlib import Path
@@ -14,6 +15,7 @@ from relay_teams.env.environment_variable_models import (
     EnvironmentVariableScope,
 )
 from relay_teams.interfaces.server.container import ServerContainer
+import relay_teams.interfaces.server.container as container_module
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.plugins.config_manager import PluginConfigManager
 from relay_teams.roles import RoleLoader
@@ -751,6 +753,27 @@ async def _wait_for_start_call(start_calls: list[str], expected: str) -> None:
         if expected in start_calls:
             return
         await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_start_sync_service_logs_timeout(monkeypatch, caplog) -> None:
+    release = threading.Event()
+
+    def _blocked_start() -> None:
+        release.wait(timeout=1)
+
+    monkeypatch.setattr(container_module, "SYNC_SERVICE_START_TIMEOUT_SECONDS", 0.001)
+    caplog.set_level(logging.WARNING)
+
+    try:
+        await ServerContainer._start_sync_service(
+            service_name="blocked-service",
+            start=_blocked_start,
+        )
+    finally:
+        release.set()
+
+    assert "Timed out while starting optional sync service" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -756,23 +756,65 @@ async def _wait_for_start_call(start_calls: list[str], expected: str) -> None:
 
 @pytest.mark.asyncio
 async def test_start_sync_service_logs_timeout(monkeypatch, caplog) -> None:
+    started = threading.Event()
     release = threading.Event()
+    finished: list[str] = []
 
     def _blocked_start() -> None:
+        started.set()
         release.wait(timeout=1)
+        finished.append("done")
 
     monkeypatch.setattr(container_module, "SYNC_SERVICE_START_TIMEOUT_SECONDS", 0.001)
     caplog.set_level(logging.WARNING)
 
     try:
-        await container_module.ServerContainer._start_sync_service(
-            service_name="blocked-service",
-            start=_blocked_start,
+        start_task = asyncio.create_task(
+            container_module.ServerContainer._start_sync_service(
+                service_name="blocked-service",
+                start=_blocked_start,
+            )
         )
+        assert await asyncio.to_thread(started.wait, 1)
+        await asyncio.sleep(0.02)
+        assert start_task.done() is False
+        release.set()
+        await start_task
     finally:
         release.set()
 
     assert "Timed out while starting optional sync service" in caplog.text
+    assert finished == ["done"]
+
+
+@pytest.mark.asyncio
+async def test_start_sync_service_background_logs_failure_immediately(
+    monkeypatch,
+    tmp_path: Path,
+    caplog,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = container_module.ServerContainer(config_dir=config_dir)
+
+    def _fail_start() -> None:
+        raise RuntimeError("subscription failed")
+
+    caplog.set_level(logging.WARNING)
+
+    container._start_sync_service_background(
+        service_name="feishu_subscription",
+        start=_fail_start,
+    )
+    for _ in range(20):
+        if "subscription failed" in caplog.text:
+            break
+        await asyncio.sleep(0.01)
+
+    assert "Startup background task failed" in caplog.text
+    assert "subscription failed" in caplog.text
+    assert container._startup_background_tasks == set()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -551,6 +551,20 @@ def test_stream_observed_text_helpers_ignore_empty_and_consume_duplicates() -> N
     assert contents == {}
 
 
+def test_missing_stream_observed_text_ignores_matching_old_history_text() -> None:
+    missing = session_runtime_module._missing_stream_observed_messages(
+        [ModelResponse(parts=[TextPart(content="OK")])],
+        [ModelResponse(parts=[TextPart(content="OK")])],
+        existing_text_messages=[],
+    )
+
+    assert len(missing) == 1
+    assert isinstance(missing[0], ModelResponse)
+    assert [
+        part.content for part in missing[0].parts if isinstance(part, TextPart)
+    ] == ["OK"]
+
+
 class _FakeNodeStream:
     def __init__(self, usage_snapshot: SimpleNamespace) -> None:
         self._usage_snapshot = usage_snapshot

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -501,6 +501,18 @@ def _index_of_tool_return(messages: Sequence[object], tool_call_id: str) -> int:
     raise AssertionError(f"missing tool return {tool_call_id}")
 
 
+def _index_of_text_response(messages: Sequence[object], content: str) -> int:
+    for index, message in enumerate(messages):
+        if not isinstance(message, ModelResponse):
+            continue
+        if any(
+            isinstance(part, TextPart) and part.content == content
+            for part in message.parts
+        ):
+            return index
+    raise AssertionError(f"missing text response {content}")
+
+
 def _index_of_user_prompt(messages: Sequence[object], content: str) -> int:
     for index, message in enumerate(messages):
         if not isinstance(message, ModelRequest):
@@ -1755,6 +1767,107 @@ async def test_generate_persists_stream_observed_tool_pair_before_injection_rest
     assert event_types.index(RunEventType.TOOL_RESULT) < event_types.index(
         RunEventType.INJECTION_APPLIED
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_stream_observed_text_before_tool_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "stream_observed_text_before_tool_call.db",
+        fake_hub,
+    )
+
+    streamed_text = (
+        "Let me also look at an actual SKILL.md example and the builtin skills."
+    )
+    text_part = TextPart(content=streamed_text)
+    tool_call = ToolCallPart(
+        tool_name="shell",
+        args={"command": "type C:\\Users\\yex\\.codex\\skills\\SKILL.md"},
+        tool_call_id="call-stream-skill",
+    )
+    tool_return = ToolReturnPart(
+        tool_name="shell",
+        tool_call_id="call-stream-skill",
+        content="skill body",
+    )
+    final_text = TextPart(content="done")
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[
+                    _ScriptedStreamingModelRequestNode(
+                        [
+                            PartStartEvent(index=0, part=text_part),
+                            PartEndEvent(index=0, part=text_part),
+                            PartEndEvent(index=1, part=tool_call),
+                        ]
+                    ),
+                    _ScriptedStreamingToolCallNode(
+                        [FunctionToolResultEvent(result=tool_return)]
+                    ),
+                ],
+                messages_by_step=[[], []],
+                result=_ScriptedResult(
+                    response=ModelResponse(parts=[final_text]),
+                    messages=[ModelResponse(parts=[final_text])],
+                ),
+            )
+        ]
+    )
+
+    monkeypatch.setattr(
+        session_runtime_module,
+        "ModelRequestNode",
+        _ScriptedStreamingModelRequestNode,
+    )
+    monkeypatch.setattr(
+        session_runtime_module,
+        "CallToolsNode",
+        _ScriptedStreamingToolCallNode,
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+
+    request = LLMRequest(
+        run_id="run-stream-observed-text-before-tool",
+        trace_id="run-stream-observed-text-before-tool",
+        task_id="task-stream-observed-text-before-tool",
+        session_id="session-stream-observed-text-before-tool",
+        workspace_id="default",
+        conversation_id=build_conversation_id(
+            "session-stream-observed-text-before-tool",
+            "Coordinator",
+        ),
+        instance_id="inst-stream-observed-text-before-tool",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="inspect skills",
+    )
+
+    response = await provider.generate(request)
+
+    assert response == "done"
+    stored_history = message_repo.get_history_for_conversation(
+        request.conversation_id or ""
+    )
+    text_index = _index_of_text_response(stored_history, streamed_text)
+    call_index = _index_of_tool_call(stored_history, "call-stream-skill")
+    return_index = _index_of_tool_return(stored_history, "call-stream-skill")
+    assert text_index < call_index < return_index
+
+    text_payloads = [
+        json.loads(event.payload_json)
+        for event in fake_hub.events
+        if event.event_type == RunEventType.TEXT_DELTA
+    ]
+    assert "".join(str(payload["text"]) for payload in text_payloads) == streamed_text
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -525,6 +525,32 @@ def _index_of_user_prompt(messages: Sequence[object], content: str) -> int:
     raise AssertionError(f"missing user prompt {content}")
 
 
+def test_stream_observed_text_helpers_ignore_empty_and_consume_duplicates() -> None:
+    contents = session_runtime_module._text_part_contents(
+        [
+            ModelRequest(parts=[UserPromptPart(content="hello")]),
+            ModelResponse(
+                parts=[
+                    TextPart(content=""),
+                    ToolCallPart(tool_name="read", args={}, tool_call_id="call-1"),
+                    TextPart(content="repeat"),
+                    TextPart(content="repeat"),
+                ]
+            ),
+        ]
+    )
+
+    assert contents == {"repeat": 2}
+    assert not session_runtime_module._consume_existing_text_content(
+        contents,
+        "missing",
+    )
+    assert session_runtime_module._consume_existing_text_content(contents, "repeat")
+    assert contents == {"repeat": 1}
+    assert session_runtime_module._consume_existing_text_content(contents, "repeat")
+    assert contents == {}
+
+
 class _FakeNodeStream:
     def __init__(self, usage_snapshot: SimpleNamespace) -> None:
         self._usage_snapshot = usage_snapshot

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -600,9 +600,9 @@ def test_missing_stream_observed_text_inserts_before_existing_tool_call() -> Non
     assert len(pending_messages) == 2
     inserted = pending_messages[0]
     assert isinstance(inserted, ModelResponse)
-    assert [
-        part.content for part in inserted.parts if isinstance(part, TextPart)
-    ] == ["before tool"]
+    assert [part.content for part in inserted.parts if isinstance(part, TextPart)] == [
+        "before tool"
+    ]
     tool_message = pending_messages[1]
     assert isinstance(tool_message, ModelResponse)
     tool_part = tool_message.parts[0]

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -565,6 +565,51 @@ def test_missing_stream_observed_text_ignores_matching_old_history_text() -> Non
     ] == ["OK"]
 
 
+def test_missing_stream_observed_text_inserts_before_existing_tool_call() -> None:
+    pending_messages: list[ModelRequest | ModelResponse] = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read",
+                    args={},
+                    tool_call_id="call-1",
+                )
+            ]
+        )
+    ]
+
+    missing = session_runtime_module._missing_stream_observed_messages(
+        list(pending_messages),
+        [
+            ModelResponse(
+                parts=[
+                    TextPart(content="before tool"),
+                    ToolCallPart(
+                        tool_name="read",
+                        args={},
+                        tool_call_id="call-1",
+                    ),
+                ]
+            )
+        ],
+        existing_text_messages=[],
+        pending_messages=pending_messages,
+    )
+
+    assert missing == []
+    assert len(pending_messages) == 2
+    inserted = pending_messages[0]
+    assert isinstance(inserted, ModelResponse)
+    assert [
+        part.content for part in inserted.parts if isinstance(part, TextPart)
+    ] == ["before tool"]
+    tool_message = pending_messages[1]
+    assert isinstance(tool_message, ModelResponse)
+    tool_part = tool_message.parts[0]
+    assert isinstance(tool_part, ToolCallPart)
+    assert tool_part.tool_call_id == "call-1"
+
+
 class _FakeNodeStream:
     def __init__(self, usage_snapshot: SimpleNamespace) -> None:
         self._usage_snapshot = usage_snapshot

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -280,6 +280,44 @@ def test_project_text_messages_from_events_skips_empty_run_and_text_events() -> 
     }
 
 
+def test_project_text_messages_from_events_flushes_at_injection_boundary() -> None:
+    projected = _project_text_messages_from_events(
+        [
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:00Z",
+                "payload_json": json.dumps({"text": "before injection"}),
+            },
+            {
+                "event_type": RunEventType.INJECTION_APPLIED.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "occurred_at": "2026-04-29T10:00:01Z",
+                "payload_json": "{}",
+            },
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:02Z",
+                "payload_json": json.dumps({"text": "after injection"}),
+            },
+        ]
+    )
+
+    messages = projected["run-1"]
+    assert [message["message"] for message in messages] == [
+        {"parts": [{"part_kind": "text", "content": "before injection"}]},
+        {"parts": [{"part_kind": "text", "content": "after injection"}]},
+    ]
+
+
 def test_event_text_message_rejects_invalid_or_blank_segments() -> None:
     assert _event_text_message({"chunks": "not-a-list"}) is None
     assert _event_text_message({"chunks": [" ", "\n"]}) is None
@@ -295,7 +333,7 @@ def test_merge_event_text_messages_skips_duplicates_and_blank_text() -> None:
     duplicate = _assistant_history_message(
         run_id="run-1",
         task_id="task-1",
-        created_at="2026-04-29T10:00:01Z",
+        created_at="2026-04-29T10:00:00Z",
         parts=[{"part_kind": "text", "content": "already persisted"}],
     )
     blank = _assistant_history_message(
@@ -306,6 +344,26 @@ def test_merge_event_text_messages_skips_duplicates_and_blank_text() -> None:
     )
 
     assert _merge_event_text_messages([existing], [duplicate, blank]) == [existing]
+
+
+def test_merge_event_text_messages_keeps_later_repeated_text() -> None:
+    existing = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:00Z",
+        parts=[{"part_kind": "text", "content": "OK"}],
+    )
+    later_event = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:10Z",
+        parts=[{"part_kind": "text", "content": "OK"}],
+    )
+
+    assert _merge_event_text_messages([existing], [later_event]) == [
+        existing,
+        later_event,
+    ]
 
 
 def test_build_session_rounds_maps_role_by_instance_across_runs(tmp_path: Path) -> None:

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -318,6 +318,75 @@ def test_project_text_messages_from_events_flushes_at_injection_boundary() -> No
     ]
 
 
+def test_project_text_messages_from_events_preserves_whitespace() -> None:
+    projected = _project_text_messages_from_events(
+        [
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:00Z",
+                "payload_json": json.dumps({"text": "\n  indented"}),
+            },
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:01Z",
+                "payload_json": json.dumps({"text": " tail "}),
+            },
+        ]
+    )
+
+    messages = projected["run-1"]
+    assert messages[0]["message"] == {
+        "parts": [{"part_kind": "text", "content": "\n  indented tail "}]
+    }
+
+
+def test_project_text_messages_from_events_includes_output_delta_text() -> None:
+    projected = _project_text_messages_from_events(
+        [
+            {
+                "event_type": RunEventType.OUTPUT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:00Z",
+                "payload_json": json.dumps(
+                    {
+                        "output": [
+                            {"kind": "text", "text": "media text"},
+                            {
+                                "kind": "media_ref",
+                                "asset_id": "asset-1",
+                                "session_id": "session-1",
+                                "modality": "image",
+                                "mime_type": "image/png",
+                                "url": "/api/media/asset-1",
+                            },
+                            {"kind": "text", "text": "after media"},
+                        ],
+                        "role_id": "Coordinator",
+                        "instance_id": "inst-coordinator",
+                    }
+                ),
+            },
+        ]
+    )
+
+    messages = projected["run-1"]
+    assert [message["message"] for message in messages] == [
+        {"parts": [{"part_kind": "text", "content": "media text"}]},
+        {"parts": [{"part_kind": "text", "content": "after media"}]},
+    ]
+
+
 def test_event_text_message_rejects_invalid_or_blank_segments() -> None:
     assert _event_text_message({"chunks": "not-a-list"}) is None
     assert _event_text_message({"chunks": [" ", "\n"]}) is None

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -709,6 +709,148 @@ def test_build_session_rounds_projects_missing_tool_pairs_from_events(
     assert parts[3]["is_error"] is True
 
 
+def test_build_session_rounds_projects_missing_text_before_tool_from_events(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_event_text_before_tool.db"
+    session_id = "session-1"
+    run_id = "run-1"
+    coordinator_instance_id = "inst-coordinator-1"
+    streamed_text = (
+        "Let me also look at an actual SKILL.md example and the builtin skills."
+    )
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="recover event text before tool",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    agent_repo.upsert_instance(
+        run_id=run_id,
+        trace_id=run_id,
+        session_id=session_id,
+        instance_id=coordinator_instance_id,
+        role_id="Coordinator",
+        workspace_id="default",
+        status=InstanceStatus.COMPLETED,
+    )
+    run_runtime_repo.ensure(
+        run_id=run_id,
+        session_id=session_id,
+        root_task_id="task-root",
+    )
+
+    events: list[dict[str, object]] = [
+        {
+            "trace_id": run_id,
+            "run_id": run_id,
+            "task_id": "task-root",
+            "event_type": RunEventType.TEXT_DELTA.value,
+            "occurred_at": "2026-04-29T10:00:00+00:00",
+            "payload_json": json.dumps(
+                {
+                    "run_id": run_id,
+                    "text": streamed_text[:24],
+                    "role_id": "Coordinator",
+                    "instance_id": coordinator_instance_id,
+                }
+            ),
+        },
+        {
+            "trace_id": run_id,
+            "run_id": run_id,
+            "task_id": "task-root",
+            "event_type": RunEventType.TEXT_DELTA.value,
+            "occurred_at": "2026-04-29T10:00:01+00:00",
+            "payload_json": json.dumps(
+                {
+                    "run_id": run_id,
+                    "text": streamed_text[24:],
+                    "role_id": "Coordinator",
+                    "instance_id": coordinator_instance_id,
+                }
+            ),
+        },
+        {
+            "trace_id": run_id,
+            "run_id": run_id,
+            "task_id": "task-root",
+            "event_type": RunEventType.TOOL_CALL.value,
+            "occurred_at": "2026-04-29T10:00:02+00:00",
+            "payload_json": json.dumps(
+                {
+                    "run_id": run_id,
+                    "tool_name": "shell",
+                    "tool_call_id": "call-1",
+                    "args": {"command": "type SKILL.md"},
+                    "role_id": "Coordinator",
+                    "instance_id": coordinator_instance_id,
+                }
+            ),
+        },
+        {
+            "trace_id": run_id,
+            "run_id": run_id,
+            "task_id": "task-root",
+            "event_type": RunEventType.TOOL_RESULT.value,
+            "occurred_at": "2026-04-29T10:00:03+00:00",
+            "payload_json": json.dumps(
+                {
+                    "run_id": run_id,
+                    "tool_name": "shell",
+                    "tool_call_id": "call-1",
+                    "result": {"ok": True, "data": "skill body"},
+                    "error": False,
+                    "role_id": "Coordinator",
+                    "instance_id": coordinator_instance_id,
+                }
+            ),
+        },
+    ]
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda _session_id: [],
+        get_session_events=lambda _session_id: events,
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+    coordinator_messages = cast(
+        list[dict[str, object]], round_item["coordinator_messages"]
+    )
+    parts = [
+        cast(
+            dict[str, object],
+            cast(
+                list[dict[str, object]],
+                cast(dict[str, object], message["message"])["parts"],
+            )[0],
+        )
+        for message in coordinator_messages
+    ]
+
+    assert [part["part_kind"] for part in parts] == [
+        "text",
+        "tool-call",
+        "tool-return",
+    ]
+    assert parts[0]["content"] == streamed_text
+
+
 def test_build_session_rounds_projects_stopped_spawn_subagent_call_without_result(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -554,6 +554,37 @@ def test_merge_event_text_messages_keeps_later_repeated_text() -> None:
     ]
 
 
+def test_merge_event_text_messages_does_not_consume_later_match_for_earlier_gap() -> (
+    None
+):
+    later_existing = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:10Z",
+        parts=[{"part_kind": "text", "content": "OK"}],
+    )
+    missing_before_boundary = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:05Z",
+        parts=[{"part_kind": "text", "content": "OK"}],
+    )
+    later_event = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:10Z",
+        parts=[{"part_kind": "text", "content": "OK"}],
+    )
+
+    assert _merge_event_text_messages(
+        [later_existing],
+        [missing_before_boundary, later_event],
+    ) == [
+        missing_before_boundary,
+        later_existing,
+    ]
+
+
 def test_merge_event_text_messages_matches_persisted_output_before_delta() -> None:
     existing_output = _assistant_history_message(
         run_id="run-1",

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -22,8 +22,11 @@ from relay_teams.sessions.session_rounds_projection import build_session_rounds
 from relay_teams.sessions.session_rounds_projection import build_session_timeline_rounds
 from relay_teams.sessions.session_rounds_projection import (
     _coordinator_event_tool_messages,
+    _event_text_message,
     _has_assistant_text_message,
     _merge_event_tool_messages,
+    _merge_event_text_messages,
+    _project_text_messages_from_events,
 )
 from relay_teams.agent_runtimes.instances.instance_repository import (
     AgentInstanceRepository,
@@ -241,6 +244,68 @@ def test_merge_event_tool_messages_preserves_repeated_tool_call_occurrences() ->
         second_event_call,
         second_event_result,
     ]
+
+
+def test_project_text_messages_from_events_skips_empty_run_and_text_events() -> None:
+    projected = _project_text_messages_from_events(
+        [
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "occurred_at": "2026-04-29T10:00:00Z",
+                "payload_json": json.dumps({"text": "missing run"}),
+            },
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "occurred_at": "2026-04-29T10:00:01Z",
+                "payload_json": json.dumps({"text": ""}),
+            },
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:02Z",
+                "payload_json": json.dumps({"text": "visible"}),
+            },
+        ]
+    )
+
+    messages = projected["run-1"]
+    assert len(messages) == 1
+    assert messages[0]["created_at"] == "2026-04-29T10:00:02Z"
+    assert messages[0]["message"] == {
+        "parts": [{"part_kind": "text", "content": "visible"}]
+    }
+
+
+def test_event_text_message_rejects_invalid_or_blank_segments() -> None:
+    assert _event_text_message({"chunks": "not-a-list"}) is None
+    assert _event_text_message({"chunks": [" ", "\n"]}) is None
+
+
+def test_merge_event_text_messages_skips_duplicates_and_blank_text() -> None:
+    existing = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:00Z",
+        parts=[{"part_kind": "text", "content": "already persisted"}],
+    )
+    duplicate = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:01Z",
+        parts=[{"part_kind": "text", "content": "already persisted"}],
+    )
+    blank = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:02Z",
+        parts=[{"part_kind": "text", "content": "   "}],
+    )
+
+    assert _merge_event_text_messages([existing], [duplicate, blank]) == [existing]
 
 
 def test_build_session_rounds_maps_role_by_instance_across_runs(tmp_path: Path) -> None:

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -318,6 +318,51 @@ def test_project_text_messages_from_events_flushes_at_injection_boundary() -> No
     ]
 
 
+def test_project_text_messages_from_events_ignores_queued_injection_boundary() -> None:
+    projected = _project_text_messages_from_events(
+        [
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:00Z",
+                "payload_json": json.dumps({"text": "before queued "}),
+            },
+            {
+                "event_type": RunEventType.INJECTION_ENQUEUED.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:01Z",
+                "payload_json": json.dumps(
+                    {
+                        "injection_id": "inj-queued",
+                        "visibility": "public",
+                        "content": "queued only",
+                    }
+                ),
+            },
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:02Z",
+                "payload_json": json.dumps({"text": "after queued"}),
+            },
+        ]
+    )
+
+    messages = projected["run-1"]
+    assert [message["message"] for message in messages] == [
+        {"parts": [{"part_kind": "text", "content": "before queued after queued"}]},
+    ]
+
+
 def test_project_text_messages_from_events_preserves_whitespace() -> None:
     projected = _project_text_messages_from_events(
         [

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -387,6 +387,80 @@ def test_project_text_messages_from_events_includes_output_delta_text() -> None:
     ]
 
 
+def test_project_text_messages_from_events_keeps_other_stream_open_at_boundary() -> (
+    None
+):
+    projected = _project_text_messages_from_events(
+        [
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:00Z",
+                "payload_json": json.dumps(
+                    {
+                        "text": "coordinator before ",
+                        "role_id": "Coordinator",
+                        "instance_id": "inst-coordinator",
+                    }
+                ),
+            },
+            {
+                "event_type": RunEventType.TOOL_CALL.value,
+                "trace_id": "run-1",
+                "task_id": "task-worker",
+                "role_id": "Worker",
+                "instance_id": "inst-worker",
+                "occurred_at": "2026-04-29T10:00:01Z",
+                "payload_json": json.dumps(
+                    {
+                        "tool_name": "shell",
+                        "tool_call_id": "call-worker",
+                        "role_id": "Worker",
+                        "instance_id": "inst-worker",
+                    }
+                ),
+            },
+            {
+                "event_type": RunEventType.TEXT_DELTA.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "role_id": "Coordinator",
+                "instance_id": "inst-coordinator",
+                "occurred_at": "2026-04-29T10:00:02Z",
+                "payload_json": json.dumps(
+                    {
+                        "text": "coordinator after",
+                        "role_id": "Coordinator",
+                        "instance_id": "inst-coordinator",
+                    }
+                ),
+            },
+            {
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "trace_id": "run-1",
+                "task_id": "task-1",
+                "occurred_at": "2026-04-29T10:00:03Z",
+                "payload_json": "{}",
+            },
+        ]
+    )
+
+    messages = projected["run-1"]
+    assert [message["message"] for message in messages] == [
+        {
+            "parts": [
+                {
+                    "part_kind": "text",
+                    "content": "coordinator before coordinator after",
+                }
+            ]
+        }
+    ]
+
+
 def test_event_text_message_rejects_invalid_or_blank_segments() -> None:
     assert _event_text_message({"chunks": "not-a-list"}) is None
     assert _event_text_message({"chunks": [" ", "\n"]}) is None
@@ -433,6 +507,28 @@ def test_merge_event_text_messages_keeps_later_repeated_text() -> None:
         existing,
         later_event,
     ]
+
+
+def test_merge_event_text_messages_matches_persisted_output_before_delta() -> None:
+    existing_output = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:00Z",
+        parts=[{"part_kind": "text", "content": "generated caption"}],
+    )
+    output_delta_event = _assistant_history_message(
+        run_id="run-1",
+        task_id="task-1",
+        created_at="2026-04-29T10:00:01Z",
+        parts=[{"part_kind": "text", "content": "generated caption"}],
+    )
+    output_delta_event["reconstructed_source_event_types"] = [
+        RunEventType.OUTPUT_DELTA.value
+    ]
+
+    merged = _merge_event_text_messages([existing_output], [output_delta_event])
+
+    assert merged == [existing_output]
 
 
 def test_build_session_rounds_maps_role_by_instance_across_runs(tmp_path: Path) -> None:

--- a/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
+++ b/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
@@ -11,8 +11,10 @@ from relay_teams.media import MediaModality
 from relay_teams.media import TextContentPart
 from relay_teams.media import content_parts_from_text
 from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_models import IntentInput
+from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions import session_service as session_service_module
 from relay_teams.sessions.runs.todo_models import TodoItem
 from relay_teams.sessions.runs.todo_models import TodoStatus
@@ -452,6 +454,60 @@ def test_round_projection_events_return_empty_without_event_log(tmp_path: Path) 
 
     assert service._get_round_projection_events("session-1") == []
     assert service._get_round_projection_events_for_runs("session-1", ("run-1",)) == []
+    assert service._get_detailed_round_projection_events("session-1") == []
+    assert (
+        service._get_detailed_round_projection_events_for_runs("session-1", ("run-1",))
+        == []
+    )
+
+
+def test_timeline_round_projection_events_skip_text_delta(tmp_path: Path) -> None:
+    service = _build_service(tmp_path / "round_events_text_delta.db")
+    assert service._event_log is not None
+    _ = service._event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.TEXT_DELTA,
+            payload_json='{"text":"streamed"}',
+        )
+    )
+    _ = service._event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.TOOL_CALL,
+            payload_json='{"tool_call_id":"call-1"}',
+        )
+    )
+
+    timeline_events = service._get_round_projection_events("session-1")
+    detailed_events = service._get_detailed_round_projection_events("session-1")
+    timeline_run_events = service._get_round_projection_events_for_runs(
+        "session-1",
+        ("run-1",),
+    )
+    detailed_run_events = service._get_detailed_round_projection_events_for_runs(
+        "session-1",
+        ("run-1",),
+    )
+
+    assert [event["event_type"] for event in timeline_events] == [
+        RunEventType.TOOL_CALL.value
+    ]
+    assert [event["event_type"] for event in detailed_events] == [
+        RunEventType.TEXT_DELTA.value,
+        RunEventType.TOOL_CALL.value,
+    ]
+    assert [event["event_type"] for event in timeline_run_events] == [
+        RunEventType.TOOL_CALL.value
+    ]
+    assert [event["event_type"] for event in detailed_run_events] == [
+        RunEventType.TEXT_DELTA.value,
+        RunEventType.TOOL_CALL.value,
+    ]
 
 
 def test_get_session_rounds_returns_empty_page_without_timeline_items(

--- a/tests/unit_tests/sessions/test_session_snapshot_cache.py
+++ b/tests/unit_tests/sessions/test_session_snapshot_cache.py
@@ -1081,12 +1081,24 @@ async def test_session_service_pending_action_event_requires_fresh_session_list(
     assert sessions[0].pending_tool_approval_count == 1
 
 
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        RunEventType.MODEL_STEP_STARTED,
+        RunEventType.TEXT_DELTA,
+        RunEventType.OUTPUT_DELTA,
+    ],
+)
 @pytest.mark.asyncio
 async def test_session_service_round_projection_event_marks_snapshot_dirty(
     tmp_path: Path,
+    event_type: RunEventType,
 ) -> None:
     runner = _CountingRunner()
-    service = _build_service(tmp_path / "session-round-event-cache.db", runner=runner)
+    service = _build_service(
+        tmp_path / f"session-round-{event_type.value}-cache.db",
+        runner=runner,
+    )
     _ = service.create_session(session_id="session-1", workspace_id="default")
     first = await service.get_session_rounds_async("session-1")
     assert first["items"] == []
@@ -1099,7 +1111,7 @@ async def test_session_service_round_projection_event_marks_snapshot_dirty(
             run_id="run-1",
             trace_id="run-1",
             instance_id="inst-1",
-            event_type=RunEventType.MODEL_STEP_STARTED,
+            event_type=event_type,
         )
     )
 

--- a/tests/unit_tests/sessions/test_session_snapshot_cache.py
+++ b/tests/unit_tests/sessions/test_session_snapshot_cache.py
@@ -1123,6 +1123,43 @@ async def test_session_service_round_projection_event_marks_snapshot_dirty(
 
 
 @pytest.mark.asyncio
+async def test_session_service_text_chunk_event_dirties_only_detailed_rounds(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    service = _build_service(
+        tmp_path / "session-text-chunk-round-only-cache.db",
+        runner=runner,
+    )
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    _ = await service.get_session_rounds_async("session-1")
+    _ = await service.get_session_rounds_async("session-1", timeline=True)
+    _ = await service.list_agents_in_session_async("session-1")
+
+    await asyncio.sleep(0.55)
+    runner.block_next = True
+    service.mark_run_event_dirty(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            instance_id="inst-1",
+            event_type=RunEventType.TEXT_DELTA,
+        )
+    )
+
+    _ = await service.list_agents_in_session_async("session-1")
+    _ = await service.get_session_rounds_async("session-1", timeline=True)
+    assert runner.started.is_set() is False
+
+    stale = await service.get_session_rounds_async("session-1")
+
+    assert stale["items"] == []
+    assert await _wait_for_event(runner.started)
+    runner.release.set()
+
+
+@pytest.mark.asyncio
 async def test_session_service_rounds_cold_miss_waits_for_projection(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- keep assistant process text split and ordered around tool/thinking/media overlay parts
- filter replayed overlay text by ordered persisted text identity so live post-tool text stays visible
- update timeline text parts through the rich text streaming helper to preserve formatting and cursor state

Closes #891

## Tests
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests (blocked locally: backend runtime hydration timed out; initial run found existing 0.0.0.0:9009 listener conflict from a local uvicorn process, rerun with RELAY_TEAMS_XIAOLUBAN_IM_LISTENER_PORT=19009 started the listener but still timed out before hydrated=true)
- uv run --extra dev pytest -q tests/integration_tests/browser/test_streaming_message_timeline.py (blocked locally by same hydration timeout before browser assertions)