### PR TITLE
fix: support pydantic AI model settings mapping

### DIFF
--- a/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
+++ b/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import logging
+import inspect
 from collections.abc import Sequence
+from typing import Protocol, cast
 
 from openai.types import chat
 from openai.types.chat.chat_completion_message_function_tool_call_param import (
@@ -23,6 +25,19 @@ from relay_teams.agents.execution.tool_call_history import normalize_replayed_me
 from relay_teams.agents.execution.tool_args_repair import repair_tool_args
 
 LOGGER = get_logger(__name__)
+_OPENAI_MAP_MESSAGES_ACCEPTS_MODEL_SETTINGS = (
+    "model_settings" in inspect.signature(OpenAIChatModel._map_messages).parameters
+)
+
+
+class _OpenAIMapMessagesWithSettings(Protocol):
+    async def __call__(
+        self,
+        messages: Sequence[ModelMessage],
+        model_request_parameters: ModelRequestParameters,
+        *,
+        model_settings: ModelSettings | None = None,
+    ) -> list[chat.ChatCompletionMessageParam]: ...
 
 
 class RecoverableOpenAIChatModel(OpenAIChatModel):
@@ -35,11 +50,22 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
         *,
         model_settings: ModelSettings | None = None,
     ) -> list[chat.ChatCompletionMessageParam]:
-        mapped = await super()._map_messages(
-            self._sanitize_replayed_messages(messages),
-            model_request_parameters,
-            model_settings=model_settings,
-        )
+        sanitized_messages = self._sanitize_replayed_messages(messages)
+        if _OPENAI_MAP_MESSAGES_ACCEPTS_MODEL_SETTINGS:
+            map_messages = cast(
+                _OpenAIMapMessagesWithSettings,
+                super()._map_messages,
+            )
+            mapped = await map_messages(
+                sanitized_messages,
+                model_request_parameters,
+                model_settings=model_settings,
+            )
+        else:
+            mapped = await super()._map_messages(
+                sanitized_messages,
+                model_request_parameters,
+            )
         for message in mapped:
             if not isinstance(message, dict):
                 continue

--- a/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
+++ b/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import logging
 import inspect
+import logging
 from collections.abc import Sequence
-from typing import Protocol, cast
 
 from openai.types import chat
 from openai.types.chat.chat_completion_message_function_tool_call_param import (
@@ -30,16 +29,6 @@ _OPENAI_MAP_MESSAGES_ACCEPTS_MODEL_SETTINGS = (
 )
 
 
-class _OpenAIMapMessagesWithSettings(Protocol):
-    async def __call__(
-        self,
-        messages: Sequence[ModelMessage],
-        model_request_parameters: ModelRequestParameters,
-        *,
-        model_settings: ModelSettings | None = None,
-    ) -> list[chat.ChatCompletionMessageParam]: ...
-
-
 class RecoverableOpenAIChatModel(OpenAIChatModel):
     """OpenAI chat model that sanitizes malformed historical tool args on replay."""
 
@@ -51,21 +40,14 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
         model_settings: ModelSettings | None = None,
     ) -> list[chat.ChatCompletionMessageParam]:
         sanitized_messages = self._sanitize_replayed_messages(messages)
+        map_kwargs: dict[str, ModelSettings | None] = {}
         if _OPENAI_MAP_MESSAGES_ACCEPTS_MODEL_SETTINGS:
-            map_messages = cast(
-                _OpenAIMapMessagesWithSettings,
-                super()._map_messages,
-            )
-            mapped = await map_messages(
-                sanitized_messages,
-                model_request_parameters,
-                model_settings=model_settings,
-            )
-        else:
-            mapped = await super()._map_messages(
-                sanitized_messages,
-                model_request_parameters,
-            )
+            map_kwargs["model_settings"] = model_settings
+        mapped = await super()._map_messages(
+            sanitized_messages,
+            model_request_parameters,
+            **map_kwargs,
+        )
         for message in mapped:
             if not isinstance(message, dict):
                 continue

