### PR TITLE
Fix commands settings collapsed UI

### DIFF
--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -375,22 +375,6 @@
     width: 100%;
 }
 
-.commands-panel-toolbar {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 1rem;
-    min-height: 40px;
-    color: var(--text-secondary);
-    font-size: 0.875rem;
-}
-
-.commands-refresh-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-}
-
 .commands-search-row {
     width: 100%;
 }
@@ -536,12 +520,6 @@
     white-space: nowrap;
 }
 
-.commands-group-hint {
-    flex: 0 0 auto;
-    color: var(--text-secondary);
-    font-size: 0.78rem;
-}
-
 .commands-list {
     display: flex;
     flex-direction: column;
@@ -641,17 +619,6 @@
     padding: 0 var(--settings-action-btn-padding-x);
 }
 
-.commands-group-summary {
-    display: flex;
-    align-items: center;
-    gap: 0.45rem;
-    min-height: 32px;
-    padding-left: 2.55rem;
-    color: var(--text-secondary);
-    font-size: 0.82rem;
-    border-top: 1px solid color-mix(in srgb, var(--settings-border-soft) 72%, transparent);
-}
-
 .commands-group-empty {
     display: flex;
     align-items: center;
@@ -663,6 +630,11 @@
     color: var(--text-secondary);
     font-size: 0.84rem;
     background: var(--settings-surface-bg);
+}
+
+.settings-content-stack .commands-group-empty {
+    min-height: 44px;
+    padding: 0.75rem 1rem;
 }
 
 .commands-empty-card {

--- a/frontend/dist/js/components/settings/commandsSettings.js
+++ b/frontend/dist/js/components/settings/commandsSettings.js
@@ -28,9 +28,6 @@ export function bindCommandsSettingsHandlers() {
     bindClick('refresh-commands-btn', () => {
         void loadCommandsSettingsPanel();
     });
-    bindClick('refresh-command-catalog-btn', () => {
-        void loadCommandsSettingsPanel();
-    });
     bindClick('add-command-btn', () => {
         openCreateCommandEditor();
     });
@@ -136,6 +133,7 @@ export function syncCommandsSettingsActions() {
         return;
     }
     const isEditorOpen = commandEditorMode !== 'list';
+    setActionDisplay('refresh-commands-btn', !isEditorOpen);
     setActionDisplay('add-command-btn', !isEditorOpen);
     setActionDisplay('cancel-command-btn', isEditorOpen);
     setActionDisplay('preview-command-btn', isEditorOpen);
@@ -358,9 +356,7 @@ function buildSuggestedPath(name) {
 function renderLoading() {
     return `
         <div class="commands-shell">
-            <div class="commands-panel-toolbar">
-                <span>${escapeHtml(t('settings.commands.loading'))}</span>
-            </div>
+            <div class="settings-status-inline">${escapeHtml(t('settings.commands.loading'))}</div>
         </div>
     `;
 }
@@ -377,7 +373,6 @@ function renderCommandCatalog(catalog) {
     }
     return `
         <div class="commands-shell">
-            ${renderCatalogActions()}
             ${renderCommandSearch()}
             <div class="commands-catalog">
                 ${
@@ -386,16 +381,6 @@ function renderCommandCatalog(catalog) {
                         : renderSearchEmpty()
                 }
             </div>
-        </div>
-    `;
-}
-
-function renderCatalogActions() {
-    return `
-        <div class="commands-panel-toolbar">
-            <button class="secondary-btn section-action-btn commands-refresh-btn" id="refresh-command-catalog-btn" type="button">
-                ${escapeHtml(t('settings.commands.refresh'))}
-            </button>
         </div>
     `;
 }
@@ -418,7 +403,6 @@ function renderCommandSearch() {
 function renderCatalogEmptyState(total) {
     return `
         <div class="commands-shell">
-            ${renderCatalogActions()}
             <div class="settings-empty-state commands-empty-card">
                 <h4>${escapeHtml(t('settings.commands.empty'))}</h4>
                 <p>${escapeHtml(t('settings.commands.empty_copy'))}</p>
@@ -432,9 +416,6 @@ function renderCommandGroup(group) {
     const rows = Array.isArray(group.refs) ? group.refs : [];
     const isSearchActive = Boolean(commandSearchQuery);
     const isCollapsed = !isSearchActive && isCommandGroupCollapsed(group);
-    const hintKey = isCollapsed
-        ? 'settings.commands.expand_hint'
-        : 'settings.commands.collapse_hint';
     return `
         <section class="commands-group ${isCollapsed ? 'commands-group-collapsed' : ''}">
             <button class="commands-group-header" id="toggle-command-group-${escapeHtml(group.key)}" type="button" aria-expanded="${isCollapsed ? 'false' : 'true'}">
@@ -444,27 +425,13 @@ function renderCommandGroup(group) {
                     <span class="commands-count-pill">${escapeHtml(String(rows.length))}</span>
                     ${group.subtitle ? `<span class="commands-group-path">${escapeHtml(group.subtitle)}</span>` : ''}
                 </div>
-                <span class="commands-group-hint">${escapeHtml(t(hintKey))}</span>
             </button>
             ${
                 isCollapsed
-                    ? renderCollapsedSummary(rows, group)
+                    ? ''
                     : renderExpandedGroupRows(rows, group)
             }
         </section>
-    `;
-}
-
-function renderCollapsedSummary(rows, group) {
-    if (rows.length === 0) {
-        return renderCommandGroupEmpty(group.emptyCopy);
-    }
-    return `
-        <div class="commands-group-summary">
-            ${escapeHtml(formatCount(rows.length))}
-            <span aria-hidden="true">&middot;</span>
-            ${escapeHtml(t('settings.commands.expand_hint'))}
-        </div>
     `;
 }
 
@@ -707,9 +674,6 @@ function renderLoadFailedState(error) {
             <div class="settings-empty-state settings-empty-state-compact commands-empty-card commands-empty-card-compact">
                 <h4>${escapeHtml(t('settings.commands.load_failed'))}</h4>
                 <p>${escapeHtml(error.message || t('settings.commands.load_failed_copy'))}</p>
-                <button class="secondary-btn section-action-btn" id="refresh-commands-btn" type="button">
-                    ${escapeHtml(t('settings.commands.refresh'))}
-                </button>
             </div>
         </div>
     `;
@@ -809,8 +773,8 @@ function isCommandGroupCollapsed(group) {
     return defaultCommandGroupCollapsed(group.key);
 }
 
-function defaultCommandGroupCollapsed(key) {
-    return key !== 'app';
+function defaultCommandGroupCollapsed() {
+    return true;
 }
 
 function catalogCommandRefs() {
@@ -862,12 +826,6 @@ function formatAliasList(aliases) {
 
 function formatAliasesInput(value) {
     return normalizeAliases(value).map(alias => formatCommandName(alias)).join(', ');
-}
-
-function formatCount(count) {
-    return count === 1
-        ? t('settings.commands.count_one')
-        : t('settings.commands.count_many').replace('{count}', String(count));
 }
 
 function compactPath(path) {

--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -148,6 +148,7 @@ const ACTION_TAB_OWNERS = {
     'save-agent-btn': 'agents',
     'delete-agent-btn': 'agents',
     'cancel-agent-btn': 'agents',
+    'refresh-commands-btn': 'commands',
     'add-command-btn': 'commands',
     'preview-command-btn': 'commands',
     'save-command-btn': 'commands',
@@ -1015,6 +1016,7 @@ function createModal() {
                             <button class="secondary-btn section-action-btn settings-action" id="delete-agent-btn" type="button" style="display:none;" data-i18n="settings.action.delete">Delete</button>
                             <button class="secondary-btn section-action-btn settings-action" id="cancel-agent-btn" type="button" style="display:none;" data-i18n="settings.action.cancel">Cancel</button>
                             <button class="secondary-btn section-action-btn settings-action" id="add-command-btn" type="button" style="display:none;" data-i18n="settings.commands.add">Add Command</button>
+                            <button class="secondary-btn section-action-btn settings-action" id="refresh-commands-btn" type="button" style="display:none;" data-i18n="settings.commands.refresh">Refresh</button>
                             <button class="secondary-btn section-action-btn settings-action" id="preview-command-btn" type="button" style="display:none;" data-i18n="settings.commands.preview">Preview</button>
                             <button class="primary-btn section-action-btn settings-action" id="save-command-btn" type="button" style="display:none;" data-i18n="settings.action.save">Save</button>
                             <button class="secondary-btn section-action-btn settings-action" id="add-role-btn" type="button" style="display:none;" data-i18n="settings.action.add_role">Add Role</button>

--- a/tests/unit_tests/frontend/test_commands_settings_ui.py
+++ b/tests/unit_tests/frontend/test_commands_settings_ui.py
@@ -129,8 +129,6 @@ export function t(key) {
         "settings.commands.table_scope": "Scope",
         "settings.commands.table_source_path": "Source path",
         "settings.commands.table_actions": "Actions",
-        "settings.commands.expand_hint": "Click to expand",
-        "settings.commands.collapse_hint": "Click to collapse",
         "settings.commands.template": "Prompt template",
         "settings.commands.source_path": "Source path",
         "settings.commands.source_meta": "Source info:",
@@ -212,6 +210,9 @@ const {
 } = await import("./commandsSettings.mjs");
 await loadCommandsSettingsPanel();
 const catalogHtml = element("commands-status").innerHTML;
+const refreshButtonDisplayInList = element("refresh-commands-btn").style.display;
+element("toggle-command-group-app").onclick();
+const appExpandedHtml = element("commands-status").innerHTML;
 element("command-search-input").value = "opsx";
 element("command-search-input").oninput();
 const searchHtml = element("commands-status").innerHTML;
@@ -219,9 +220,14 @@ element("command-search-input").value = "";
 element("command-search-input").oninput();
 element("toggle-command-group-workspace-workspace-1").onclick();
 const expandedCatalogHtml = element("commands-status").innerHTML;
+element("toggle-command-group-workspace-workspace-2").onclick();
+const emptyWorkspaceExpandedHtml = element("commands-status").innerHTML;
+element("toggle-command-group-workspace-workspace-2").onclick();
+const emptyWorkspaceCollapsedAgainHtml = element("commands-status").innerHTML;
 
 element("edit-command-workspace-0-0").onclick();
 const editHtml = element("commands-status").innerHTML;
+const refreshButtonDisplayInEdit = element("refresh-commands-btn").style.display;
 element("command-description-input").value = "Updated proposal command";
 element("command-template-input").value = "Updated {{args}}";
 element("preview-command-btn").onclick();
@@ -241,12 +247,16 @@ const addButtonDisplayInCreate = element("add-command-btn").style.display;
 const saveButtonDisplayInCreate = element("save-command-btn").style.display;
 const cancelButtonDisplayInCreate = element("cancel-command-btn").style.display;
 const previewButtonDisplayInCreate = element("preview-command-btn").style.display;
+const refreshButtonDisplayInCreate = element("refresh-commands-btn").style.display;
 await element("save-command-btn").onclick();
 
 console.log(JSON.stringify({
     catalogHtml,
+    appExpandedHtml,
     searchHtml,
     expandedCatalogHtml,
+    emptyWorkspaceExpandedHtml,
+    emptyWorkspaceCollapsedAgainHtml,
     editHtml,
     createHtml,
     suggestedPath: element("command-path-input").value,
@@ -259,6 +269,9 @@ console.log(JSON.stringify({
     saveButtonDisplayInCreate,
     cancelButtonDisplayInCreate,
     previewButtonDisplayInCreate,
+    refreshButtonDisplayInList,
+    refreshButtonDisplayInEdit,
+    refreshButtonDisplayInCreate,
     documentEvents: globalThis.__documentEvents || [],
 }));
 """.strip()
@@ -273,32 +286,46 @@ console.log(JSON.stringify({
 
     payload = json.loads(result.stdout)
     catalog_html = str(payload["catalogHtml"])
+    app_expanded_html = str(payload["appExpandedHtml"])
     search_html = str(payload["searchHtml"])
     expanded_catalog_html = str(payload["expandedCatalogHtml"])
+    empty_workspace_expanded_html = str(payload["emptyWorkspaceExpandedHtml"])
+    empty_workspace_collapsed_again_html = str(
+        payload["emptyWorkspaceCollapsedAgainHtml"]
+    )
     edit_html = str(payload["editHtml"])
     create_html = str(payload["createHtml"])
     assert "Global commands" in catalog_html
-    assert "/global" in catalog_html
+    assert "/global" not in catalog_html
+    assert "/global" in app_expanded_html
     assert "Search command or workspace" in catalog_html
     assert "commands-table" not in catalog_html
     assert "commands-table-head" not in catalog_html
     assert "commands-total" not in catalog_html
+    assert "refresh-command-catalog-btn" not in catalog_html
     toolbar_html = catalog_html.split("Search command or workspace", 1)[0]
     assert "1 command" not in toolbar_html
     assert "workspace" not in toolbar_html
-    assert 'class="settings-record-list commands-list"' in catalog_html
+    assert 'class="settings-record-list commands-list"' not in catalog_html
     assert "workspace-1" in catalog_html
     assert "workspace-2" in catalog_html
     assert "read-only" in catalog_html
     assert "remote-only" in catalog_html
-    assert "Click to expand" in catalog_html
+    assert "Click to expand" not in catalog_html
+    assert "Click to collapse" not in app_expanded_html
     assert "/opsx:propose" not in catalog_html
     assert "/opsx:propose" in search_html
     assert "alias /opsx/propose" in search_html
     assert "/opsx:propose" in expanded_catalog_html
     assert "alias /opsx/propose" in expanded_catalog_html
-    assert "No project commands in this workspace." in catalog_html
-    assert "Edit" in catalog_html
+    assert "No project commands in this workspace." not in catalog_html
+    assert "No project commands in this workspace." in empty_workspace_expanded_html
+    assert (
+        "No project commands in this workspace."
+        not in empty_workspace_collapsed_again_html
+    )
+    assert "Edit" in app_expanded_html
+    assert "Edit" in expanded_catalog_html
     assert "C:/repo/.claude/commands/opsx/propose.md" in edit_html
     assert "Edit Command" in edit_html
     assert "Aliases (optional)" in edit_html
@@ -311,6 +338,9 @@ console.log(JSON.stringify({
     assert payload["saveButtonDisplayInCreate"] == "inline-flex"
     assert payload["cancelButtonDisplayInCreate"] == "inline-flex"
     assert payload["previewButtonDisplayInCreate"] == "inline-flex"
+    assert payload["refreshButtonDisplayInList"] == "inline-flex"
+    assert payload["refreshButtonDisplayInEdit"] == "none"
+    assert payload["refreshButtonDisplayInCreate"] == "none"
     assert "aliases: [opsx/propose]" in str(payload["previewText"])
     assert "Updated {{args}}" in str(payload["previewText"])
     assert payload["suggestedPath"] == "opsx/review.md"
@@ -458,6 +488,7 @@ resolveCurrent({
 await currentLoad;
 rejectStale(new Error("stale load failed"));
 await staleLoad;
+element("toggle-command-group-app").onclick();
 
 console.log(JSON.stringify({
     html: element("commands-status").innerHTML,

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -45,6 +45,12 @@ console.log(JSON.stringify({
     assert "settings-model-stack" in modal_html
     assert "status-stack" in modal_html
     assert "settings-actions-bar" in modal_html
+    assert modal_html.index('id="add-command-btn"') < modal_html.index(
+        'id="refresh-commands-btn"'
+    )
+    assert modal_html.index('id="refresh-commands-btn"') < modal_html.index(
+        'id="preview-command-btn"'
+    )
     assert "Proxy Settings" in modal_html
     assert "Connectivity Test" in modal_html
     assert 'class="proxy-editor-form"' in modal_html


### PR DESCRIPTION
## Summary
- Collapse all command groups by default and remove collapsed summary/hint text
- Move the Commands refresh action to the footer action bar, to the right of Add Command
- Keep empty workspace messaging only when the group is expanded

Fixes #898

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`