### PR TITLE
Fix subagent view ownership races

### DIFF
--- a/frontend/dist/css/components/rounds/navigator.css
+++ b/frontend/dist/css/components/rounds/navigator.css
@@ -35,6 +35,18 @@
     width: min(1264px, 100%);
 }
 
+.chat-container.is-subagent-session-active #round-nav-float.round-nav-timeline {
+    display: none !important;
+}
+
+.chat-container.is-subagent-session-active.rounds-timeline-visible .chat-scroll > * {
+    width: min(1264px, 100%);
+}
+
+.chat-container.is-subagent-session-active.rounds-timeline-visible .subagent-workspace {
+    padding-right: 0;
+}
+
 .round-nav-float.round-nav-timeline {
     position: absolute;
     top: 0.75rem;

--- a/frontend/dist/css/components/tools.css
+++ b/frontend/dist/css/components/tools.css
@@ -5,6 +5,8 @@
     border: none;
     background: transparent;
     overflow: visible;
+    --tool-summary-rest-color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
+    --tool-summary-preview-rest-color: color-mix(in srgb, var(--text-secondary) 68%, transparent);
 }
 
 /* --- Summary / collapsed state --- */
@@ -42,6 +44,80 @@
     flex: 0 0 auto;
 }
 
+.tool-block:not([open]) > .tool-summary {
+    color: var(--tool-summary-rest-color);
+}
+
+.tool-block:not([open]) > .tool-summary::before {
+    color: color-mix(in srgb, var(--text-secondary) 58%, transparent);
+}
+
+.tool-block:not([open]) .tool-summary-label {
+    font-weight: 400;
+    opacity: 0.76;
+}
+
+.tool-block:not([open]) .tool-summary-preview {
+    color: var(--tool-summary-preview-rest-color);
+    opacity: 0.72;
+}
+
+.tool-block:not([open]) .tool-status {
+    opacity: 0.42;
+}
+
+.tool-block:not([open]) > .tool-summary:hover {
+    color: color-mix(in srgb, var(--text-primary) 88%, var(--text-secondary));
+}
+
+.tool-block:not([open]) > .tool-summary:hover::before {
+    color: color-mix(in srgb, var(--text-primary) 72%, var(--text-secondary));
+}
+
+.tool-block:not([open]) > .tool-summary:hover .tool-summary-label {
+    opacity: 1;
+}
+
+.tool-block:not([open]) > .tool-summary:hover .tool-summary-preview {
+    color: color-mix(in srgb, var(--text-primary) 68%, var(--text-secondary));
+    opacity: 0.92;
+}
+
+.tool-block:not([open]) > .tool-summary:hover .tool-status {
+    opacity: 0.8;
+}
+
+.tool-block:not([open])[data-status="running"] > .tool-summary,
+.tool-block:not([open])[data-status="error"] > .tool-summary,
+.tool-block:not([open])[data-status="warning"] > .tool-summary {
+    color: var(--text-secondary);
+}
+
+.tool-block:not([open])[data-status="running"] > .tool-summary::before,
+.tool-block:not([open])[data-status="error"] > .tool-summary::before,
+.tool-block:not([open])[data-status="warning"] > .tool-summary::before {
+    color: var(--text-secondary);
+}
+
+.tool-block:not([open])[data-status="running"] .tool-summary-label,
+.tool-block:not([open])[data-status="error"] .tool-summary-label,
+.tool-block:not([open])[data-status="warning"] .tool-summary-label {
+    opacity: 1;
+}
+
+.tool-block:not([open])[data-status="running"] .tool-summary-preview,
+.tool-block:not([open])[data-status="error"] .tool-summary-preview,
+.tool-block:not([open])[data-status="warning"] .tool-summary-preview {
+    color: var(--text-muted, var(--text-secondary));
+    opacity: 1;
+}
+
+.tool-block:not([open])[data-status="running"] .tool-status,
+.tool-block:not([open])[data-status="error"] .tool-status,
+.tool-block:not([open])[data-status="warning"] .tool-status {
+    opacity: 1;
+}
+
 .tool-block[open] > .tool-summary::before {
     transform: rotate(90deg);
 }
@@ -50,6 +126,7 @@
     font-weight: 500;
     white-space: nowrap;
     flex: 0 0 auto;
+    transition: opacity 0.15s ease;
 }
 
 .tool-summary-preview {
@@ -77,6 +154,7 @@
     align-items: center;
     flex: 0 0 auto;
     margin-left: auto;
+    transition: opacity 0.15s ease;
 }
 
 /* --- Detail / expanded state --- */
@@ -489,7 +567,7 @@
     gap: 0.6rem;
     cursor: pointer;
     list-style: none;
-    color: var(--text-secondary);
+    color: color-mix(in srgb, var(--text-secondary) 78%, transparent);
     font-size: 0.8125rem;
     font-family: var(--font-ui);
     user-select: none;