--- a/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
+++ b/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import inspect
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from typing import Protocol, cast
 
 from openai.types import chat
 from openai.types.chat.chat_completion_message_function_tool_call_param import (
@@ -24,9 +25,37 @@ from relay_teams.agents.execution.tool_call_history import normalize_replayed_me
 from relay_teams.agents.execution.tool_args_repair import repair_tool_args
 
 LOGGER = get_logger(__name__)
-_OPENAI_MAP_MESSAGES_ACCEPTS_MODEL_SETTINGS = (
-    "model_settings" in inspect.signature(OpenAIChatModel._map_messages).parameters
-)
+
+
+class _OpenAIMapMessagesWithSettings(Protocol):
+    async def __call__(
+        self,
+        messages: Sequence[ModelMessage],
+        model_request_parameters: ModelRequestParameters,
+        *,
+        model_settings: ModelSettings | None = None,
+    ) -> list[chat.ChatCompletionMessageParam]:
+        raise NotImplementedError
+
+
+def _map_messages_accepts_model_settings(
+    map_messages: Callable[..., object],
+) -> bool:
+    return "model_settings" in inspect.signature(map_messages).parameters
+
+
+async def _call_map_messages_with_settings(
+    map_messages: Callable[..., object],
+    messages: Sequence[ModelMessage],
+    model_request_parameters: ModelRequestParameters,
+    model_settings: ModelSettings | None,
+) -> list[chat.ChatCompletionMessageParam]:
+    typed_map_messages = cast(_OpenAIMapMessagesWithSettings, map_messages)
+    return await typed_map_messages(
+        messages,
+        model_request_parameters,
+        model_settings=model_settings,
+    )
 
 
 class RecoverableOpenAIChatModel(OpenAIChatModel):
@@ -40,14 +69,19 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
         model_settings: ModelSettings | None = None,
     ) -> list[chat.ChatCompletionMessageParam]:
         sanitized_messages = self._sanitize_replayed_messages(messages)
-        map_kwargs: dict[str, ModelSettings | None] = {}
-        if _OPENAI_MAP_MESSAGES_ACCEPTS_MODEL_SETTINGS:
-            map_kwargs["model_settings"] = model_settings
-        mapped = await super()._map_messages(
-            sanitized_messages,
-            model_request_parameters,
-            **map_kwargs,
-        )
+        super_map_messages = super()._map_messages
+        if _map_messages_accepts_model_settings(super_map_messages):
+            mapped = await _call_map_messages_with_settings(
+                super_map_messages,
+                sanitized_messages,
+                model_request_parameters,
+                model_settings,
+            )
+        else:
+            mapped = await super_map_messages(
+                sanitized_messages,
+                model_request_parameters,
+            )
         for message in mapped:
             if not isinstance(message, dict):
                 continue

--- a/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
+++ b/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
@@ -16,6 +16,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.settings import ModelSettings
 
 from relay_teams.logger import get_logger, log_event
 from relay_teams.agents.execution.tool_call_history import normalize_replayed_messages
@@ -31,10 +32,13 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
         self,
         messages: Sequence[ModelMessage],
         model_request_parameters: ModelRequestParameters,
+        *,
+        model_settings: ModelSettings | None = None,
     ) -> list[chat.ChatCompletionMessageParam]:
         mapped = await super()._map_messages(
             self._sanitize_replayed_messages(messages),
             model_request_parameters,
+            model_settings=model_settings,
         )
         for message in mapped:
             if not isinstance(message, dict):

--- a/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
+++ b/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
@@ -18,6 +18,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.settings import ModelSettings
 
 
 def test_map_tool_call_keeps_valid_json_arguments() -> None:
@@ -216,7 +217,12 @@ async def test_map_messages_replays_deepseek_reasoning_content() -> None:
             ),
         ]
 
-        mapped = await model._map_messages(messages, ModelRequestParameters())
+        model_settings: ModelSettings = {"temperature": 0.2}
+        mapped = await model._map_messages(
+            messages,
+            ModelRequestParameters(),
+            model_settings=model_settings,
+        )
     finally:
         await http_client.aclose()
 

--- a/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
+++ b/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
@@ -9,7 +9,6 @@ import httpx
 import pytest
 from openai.types import chat
 
