### PR TITLE
fix: preserve skill team role display names

### DIFF
--- a/docs/modules/skills/skill-routing-design.md
+++ b/docs/modules/skills/skill-routing-design.md
@@ -166,7 +166,8 @@ The `skill-teams` group contains:
 - `list_skill_roles(skill_name)`: scans skill-local markdown files that expose role
   front matter and returns role summaries only. `agents/*.md` is the preferred
   convention for skill-local subagents, and the full document contract is defined
-  in [Skill-local agent roles](skill-local-agent-roles-spec.md).
+  in [Skill-local agent roles](skill-local-agent-roles-spec.md). The list output
+  does not include run-scoped effective role ids.
 - `activate_skill_roles(skill_name, role_ids)`: materializes selected skill-local
   roles as run-scoped effective roles. Returned `effective_role_id` values may be
   passed to existing `spawn_subagent` or `orch_dispatch_task`.

--- a/frontend/dist/js/core/state.js
+++ b/frontend/dist/js/core/state.js
@@ -268,7 +268,7 @@ export function getRoleDisplayName(roleId, { fallback = 'Agent' } = {}) {
         return matchingRole.name;
     }
     return safeRoleId
-        .split(/[_\\s-]+/)
+        .split(/[_\s-]+/)
         .filter(Boolean)
         .map(part => part.charAt(0).toUpperCase() + part.slice(1))
         .join(' ') || fallback;

--- a/src/relay_teams/tools/skill_team_tools/list_skill_roles.py
+++ b/src/relay_teams/tools/skill_team_tools/list_skill_roles.py
@@ -30,7 +30,11 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             )
             roles = list_skill_team_roles(skill)
             role_payloads: list[JsonValue] = [
-                skill_team_role_summary_to_json(entry.summary) for entry in roles
+                skill_team_role_summary_to_json(
+                    entry.summary,
+                    include_effective_role_id=False,
+                )
+                for entry in roles
             ]
             return {
                 "skill": {

--- a/src/relay_teams/tools/skill_team_tools/list_skill_roles.txt
+++ b/src/relay_teams/tools/skill_team_tools/list_skill_roles.txt
@@ -3,9 +3,8 @@ List the lightweight role summaries bundled inside an authorized skill.
 Arguments:
 - `skill_name`: skill name to inspect.
 
-Returns role ids, effective role ids, names, descriptions, tools, MCP servers, skills, model profile, and skill-relative source paths. It does not return role system prompts.
+Returns role ids, names, descriptions, tools, MCP servers, skills, model profile, and skill-relative source paths. It does not return role system prompts or run-scoped effective role ids.
 
 Usage rules:
 - Call this after `load_skill` or skill routing indicates a skill may contain a team workflow.
 - Use the returned `role_id` values with `activate_skill_roles`.
-- Use the returned `effective_role_id` values only after activation.

--- a/src/relay_teams/tools/skill_team_tools/support.py
+++ b/src/relay_teams/tools/skill_team_tools/support.py
@@ -62,5 +62,12 @@ def get_effective_role_for_skill_tool(ctx: ToolContext) -> RoleDefinition:
 
 def skill_team_role_summary_to_json(
     summary: SkillTeamRoleSummary,
+    *,
+    include_effective_role_id: bool = True,
 ) -> dict[str, JsonValue]:
-    return cast(dict[str, JsonValue], summary.model_dump(mode="json"))
+    payload = (
+        summary.model_dump(mode="json")
+        if include_effective_role_id
+        else summary.model_dump(mode="json", exclude={"effective_role_id"})
+    )
+    return cast(dict[str, JsonValue], payload)

--- a/tests/integration_tests/frontend/test_state_primary_roles_ui.py
+++ b/tests/integration_tests/frontend/test_state_primary_roles_ui.py
@@ -62,3 +62,48 @@ console.log(JSON.stringify({
         "mainAgentAlias": True,
         "workerPrimary": False,
     }
+
+
+def test_role_display_name_preserves_skill_team_prefix_without_options(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "core" / "state.js").read_text(
+        encoding="utf-8"
+    )
+    (tmp_path / "state.mjs").write_text(source, encoding="utf-8")
+    (tmp_path / "runner.mjs").write_text(
+        """
+globalThis.document = {
+  getElementById() { return null; },
+  querySelector() { return null; },
+};
+
+const { getRoleDisplayName } = await import('./state.mjs');
+
+console.log(JSON.stringify({
+  skillTeam: getRoleDisplayName(
+    'skill_team_codehub_mr_review_reviewer_b2c2b735',
+    { fallback: 'Agent' },
+  ),
+  subagentRole: getRoleDisplayName('subagent_role', { fallback: 'Agent' }),
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", "runner.mjs"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "skillTeam": "Skill Team Codehub Mr Review Reviewer B2c2b735",
+        "subagentRole": "Subagent Role",
+    }

--- a/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
+++ b/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
@@ -147,9 +147,7 @@ async def test_list_skill_roles_returns_lightweight_role_summaries(
     }
     roles = cast(list[dict[str, object]], result["roles"])
     assert roles[0]["role_id"] == "analyst"
-    assert cast(str, roles[0]["effective_role_id"]).startswith(
-        "skill_team_team_review_analyst_"
-    )
+    assert "effective_role_id" not in roles[0]
     assert roles[0]["source_path"] == "agents/analyst.md"
     assert "system_prompt" not in roles[0]
 


### PR DESCRIPTION
## Summary
- preserve skill team role display names when returning listed roles
- omit effective role ids from skill role listings
- update frontend role-name state handling and regression coverage

Fixes #930

## Tests
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests` timed out locally after 10 minutes; GitHub unit coverage passed on PR #929.