@@ -508,7 +586,7 @@
 .tool-group-line {
     flex: 1 1 auto;
     height: 1px;
-    background: color-mix(in srgb, var(--border-color) 82%, transparent);
+    background: color-mix(in srgb, var(--border-color) 62%, transparent);
 }
 
 .tool-group-label {

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Agent Teams</title>
+    <title>Relay Teams</title>
     <link rel="icon" href="data:," />
     <style>
       :root {
@@ -255,7 +255,7 @@
             </svg>
           </button>
           <div class="workspace-heading">
-            <div class="workspace-title">agent-teams</div>
+            <div class="workspace-title">relay-teams</div>
           </div>
         </div>
         <div class="topbar-section topbar-section-right">

--- a/frontend/dist/js/app/recovery.js
+++ b/frontend/dist/js/app/recovery.js
@@ -31,6 +31,10 @@ import {
     state,
 } from '../core/state.js';
 import { endStream, resumeRunStream } from '../core/stream.js';
+import {
+    canRenderMainSessionView,
+    hasActiveSubagentSessionFor,
+} from '../core/viewGuards.js';
 import { els } from '../utils/dom.js';
 import { formatMessage, t } from '../utils/i18n.js';
 import { sysLog } from '../utils/logger.js';
@@ -109,7 +113,6 @@ export async function hydrateSessionView(
     throwIfAborted(signal);
 
     startSessionContinuity(safeSessionId);
-    const preserveActiveSubagentView = shouldPreserveActiveSubagentView(safeSessionId);
     const shouldSkipRoundsReload = !!(
         includeRounds
         && state.currentSessionId === safeSessionId
@@ -127,7 +130,7 @@ export async function hydrateSessionView(
         await loadSessionRounds(safeSessionId, {
             forceRefresh: forceRefresh === true,
             priority,
-            render: !preserveActiveSubagentView,
+            render: canRenderMainSessionView(safeSessionId),
             scrollPolicy: roundsScrollPolicy || undefined,
             signal,
         });
@@ -171,7 +174,7 @@ export async function hydrateSessionSwitchView(
     startSessionContinuity(safeSessionId);
     await loadSessionRounds(safeSessionId, {
         priority,
-        render: !shouldPreserveActiveSubagentView(safeSessionId),
+        render: canRenderMainSessionView(safeSessionId),
         scrollPolicy: roundsScrollPolicy || 'session-load',
         signal,
         timelineLoadMode: 'background',
@@ -1162,7 +1165,7 @@ async function runScheduledContinuityRefresh(request) {
     if (canRefreshRounds) {
         await loadSessionRounds(safeSessionId, {
             forceRefresh: request.forceRefresh === true,
-            render: !shouldPreserveActiveSubagentView(safeSessionId),
+            render: canRenderMainSessionView(safeSessionId),
         });
         if (state.currentSessionId !== safeSessionId) return null;
     }
@@ -1189,6 +1192,7 @@ async function ensureAutomaticRecoveryStream(
 ) {
     const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
     if (!safeSessionId || state.currentSessionId !== safeSessionId) return false;
+    if (!canRenderMainSessionView(safeSessionId)) return false;
     const activeRun = snapshot?.activeRun || null;
     if (!shouldAutoAttachRecoveryStream(activeRun)) return false;
 
@@ -1230,7 +1234,7 @@ async function reconcileMissingActiveRun(
 
     endStream({ preserveRunStreamState: true, focusPrompt: false });
     await loadSessionRounds(safeSessionId, {
-        render: !shouldPreserveActiveSubagentView(safeSessionId),
+        render: canRenderMainSessionView(safeSessionId),
     });
     if (state.currentSessionId !== safeSessionId) return false;
 
@@ -1245,14 +1249,7 @@ async function reconcileMissingActiveRun(
 }
 
 function shouldPreserveActiveSubagentView(sessionId = state.currentSessionId) {
-    const active = state.activeSubagentSession;
-    const safeSessionId = String(sessionId || '').trim();
-    return !!(
-        active
-        && typeof active === 'object'
-        && safeSessionId
-        && String(active.sessionId || '').trim() === safeSessionId
-    );
+    return hasActiveSubagentSessionFor(sessionId);
 }
 
 function resolveRecoveryAfterEventId(activeRun) {

--- a/frontend/dist/js/app/session.js
+++ b/frontend/dist/js/app/session.js
@@ -33,6 +33,7 @@ import {
     prepareStreamsForForegroundNavigation,
 } from '../core/stream.js';
 import { detachForegroundSubmission } from '../core/submission.js';
+import { canRenderMainSessionView } from '../core/viewGuards.js';
 import { els } from '../utils/dom.js';
 import { formatMessage, t } from '../utils/i18n.js';
 import { sysLog } from '../utils/logger.js';
@@ -53,7 +54,11 @@ const TERMINAL_VIEW_MAX_ATTEMPTS = 3;
 bindSessionSelectionCancellation();
 
 function isLatestSessionSelection(token, sessionId) {
-    return token === sessionSelectionToken && state.currentSessionId === sessionId;
+    return !!(
+        token === sessionSelectionToken
+        && state.currentSessionId === sessionId
+        && canRenderMainSessionView(sessionId)
+    );
 }
 
 export async function selectSession(sessionId, options = {}) {
@@ -513,6 +518,7 @@ export async function selectSubagentSession(sessionId, subagent) {
     const resolved = cachedRecords.find(item => item.instanceId === safeInstanceId) || fallback;
     hideProjectView();
     setRoundsMode();
+    cancelActiveSessionSelection();
     void openSubagentSession(safeSessionId, resolved);
     void ensureSessionSubagents(safeSessionId, { force: false }).catch(error => {
         if (error?.name === 'AbortError') {

--- a/frontend/dist/js/app/sessionView.js
+++ b/frontend/dist/js/app/sessionView.js
@@ -6,7 +6,7 @@ import {
     hydrateSessionSwitchView,
     hydrateSessionView,
 } from './recovery.js';
-import { state } from '../core/state.js';
+import { canRenderMainSessionView } from '../core/viewGuards.js';
 import { els } from '../utils/dom.js';
 import { t } from '../utils/i18n.js';
 import { sysLog } from '../utils/logger.js';
@@ -42,6 +42,10 @@ export async function restoreMainSessionView(sessionId, { quiet = true } = {}) {
     const restoreController = restoreRequest.controller;
     const restoreToken = restoreRequest.token;
     const restoreSignal = restoreController.signal;
+    if (!canRenderMainSessionView(safeSessionId)) {
+        clearMainSessionRestoreController(restoreController);
+        return null;
+    }
     showMainSessionLoadingPlaceholder(safeSessionId);
     document.dispatchEvent(new CustomEvent('agent-teams-subagent-session-cleared', {
         detail: { sessionId: safeSessionId },
@@ -55,8 +59,7 @@ export async function restoreMainSessionView(sessionId, { quiet = true } = {}) {
         if (
             restoreSignal.aborted
             || !isLatestMainSessionRestore(restoreToken, restoreController, safeSessionId)
-            || String(state.currentSessionId || '').trim() !== safeSessionId
-            || state.activeSubagentSession
+            || !canRenderMainSessionView(safeSessionId)
         ) {
             return null;
         }
@@ -69,6 +72,9 @@ export async function restoreMainSessionView(sessionId, { quiet = true } = {}) {
         return snapshot;
     } catch (error) {
         if (error?.name === 'AbortError') {
+            return null;
+        }
+        if (!canRenderMainSessionView(safeSessionId)) {
             return null;
         }
         showMainSessionLoadFailed(safeSessionId);
@@ -109,12 +115,15 @@ function isLatestMainSessionRestore(token, controller, sessionId) {
         mainSessionRestoreController === controller
         && mainSessionRestoreToken === token
         && !controller.signal.aborted
-        && String(state.currentSessionId || '').trim() === String(sessionId || '').trim()
+        && canRenderMainSessionView(sessionId)
     );
 }
 
 function showMainSessionLoadingPlaceholder(sessionId) {
     if (!els.chatMessages) {
+        return;
+    }
+    if (!canRenderMainSessionView(sessionId)) {
         return;
     }
     els.chatMessages.innerHTML = `
@@ -127,6 +136,9 @@ function showMainSessionLoadingPlaceholder(sessionId) {
 
 function showMainSessionLoadFailed(sessionId) {
     if (!els.chatMessages) {
+        return;
+    }
+    if (!canRenderMainSessionView(sessionId)) {
         return;
     }
     els.chatMessages.innerHTML = `

--- a/frontend/dist/js/components/rounds/navigator.js
+++ b/frontend/dist/js/components/rounds/navigator.js
@@ -48,6 +48,10 @@ export function renderRoundNavigator(rounds, onSelectRound, options = {}) {
     if (Object.prototype.hasOwnProperty.call(options, 'activeRunId')) {
         navActiveRunId = String(options.activeRunId || '').trim() || null;
     }
+    if (isRoundNavigatorSuppressed()) {
+        hideRoundNavigator();
+        return;
+    }
     const nav = ensureRoundNavigator();
     if (navRounds.length === 0) {
         hideRoundNavigator();
@@ -92,6 +96,10 @@ export function clearRoundNavigator() {
 
 export function setActiveRoundNav(runId, options = {}) {
     navActiveRunId = String(runId || '').trim() || null;
+    if (isRoundNavigatorSuppressed()) {
+        hideRoundNavigator();
+        return;
+    }
     const nav = document.getElementById(ROUND_NAV_ID);
     if (!nav || navRounds.length === 0) return;
     syncRoundNavActiveState(nav);
@@ -170,6 +178,14 @@ function setTimelineVisibility(visible) {
     if (!visible) {
         delete host.dataset.roundTimelineDensity;
     }
+}
+
+function isRoundNavigatorSuppressed() {
+    const chat = document.querySelector('.chat-container');
+    return !!(
+        chat?.classList?.contains?.('is-subagent-session-active')
+        || document.querySelector('.subagent-session-view')
+    );
 }
 
 function renderNavigatorDom(nav, options = {}) {
@@ -744,6 +760,10 @@ function mergeRoundNavLayoutReason(current, next) {
 }
 
 function syncRoundNavLayout(reason = 'structure') {
+    if (isRoundNavigatorSuppressed()) {
+        hideRoundNavigator();
+        return;
+    }
     const nav = document.getElementById(ROUND_NAV_ID);
     const list = nav?.querySelector?.('.round-nav-list');
     const track = list?.querySelector?.('.round-nav-track');

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -28,6 +28,7 @@ import {
 import { renderPromptTokenizedText } from '../../utils/promptTokens.js';
 import {
     clearRoundNavigator,
+    hideRoundNavigator,
     patchRoundNavigatorTodo,
     renderRoundNavigator,
     setActiveRoundNav,
@@ -57,6 +58,10 @@ import {
 } from './utils.js';
 import { errorToPayload, logError } from '../../utils/logger.js';
 import { formatMessage, t } from '../../utils/i18n.js';
+import {
+    canRenderMainSessionView,
+    hasActiveSubagentSessionFor,
+} from '../../core/viewGuards.js';
 
 export let currentRounds = [];
 export let currentRound = null;
@@ -674,6 +679,7 @@ export function showPendingRunStartPlaceholder(sessionId, intentText, intentPart
         && (
             !safeSessionId
             || safeSessionId !== String(state.currentSessionId || '').trim()
+            || !canRenderMainSessionView(safeSessionId)
         )
     ) {
         return;
@@ -720,13 +726,7 @@ export function clearPendingRunStartPlaceholder() {
 }
 
 function shouldPreserveSubagentView(sessionId) {
-    const active = state.activeSubagentSession;
-    const safeSessionId = String(sessionId || state.currentSessionId || '').trim();
-    return !!(
-        active
-        && typeof active === 'object'
-        && String(active.sessionId || '').trim() === safeSessionId
-    );
+    return hasActiveSubagentSessionFor(sessionId || state.currentSessionId);
 }
 
 function roundsForNavigator() {
@@ -750,6 +750,12 @@ function roundsForNavigator() {
 }
 
 function renderNavigatorForTimeline(options = {}) {
+    if (!canRenderMainSessionView(state.currentSessionId)) {
+        if (hasActiveSubagentSessionFor(state.currentSessionId)) {
+            hideRoundNavigator();
+        }
+        return;
+    }
     renderRoundNavigator(roundsForNavigator(), selectRound, {
         activeRunId: roundsState.activeRunId,
         layoutReason: options.layoutReason || 'structure',
@@ -1579,6 +1585,9 @@ export function goBackToSessions() {
 function renderSessionTimeline(rounds, opts = { preserveScroll: true }) {
     const container = els.chatMessages;
     if (!container) return;
+    if (!canRenderMainSessionView(state.currentSessionId)) {
+        return;
+    }
 
     const renderPlan = opts.scrollPlan || captureRoundRenderPlan(opts);
 
@@ -1686,6 +1695,9 @@ function renderSessionTimeline(rounds, opts = { preserveScroll: true }) {
 
 export function renderCurrentSessionTimeline(opts = {}) {
     if (!Array.isArray(roundsState.currentRounds) || roundsState.currentRounds.length === 0) {
+        return false;
+    }
+    if (!canRenderMainSessionView(state.currentSessionId)) {
         return false;
     }
     renderSessionTimeline(roundsState.currentRounds, opts);

--- a/frontend/dist/js/components/subagentSessions.js
+++ b/frontend/dist/js/components/subagentSessions.js
@@ -601,6 +601,7 @@ export async function openSubagentSession(sessionId, record) {
     if (!safeSessionId || normalized === null) {
         return;
     }
+    emitSessionSelectionCancelledForSubagentOpen(normalized);
     abortMainSessionRestore();
     state.activeSubagentSession = normalized;
     state.activeView = 'subagent-session';
@@ -621,6 +622,24 @@ export async function openSubagentSession(sessionId, record) {
     }
     cancelTerminalRefreshForInstance(normalized.instanceId);
     await renderActiveSubagentSession({ showLoading: true });
+}
+
+function emitSessionSelectionCancelledForSubagentOpen(active) {
+    if (
+        typeof document === 'undefined'
+        || typeof document.dispatchEvent !== 'function'
+    ) {
+        return;
+    }
+    const detail = {
+        reason: 'subagent-session-opened',
+        sessionId: active.sessionId,
+        instanceId: active.instanceId,
+    };
+    const event = typeof CustomEvent === 'function'
+        ? new CustomEvent('agent-teams-session-selection-cancelled', { detail })
+        : { type: 'agent-teams-session-selection-cancelled', detail };
+    document.dispatchEvent(event);
 }
 
 export async function returnToMainSessionView() {

--- a/frontend/dist/js/core/viewGuards.js
+++ b/frontend/dist/js/core/viewGuards.js
@@ -1,0 +1,26 @@
+/**
+ * core/viewGuards.js
+ * Shared view ownership checks for async session rendering.
+ */
+import { state } from './state.js';
+
+export function hasActiveSubagentSessionFor(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    const active = state.activeSubagentSession;
+    return !!(
+        safeSessionId
+        && active
+        && typeof active === 'object'
+        && String(active.sessionId || '').trim() === safeSessionId
+    );
+}
+
+export function canRenderMainSessionView(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    const currentSessionId = String(state.currentSessionId || '').trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && !hasActiveSubagentSessionFor(safeSessionId)
+    );
+}

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -21,6 +21,7 @@ from relay_teams.interfaces.cli.gateway_cli import _build_acp_stdio_runtime
 from pydantic import JsonValue
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page, Request, Response
+from playwright.sync_api import Route
 from playwright.sync_api import expect
 from playwright.sync_api import sync_playwright
 import pytest
@@ -2177,6 +2178,169 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
     assert len(session_index_requests) <= 4
 
 
+def test_browser_subagent_view_survives_complex_switching_races(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+    api_client: httpx.Client,
+) -> None:
+    subagent_session_id = create_session(
+        api_client,
+        session_id=new_session_id("browser-subagent-race"),
+    )
+    run_id = create_run(
+        api_client,
+        session_id=subagent_session_id,
+        intent=(
+            "[hook-subagent-lifecycle] spawn one synchronous subagent and "
+            "finish browser subagent race guard"
+        ),
+        execution_mode="ai",
+    )
+    events = stream_run_until_terminal(
+        api_client,
+        run_id=run_id,
+        timeout_seconds=80.0,
+    )
+    assert events[-1]["event_type"] == "run_completed"
+    control_session_id = create_session(
+        api_client,
+        session_id=new_session_id("browser-subagent-race-control"),
+    )
+
+    page = browser_page
+    raced_request_urls: list[str] = []
+
+    def record_raced_parent_requests(route: Route) -> None:
+        request = route.request
+        request_url = str(request.url)
+        parent_path = f"/api/sessions/{subagent_session_id}"
+        if parent_path in request_url and (
+            request_url.endswith(parent_path) or f"{parent_path}/rounds?" in request_url
+        ):
+            raced_request_urls.append(request_url)
+        route.continue_()
+
+    page.route(f"**/api/sessions/{subagent_session_id}**", record_raced_parent_requests)
+    page.add_init_script(
+        f"""
+        (() => {{
+          const targetSessionId = {json.dumps(subagent_session_id)};
+          const originalFetch = window.fetch.bind(window);
+          const state = {{
+            enabled: false,
+            delayedCount: 0,
+            waiters: [],
+          }};
+          const shouldDelay = input => {{
+            if (!state.enabled) return false;
+            const rawUrl = typeof input === 'string' ? input : (input && input.url) || '';
+            if (!rawUrl) return false;
+            const url = new URL(rawUrl, window.location.origin);
+            return url.pathname === `/api/sessions/${{targetSessionId}}`
+              || url.pathname === `/api/sessions/${{targetSessionId}}/rounds`;
+          }};
+          window.__subagentRaceDelay = {{
+            enable() {{
+              state.enabled = true;
+            }},
+            release() {{
+              state.enabled = false;
+              const waiters = state.waiters.splice(0);
+              waiters.forEach(resolve => resolve());
+            }},
+            delayedCount() {{
+              return state.delayedCount;
+            }},
+          }};
+          window.fetch = async (...args) => {{
+            if (shouldDelay(args[0])) {{
+              state.delayedCount += 1;
+              await new Promise(resolve => {{
+                state.waiters.push(resolve);
+                window.setTimeout(resolve, 1500);
+              }});
+            }}
+            return originalFetch(...args);
+          }};
+        }})();
+        """,
+    )
+
+    _open_app(page, integration_env)
+    _click_visible_session_item(page, subagent_session_id)
+    subagent_toggle = page.locator(
+        f'.session-subagents-toggle[data-session-id="{subagent_session_id}"]'
+    ).first
+    expect(subagent_toggle).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    subagent_toggle.click()
+    child = page.locator(
+        f'.session-subagent-item[data-session-id="{subagent_session_id}"]'
+    ).first
+    expect(child).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    child_instance_id = str(child.get_attribute("data-subagent-instance-id") or "")
+    assert child_instance_id
+
+    _click_visible_session_item(page, control_session_id)
+    expect(page.locator(".session-item.active")).to_have_attribute(
+        "data-session-id",
+        control_session_id,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    page.evaluate("() => window.__subagentRaceDelay.enable()")
+    _click_visible_session_item(page, subagent_session_id)
+    child.click(timeout=_WAIT_TIMEOUT_MS)
+    _assert_subagent_child_view(page, subagent_session_id, child_instance_id)
+    page.evaluate("() => window.__subagentRaceDelay.release()")
+    page.wait_for_timeout(1800)
+    _assert_subagent_child_view(page, subagent_session_id, child_instance_id)
+
+    page.evaluate("() => window.dispatchEvent(new Event('focus'))")
+    page.evaluate(
+        """
+        sessionId => document.dispatchEvent(new CustomEvent(
+          'agent-teams-subagent-sessions-changed',
+          { detail: { sessionId, reason: 'status', forceRefresh: false } }
+        ))
+        """,
+        subagent_session_id,
+    )
+    page.wait_for_timeout(600)
+    _assert_subagent_child_view(page, subagent_session_id, child_instance_id)
+
+    _click_visible_session_item(page, control_session_id)
+    expect(page.locator(".session-item.active")).to_have_attribute(
+        "data-session-id",
+        control_session_id,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    child.click(timeout=_WAIT_TIMEOUT_MS)
+    _assert_subagent_child_view(page, subagent_session_id, child_instance_id)
+
+    page.locator(".subagent-session-back-btn").click()
+    expect(page.locator(".session-round-section").first).to_be_visible(
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(page.locator(".subagent-session-view")).to_have_count(
+        0,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(page.locator("#prompt-input")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+    child.click(timeout=_WAIT_TIMEOUT_MS)
+    _assert_subagent_child_view(page, subagent_session_id, child_instance_id)
+    _click_visible_session_item(page, subagent_session_id)
+    expect(page.locator(".session-round-section").first).to_be_visible(
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(page.locator(".subagent-session-view")).to_have_count(
+        0,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+
+    assert raced_request_urls
+    assert page.evaluate("() => window.__subagentRaceDelay.delayedCount()") > 0
+
+
 @pytest.mark.skip(reason="Timing-sensitive; unreliable on shared CI runners")
 def test_browser_burst_new_session_starts_stay_within_request_budget(
     browser_page: Page,
@@ -2402,6 +2566,34 @@ def _click_visible_session_item(page: Page, session_id: str) -> None:
     raise AssertionError(
         f"Timed out clicking visible session item: {session_id}"
     ) from last_error
+
+
+def _assert_subagent_child_view(
+    page: Page,
+    session_id: str,
+    instance_id: str,
+) -> None:
+    expect(page.locator(".subagent-session-view")).to_be_visible(
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(page.locator(".chat-container")).to_have_class(
+        re.compile(r"\bis-subagent-session-active\b"),
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(page.locator(".subagent-main-session-loading")).to_have_count(
+        0,
+        timeout=1200,
+    )
+    expect(page.locator(".session-round-section")).to_have_count(
+        0,
+        timeout=1200,
+    )
+    child = page.locator(
+        f'.session-subagent-item[data-session-id="{session_id}"]'
+        f'[data-subagent-instance-id="{instance_id}"]'
+    ).first
+    expect(child).to_have_class(re.compile(r"\bactive\b"), timeout=_WAIT_TIMEOUT_MS)
+    expect(page.locator("#input-container")).to_be_hidden(timeout=_WAIT_TIMEOUT_MS)
 
 
 def _api_path(integration_env: IntegrationEnvironment, url: str) -> str:

--- a/tests/integration_tests/browser/test_message_copy_actions.py
+++ b/tests/integration_tests/browser/test_message_copy_actions.py
@@ -427,6 +427,9 @@ def _round_intent_harness_html(base_url: str) -> str:
       overlayRoundRecoveryState,
       renderCurrentSessionTimeline,
     }} from "{base_url}/frontend/dist/js/components/rounds/timeline.js";
+    import {{ state }} from "{base_url}/frontend/dist/js/core/state.js";
+
+    state.currentSessionId = 'round-intent-harness';
 
     const waitForLayout = () => new Promise(resolve => {{
       requestAnimationFrame(() => requestAnimationFrame(resolve));

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -230,6 +230,59 @@ def test_streamed_tool_args_match_persisted_history_in_browser(
     assert payload["overlayAfterPersist"] is None
 
 
+def test_completed_tool_summaries_render_muted_by_default_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderToolSummaryVisualWeight()
+        """
+    )
+    page.wait_for_timeout(200)
+    payload = page.evaluate(
+        """
+        () => ({
+          completed: window.__streamTimelineHarness.readToolSummaryVisualWeight(
+            'call-muted-tool'
+          ),
+          error: window.__streamTimelineHarness.readToolSummaryVisualWeight(
+            'call-error-tool'
+          ),
+        })
+        """
+    )
+    page.locator(
+        "#tool-summary-visual-weight "
+        '[data-tool-call-id="call-muted-tool"] > .tool-summary'
+    ).hover()
+    page.wait_for_timeout(200)
+    hover_payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.readToolSummaryVisualWeight(
+          'call-muted-tool'
+        )
+        """
+    )
+
+    payload_message = json.dumps(payload, sort_keys=True)
+    hover_payload_message = json.dumps(hover_payload, sort_keys=True)
+
+    assert payload["completed"]["labelOpacity"] < 0.8, payload_message
+    assert payload["completed"]["previewOpacity"] < 0.8, payload_message
+    assert payload["completed"]["statusOpacity"] < 0.5, payload_message
+    assert hover_payload["summaryAlpha"] == 1, hover_payload_message
+    assert hover_payload["labelOpacity"] == 1, hover_payload_message
+    assert hover_payload["previewOpacity"] > 0.9, hover_payload_message
+    assert hover_payload["statusOpacity"] >= 0.8, hover_payload_message
+    assert payload["error"]["labelOpacity"] == 1, payload_message
+    assert payload["error"]["previewOpacity"] == 1, payload_message
+    assert payload["error"]["statusOpacity"] == 1, payload_message
+
+
 def test_session_switching_keeps_stream_overlays_isolated_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -955,6 +1008,30 @@ def test_subagent_session_width_stays_stable_in_browser(
     assert payload["afterWithinScroll"] is True
 
 
+def test_subagent_session_suppresses_round_navigator_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderSubagentRoundNavigatorSuppression()
+        """
+    )
+
+    assert payload["subagentNavVisible"] is False, payload
+    assert payload["subagentHasTimelineClass"] is False, payload
+    assert payload["subagentDensity"] == "", payload
+    assert payload["staleNavVisible"] is False, payload
+    assert payload["baselineWidth"] == payload["staleWidth"], payload
+    assert payload["staleWithinScroll"] is True, payload
+    assert payload["mainNavVisible"] is True, payload
+    assert payload["mainHasTimelineClass"] is True, payload
+    assert payload["mainNodeCount"] == 2, payload
+
+
 def _open_harness(page: Page, tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     html_path = tmp_path / "stream_timeline_harness.html"
@@ -972,6 +1049,9 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
             f"{base_url}/frontend/dist/js/components/messageTimeline/store.js"
         )
         event_router_module = f"{base_url}/frontend/dist/js/core/eventRouter/index.js"
+        round_navigator_module = (
+            f"{base_url}/frontend/dist/js/components/rounds/navigator.js"
+        )
         html_path.write_text(
             f"""
 <!doctype html>
@@ -979,7 +1059,10 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
 <head>
   <meta charset="utf-8">
   <title>stream timeline harness</title>
+  <link rel="stylesheet" href="{base_url}/frontend/dist/css/base.css">
   <link rel="stylesheet" href="{base_url}/frontend/dist/css/layout.css">
+  <link rel="stylesheet" href="{base_url}/frontend/dist/css/components/tools.css">
+  <link rel="stylesheet" href="{base_url}/frontend/dist/css/components/rounds/navigator.css">
   <link rel="stylesheet" href="{base_url}/frontend/dist/css/components/subagent.css">
 </head>
 <body>
@@ -1015,6 +1098,9 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
     import {{
       routeEvent,
     }} from {json.dumps(event_router_module)};
+    import {{
+      renderRoundNavigator,
+    }} from {json.dumps(round_navigator_module)};
 
     function makeContainer(id) {{
       const container = document.createElement('section');
@@ -1083,7 +1169,36 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
       }});
     }}
 
+    function cssColorAlpha(value) {{
+      const text = String(value || '').trim();
+      const colorAlpha = text.match(/\\/\\s*([0-9.]+)\\)?$/);
+      if (colorAlpha) return Number(colorAlpha[1]);
+      const rgbaAlpha = text.match(/^rgba\\([^,]+,[^,]+,[^,]+,\\s*([0-9.]+)\\)$/);
+      if (rgbaAlpha) return Number(rgbaAlpha[1]);
+      return 1;
+    }}
+
+    function readToolSummaryVisualState(block) {{
+      const summary = block.querySelector('.tool-summary');
+      const label = summary.querySelector('.tool-summary-label');
+      const preview = summary.querySelector('.tool-summary-preview');
+      const status = summary.querySelector('.tool-status');
+      return {{
+        status: block.dataset.status || '',
+        summaryAlpha: cssColorAlpha(getComputedStyle(summary).color),
+        labelOpacity: Number(getComputedStyle(label).opacity),
+        previewOpacity: Number(getComputedStyle(preview).opacity),
+        statusOpacity: Number(getComputedStyle(status).opacity),
+      }};
+    }}
+
     window.__streamTimelineHarness = {{
+      readToolSummaryVisualWeight(toolCallId) {{
+        return readToolSummaryVisualState(
+          document.querySelector(`[data-tool-call-id="${{toolCallId}}"]`),
+        );
+      }},
+
       renderLiveTextAroundToolCalls() {{
         clearAllStreamState();
         const container = makeContainer('live-text-around-tools');
@@ -1177,6 +1292,49 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
               status: part.status || '',
             }})),
           cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderToolSummaryVisualWeight() {{
+        clearAllStreamState();
+        const container = makeContainer('tool-summary-visual-weight');
+        const runId = 'run-tool-summary-visual-weight';
+        getOrCreateStreamBlock(container, 'primary', 'Coordinator', 'Main Agent', runId);
+        appendToolCallBlock(
+          container,
+          'primary',
+          'shell',
+          {{ command: 'date' }},
+          'call-muted-tool',
+          {{ runId, roleId: 'Coordinator', label: 'Main Agent' }},
+        );
+        updateToolResult(
+          'primary',
+          'shell',
+          {{ ok: true, output: 'done' }},
+          false,
+          'call-muted-tool',
+          {{ runId, roleId: 'Coordinator', label: 'Main Agent', container }},
+        );
+        appendToolCallBlock(
+          container,
+          'primary',
+          'grep',
+          {{ pattern: 'missing' }},
+          'call-error-tool',
+          {{ runId, roleId: 'Coordinator', label: 'Main Agent' }},
+        );
+        updateToolResult(
+          'primary',
+          'grep',
+          {{ ok: false, error: 'failed' }},
+          true,
+          'call-error-tool',
+          {{ runId, roleId: 'Coordinator', label: 'Main Agent', container }},
+        );
+        return {{
+          completed: readToolSummaryVisualState(container.querySelector('[data-tool-call-id="call-muted-tool"]')),
+          error: readToolSummaryVisualState(container.querySelector('[data-tool-call-id="call-error-tool"]')),
         }};
       }},
 
@@ -3697,9 +3855,105 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
         }};
       }},
 
+      async renderSubagentRoundNavigatorSuppression() {{
+        const existingNav = document.getElementById('round-nav-float');
+        existingNav?.remove?.();
+        document.querySelectorAll('.chat-container').forEach(node => node.remove());
+
+        const shell = document.createElement('main');
+        shell.id = 'chat-container';
+        shell.className = 'chat-container is-subagent-session-active';
+        shell.style.width = '960px';
+        shell.style.height = '420px';
+        shell.style.display = 'flex';
+        shell.style.position = 'relative';
+        const scroll = document.createElement('div');
+        scroll.className = 'chat-scroll';
+        scroll.style.width = '960px';
+        scroll.style.height = '420px';
+        const wrapper = document.createElement('section');
+        wrapper.className = 'subagent-session-view';
+        const body = document.createElement('div');
+        body.className = 'subagent-session-body';
+        wrapper.appendChild(body);
+        scroll.appendChild(wrapper);
+        shell.appendChild(scroll);
+        document.body.appendChild(shell);
+
+        const rounds = [
+          {{
+            run_id: 'round-suppressed-1',
+            intent: 'Suppressed round one',
+            status: 'completed',
+            created_at: '2026-04-25T12:00:00Z',
+          }},
+          {{
+            run_id: 'round-suppressed-2',
+            intent: 'Suppressed round two',
+            status: 'running',
+            created_at: '2026-04-25T12:02:00Z',
+          }},
+        ];
+        const nextFrame = () => new Promise(resolve => {{
+          window.requestAnimationFrame(() => window.requestAnimationFrame(resolve));
+        }});
+        const isVisible = element => {{
+          if (!element) return false;
+          const style = window.getComputedStyle(element);
+          const rect = element.getBoundingClientRect();
+          return style.display !== 'none'
+            && style.visibility !== 'hidden'
+            && Number(rect.width || 0) > 0
+            && Number(rect.height || 0) > 0;
+        }};
+
+        renderRoundNavigator(rounds, () => {{}}, {{ activeRunId: 'round-suppressed-1' }});
+        await nextFrame();
+        const subagentNav = document.getElementById('round-nav-float');
+        const subagentNavVisible = isVisible(subagentNav);
+        const subagentHasTimelineClass = shell.classList.contains('rounds-timeline-visible');
+        const subagentDensity = shell.getAttribute('data-round-timeline-density') || '';
+
+        const baselineWidth = Math.round(wrapper.getBoundingClientRect().width);
+        const staleNav = subagentNav || document.createElement('aside');
+        staleNav.id = 'round-nav-float';
+        staleNav.className = 'round-nav-float round-nav-timeline';
+        staleNav.style.display = 'block';
+        if (!staleNav.parentNode) {{
+          shell.appendChild(staleNav);
+        }}
+        shell.classList.add('rounds-timeline-visible');
+        shell.dataset.roundTimelineDensity = 'full';
+        await nextFrame();
+        const staleWidth = Math.round(wrapper.getBoundingClientRect().width);
+        const scrollWidth = Math.round(scroll.getBoundingClientRect().width);
+        const staleNavVisible = isVisible(staleNav);
+
+        shell.classList.remove('is-subagent-session-active');
+        shell.classList.remove('rounds-timeline-visible');
+        delete shell.dataset.roundTimelineDensity;
+        wrapper.remove();
+        renderRoundNavigator(rounds, () => {{}}, {{ activeRunId: 'round-suppressed-1' }});
+        await nextFrame();
+        const mainNav = document.getElementById('round-nav-float');
+        return {{
+          subagentNavVisible,
+          subagentHasTimelineClass,
+          subagentDensity,
+          staleNavVisible,
+          baselineWidth,
+          staleWidth,
+          staleWithinScroll: staleWidth <= scrollWidth,
+          mainNavVisible: isVisible(mainNav),
+          mainHasTimelineClass: shell.classList.contains('rounds-timeline-visible'),
+          mainNodeCount: mainNav?.querySelectorAll?.('.round-nav-node')?.length || 0,
+        }};
+      }},
+
       measureSubagentSessionWidth() {{
         const shell = document.createElement('main');
         shell.id = 'chat-container';
+        shell.className = 'chat-container';
         shell.style.width = '960px';
         shell.style.height = '400px';
         shell.style.display = 'block';

--- a/tests/unit_tests/frontend/test_recovery_background_tasks_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_background_tasks_ui.py
@@ -119,6 +119,7 @@ def test_background_task_event_renders_control_strip_immediately(
         .replace("../components/sidebar.js", "./mockSidebar.mjs")
         .replace("../core/api.js", "./mockApi.mjs")
         .replace("../core/state.js", "./mockState.mjs")
+        .replace("../core/viewGuards.js", "./mockViewGuards.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("../utils/dom.js", "./mockDom.mjs")
         .replace("../utils/i18n.js", "./mockI18n.mjs")
@@ -177,6 +178,33 @@ export function humanizeRoleId(roleId) { return String(roleId || ""); }
 export function isPrimaryRoleId() { return false; }
 export function isReservedSystemRoleId() { return false; }
 export function setRunPrimaryRole() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockViewGuards.mjs").write_text(
+        """
+import { state } from "./mockState.mjs";
+
+export function hasActiveSubagentSessionFor(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const active = state.activeSubagentSession;
+    return !!(
+        safeSessionId
+        && active
+        && typeof active === "object"
+        && String(active.sessionId || "").trim() === safeSessionId
+    );
+}
+
+export function canRenderMainSessionView(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const currentSessionId = String(state.currentSessionId || "").trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && !hasActiveSubagentSessionFor(safeSessionId)
+    );
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -293,6 +321,7 @@ def test_foreground_command_task_event_does_not_open_background_strip(
         .replace("../components/sidebar.js", "./mockSidebar.mjs")
         .replace("../core/api.js", "./mockApi.mjs")
         .replace("../core/state.js", "./mockState.mjs")
+        .replace("../core/viewGuards.js", "./mockViewGuards.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("../utils/dom.js", "./mockDom.mjs")
         .replace("../utils/i18n.js", "./mockI18n.mjs")
@@ -351,6 +380,33 @@ export function humanizeRoleId(roleId) { return String(roleId || ""); }
 export function isPrimaryRoleId() { return false; }
 export function isReservedSystemRoleId() { return false; }
 export function setRunPrimaryRole() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockViewGuards.mjs").write_text(
+        """
+import { state } from "./mockState.mjs";
+
+export function hasActiveSubagentSessionFor(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const active = state.activeSubagentSession;
+    return !!(
+        safeSessionId
+        && active
+        && typeof active === "object"
+        && String(active.sessionId || "").trim() === safeSessionId
+    );
+}
+
+export function canRenderMainSessionView(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const currentSessionId = String(state.currentSessionId || "").trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && !hasActiveSubagentSessionFor(safeSessionId)
+    );
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -448,6 +504,7 @@ def test_terminal_run_state_patches_round_without_recovery_snapshot(
         .replace("../components/sidebar.js", "./mockSidebar.mjs")
         .replace("../core/api.js", "./mockApi.mjs")
         .replace("../core/state.js", "./mockState.mjs")
+        .replace("../core/viewGuards.js", "./mockViewGuards.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("../utils/dom.js", "./mockDom.mjs")
         .replace("../utils/i18n.js", "./mockI18n.mjs")
@@ -514,6 +571,33 @@ export function humanizeRoleId(roleId) { return String(roleId || ""); }
 export function isPrimaryRoleId() { return false; }
 export function isReservedSystemRoleId() { return false; }
 export function setRunPrimaryRole() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockViewGuards.mjs").write_text(
+        """
+import { state } from "./mockState.mjs";
+
+export function hasActiveSubagentSessionFor(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const active = state.activeSubagentSession;
+    return !!(
+        safeSessionId
+        && active
+        && typeof active === "object"
+        && String(active.sessionId || "").trim() === safeSessionId
+    );
+}
+
+export function canRenderMainSessionView(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const currentSessionId = String(state.currentSessionId || "").trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && !hasActiveSubagentSessionFor(safeSessionId)
+    );
+}
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -110,10 +110,8 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
         in recovery_script
     )
     assert "await loadSessionRounds(safeSessionId, {" in recovery_script
-    assert "render: !preserveActiveSubagentView," in recovery_script
-    assert (
-        "render: !shouldPreserveActiveSubagentView(safeSessionId)," in recovery_script
-    )
+    assert "render: canRenderMainSessionView(safeSessionId)," in recovery_script
+    assert "canRenderMainSessionView," in recovery_script
     assert "clearRunStreamState(safePreviousActiveRunId);" in recovery_script
     assert "clearRunPrimaryRole(safePreviousActiveRunId);" in recovery_script
     assert (

--- a/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
+++ b/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
@@ -872,6 +872,7 @@ def _run_round_timeline_script(tmp_path: Path, runner_source: str) -> dict[str, 
     replacements = {
         "../../utils/dom.js": "./mockDom.mjs",
         "../../core/state.js": "./mockState.mjs",
+        "../../core/viewGuards.js": "./mockViewGuards.mjs",
         "../../core/api.js": "./mockApi.mjs",
         "../agentPanel.js": "./mockAgentPanel.mjs",
         "../messageRenderer.js": "./mockMessageRenderer.mjs",
@@ -924,6 +925,33 @@ export function getRunPrimaryRoleLabel() {
 
 export function isRunPrimaryRoleId() {
     return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockViewGuards.mjs").write_text(
+        """
+import { state } from "./mockState.mjs";
+
+export function hasActiveSubagentSessionFor(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const active = state.activeSubagentSession;
+    return !!(
+        safeSessionId
+        && active
+        && typeof active === "object"
+        && String(active.sessionId || "").trim() === safeSessionId
+    );
+}
+
+export function canRenderMainSessionView(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const currentSessionId = String(state.currentSessionId || "").trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && !hasActiveSubagentSessionFor(safeSessionId)
+    );
 }
 """.strip(),
         encoding="utf-8",
@@ -1030,6 +1058,10 @@ export function renderRoundNavigator(rounds) {
 }
 
 export function clearRoundNavigator() {
+    return undefined;
+}
+
+export function hideRoundNavigator() {
     return undefined;
 }
 

--- a/tests/unit_tests/frontend/test_session_selection_ui.py
+++ b/tests/unit_tests/frontend/test_session_selection_ui.py
@@ -712,6 +712,7 @@ def _run_session_script(tmp_path: Path, runner_source: str) -> dict[str, object]
     mock_stream_path = tmp_path / "mockStream.mjs"
     mock_submission_path = tmp_path / "mockSubmission.mjs"
     mock_dom_path = tmp_path / "mockDom.mjs"
+    mock_view_guards_path = tmp_path / "mockViewGuards.mjs"
     mock_i18n_path = tmp_path / "mockI18n.mjs"
     mock_logger_path = tmp_path / "mockLogger.mjs"
     mock_prompt_path = tmp_path / "mockPrompt.mjs"
@@ -816,6 +817,7 @@ import { state } from "./mockState.mjs";
 
 export function clearActiveSubagentSession() {
     globalThis.__clearActiveSubagentSessionCalls += 1;
+    state.activeSubagentSession = null;
 }
 
 export function getSessionSubagentSessions() {
@@ -1132,6 +1134,33 @@ export function refreshSessionTopologyControls() {
 """.strip(),
         encoding="utf-8",
     )
+    mock_view_guards_path.write_text(
+        """
+import { state } from "./mockState.mjs";
+
+export function hasActiveSubagentSessionFor(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const active = state.activeSubagentSession;
+    return !!(
+        safeSessionId
+        && active
+        && typeof active === "object"
+        && String(active.sessionId || "").trim() === safeSessionId
+    );
+}
+
+export function canRenderMainSessionView(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const currentSessionId = String(state.currentSessionId || "").trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && !hasActiveSubagentSessionFor(safeSessionId)
+    );
+}
+""".strip(),
+        encoding="utf-8",
+    )
 
     source_text = (
         source_path.read_text(encoding="utf-8")
@@ -1154,6 +1183,7 @@ export function refreshSessionTopologyControls() {
         .replace("../core/state.js", "./mockState.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("../core/submission.js", "./mockSubmission.mjs")
+        .replace("../core/viewGuards.js", "./mockViewGuards.mjs")
         .replace("../utils/dom.js", "./mockDom.mjs")
         .replace("../utils/i18n.js", "./mockI18n.mjs")
         .replace("../utils/logger.js", "./mockLogger.mjs")

--- a/tests/unit_tests/frontend/test_session_view_ui.py
+++ b/tests/unit_tests/frontend/test_session_view_ui.py
@@ -100,6 +100,7 @@ def _run_session_view_script(tmp_path: Path, runner_source: str) -> dict[str, ob
         source_path.read_text(encoding="utf-8")
         .replace("./recovery.js", "./mockRecovery.mjs")
         .replace("../core/state.js", "./mockState.mjs")
+        .replace("../core/viewGuards.js", "./mockViewGuards.mjs")
         .replace("../utils/dom.js", "./mockDom.mjs")
         .replace("../utils/i18n.js", "./mockI18n.mjs")
         .replace("../utils/logger.js", "./mockLogger.mjs")
@@ -137,6 +138,33 @@ export const state = {
     currentSessionId: "session-1",
     activeSubagentSession: null,
 };
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockViewGuards.mjs").write_text(
+        """
+import { state } from "./mockState.mjs";
+
+export function hasActiveSubagentSessionFor(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const active = state.activeSubagentSession;
+    return !!(
+        safeSessionId
+        && active
+        && typeof active === "object"
+        && String(active.sessionId || "").trim() === safeSessionId
+    );
+}
+
+export function canRenderMainSessionView(sessionId = state.currentSessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    const currentSessionId = String(state.currentSessionId || "").trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && !hasActiveSubagentSessionFor(safeSessionId)
+    );
+}
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/unit_tests/frontend/test_subagent_sessions_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_sessions_ui.py
@@ -230,6 +230,13 @@ globalThis.document = {
     createElement() {
         return createSectionElement();
     },
+    dispatchEvent(event) {
+        globalThis.__documentDispatches.push({
+            type: event.type,
+            detail: event.detail,
+        });
+        return true;
+    },
 };
 """.strip(),
         encoding="utf-8",
@@ -264,6 +271,7 @@ globalThis.__renderCalls = [];
 globalThis.__clearAllPanelsCalls = 0;
 globalThis.__hideRoundNavigatorCalls = 0;
 globalThis.__syncNormalModeSubagentStreamsCalls = 0;
+globalThis.__documentDispatches = [];
 
 const { els } = await import("./mockDom.mjs");
 const { state } = await import("./mockState.mjs");
@@ -303,6 +311,8 @@ console.log(JSON.stringify({
     renderCalls: globalThis.__renderCalls,
     clearAllPanelsCalls: globalThis.__clearAllPanelsCalls,
     hideRoundNavigatorCalls: globalThis.__hideRoundNavigatorCalls,
+    selectionCancelledEvents: globalThis.__documentDispatches
+        .filter(event => event.type === "agent-teams-session-selection-cancelled"),
 }));
 """.strip(),
         encoding="utf-8",
@@ -349,6 +359,16 @@ console.log(JSON.stringify({
     ]
     assert payload["clearAllPanelsCalls"] == 1
     assert payload["hideRoundNavigatorCalls"] == 2
+    assert payload["selectionCancelledEvents"] == [
+        {
+            "type": "agent-teams-session-selection-cancelled",
+            "detail": {
+                "reason": "subagent-session-opened",
+                "sessionId": "session-1",
+                "instanceId": "inst-sub-1",
+            },
+        }
+    ]
 
 
 def test_subagent_gate_resolved_during_open_does_not_render_stale_card(

--- a/tests/unit_tests/frontend/test_workspace_prompt_ui.py
+++ b/tests/unit_tests/frontend/test_workspace_prompt_ui.py
@@ -123,7 +123,7 @@ def test_workspace_shell_hides_execution_mode_selector() -> None:
     assert 'src="/vendor/chart.js" defer' in index_html
     assert 'id="projects-list"' in index_html
     assert "<h2>agent-teams</h2>" not in index_html
-    assert '<div class="workspace-title">agent-teams</div>' in index_html
+    assert '<div class="workspace-title">relay-teams</div>' in index_html
     assert 'id="backend-status"' in index_html
     assert 'id="backend-status-label"' in index_html
     assert 'id="language-toggle-btn"' in index_html


### PR DESCRIPTION
## Summary
- Add a shared frontend view guard so stale main-session async work cannot overwrite an active subagent child-session view.
- Suppress main timeline, round navigator, and pending placeholders while a normal-mode subagent session owns the view.
- Add browser coverage for delayed parent session requests, focus refresh, sidebar refresh, and normal return-to-main flows.

Fixes #896

## Validation
- uv run --extra dev ruff check tests/integration_tests/browser/test_browser_smoke.py tests/integration_tests/browser/test_streaming_message_timeline.py
- uv run --extra dev pytest -q tests/integration_tests/browser/test_browser_smoke.py::test_browser_subagent_view_survives_complex_switching_races
- uv run --extra dev pytest -q tests/integration_tests/browser/test_browser_smoke.py::test_browser_session_send_switch_and_subagent_view_stay_responsive_under_load
- uv run --extra dev pytest -q tests/integration_tests/browser/test_streaming_message_timeline.py::test_subagent_session_suppresses_round_navigator_in_browser
- git diff --check