-import relay_teams.agents.execution.recoverable_openai_chat_model as recoverable_model_module
 from relay_teams.agents.execution.recoverable_openai_chat_model import (
     RecoverableOpenAIChatModel,
     _call_map_messages_with_settings,
@@ -281,12 +280,12 @@ async def test_map_messages_uses_model_settings_branch_when_supported(
         return [assistant_message]
 
     monkeypatch.setattr(
-        recoverable_model_module,
+        "relay_teams.agents.execution.recoverable_openai_chat_model."
         "_map_messages_accepts_model_settings",
         accepts_model_settings,
     )
     monkeypatch.setattr(
-        recoverable_model_module,
+        "relay_teams.agents.execution.recoverable_openai_chat_model."
         "_call_map_messages_with_settings",
         call_with_settings,
     )

--- a/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
+++ b/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
@@ -2,14 +2,22 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable, Sequence
+from typing import cast
+
 import httpx
 import pytest
+from openai.types import chat
 
+import relay_teams.agents.execution.recoverable_openai_chat_model as recoverable_model_module
 from relay_teams.agents.execution.recoverable_openai_chat_model import (
     RecoverableOpenAIChatModel,
+    _call_map_messages_with_settings,
+    _map_messages_accepts_model_settings,
 )
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.messages import (
+    ModelMessage,
     ModelRequest,
     ModelResponse,
     ThinkingPart,
@@ -190,6 +198,120 @@ def test_sanitize_replayed_messages_keeps_thinking_only_response() -> None:
     assert isinstance(sanitized[1].parts[0], ThinkingPart)
     assert isinstance(sanitized[2], ModelResponse)
     assert isinstance(sanitized[2].parts[0], ToolCallPart)
+
+
+def test_map_messages_accepts_model_settings_detects_optional_keyword() -> None:
+    async def map_messages_with_settings(
+        messages: Sequence[ModelMessage],
+        model_request_parameters: ModelRequestParameters,
+        *,
+        model_settings: ModelSettings | None = None,
+    ) -> list[chat.ChatCompletionMessageParam]:
+        del messages, model_request_parameters, model_settings
+        return []
+
+    async def map_messages_without_settings(
+        messages: Sequence[ModelMessage],
+        model_request_parameters: ModelRequestParameters,
+    ) -> list[chat.ChatCompletionMessageParam]:
+        del messages, model_request_parameters
+        return []
+
+    assert _map_messages_accepts_model_settings(map_messages_with_settings)
+    assert not _map_messages_accepts_model_settings(map_messages_without_settings)
+
+
+@pytest.mark.asyncio
+async def test_call_map_messages_with_settings_forwards_settings() -> None:
+    seen_model_settings: ModelSettings | None = None
+    user_message = cast(
+        chat.ChatCompletionMessageParam,
+        {"role": "user", "content": "ok"},
+    )
+
+    async def map_messages(
+        messages: Sequence[ModelMessage],
+        model_request_parameters: ModelRequestParameters,
+        *,
+        model_settings: ModelSettings | None = None,
+    ) -> list[chat.ChatCompletionMessageParam]:
+        nonlocal seen_model_settings
+        del messages, model_request_parameters
+        seen_model_settings = model_settings
+        return [user_message]
+
+    settings: ModelSettings = {"temperature": 0.2}
+
+    mapped = await _call_map_messages_with_settings(
+        map_messages,
+        [],
+        ModelRequestParameters(),
+        settings,
+    )
+
+    assert mapped == [user_message]
+    assert seen_model_settings == settings
+
+
+@pytest.mark.asyncio
+async def test_map_messages_uses_model_settings_branch_when_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assistant_message = cast(
+        chat.ChatCompletionMessageParam,
+        {"role": "assistant", "content": None},
+    )
+    seen_model_settings: ModelSettings | None = None
+
+    def accepts_model_settings(
+        map_messages: Callable[..., object],
+    ) -> bool:
+        del map_messages
+        return True
+
+    async def call_with_settings(
+        map_messages: Callable[..., object],
+        messages: Sequence[ModelMessage],
+        model_request_parameters: ModelRequestParameters,
+        model_settings: ModelSettings | None,
+    ) -> list[chat.ChatCompletionMessageParam]:
+        nonlocal seen_model_settings
+        del map_messages, messages, model_request_parameters
+        seen_model_settings = model_settings
+        return [assistant_message]
+
+    monkeypatch.setattr(
+        recoverable_model_module,
+        "_map_messages_accepts_model_settings",
+        accepts_model_settings,
+    )
+    monkeypatch.setattr(
+        recoverable_model_module,
+        "_call_map_messages_with_settings",
+        call_with_settings,
+    )
+    http_client = httpx.AsyncClient(trust_env=False)
+    try:
+        model = RecoverableOpenAIChatModel(
+            "gpt-5.4",
+            provider=OpenAIProvider(
+                base_url="https://example.test/v1",
+                api_key="test",
+                http_client=http_client,
+            ),
+        )
+        settings: ModelSettings = {"temperature": 0.2}
+
+        mapped = await model._map_messages(
+            [ModelRequest(parts=[UserPromptPart(content="continue")])],
+            ModelRequestParameters(),
+            model_settings=settings,
+        )
+    finally:
+        await http_client.aclose()
+
+    assert seen_model_settings == settings
+    assert mapped == [{"role": "assistant", "content": ""}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Summary
- Thread `model_settings` through `RecoverableOpenAIChatModel._map_messages` when the installed `pydantic_ai` base model supports it.
- Keep compatibility with `pydantic-ai` 1.103.0, where `OpenAIChatModel._map_messages` does not accept `model_settings`.
- Preserve replay sanitization and assistant content normalization for recoverable OpenAI chat history.

## Root Cause
`pydantic_ai` private message-mapping signatures differ across versions. Passing `model_settings` unconditionally breaks environments whose `OpenAIChatModel._map_messages` still has the older two-argument signature.

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests` failed locally because the Playwright Chromium browser cache is missing on this machine; `uv run --extra dev playwright install chromium` timed out after 15 minutes.


Fixes #934

