### PR TITLE
Fix multi-session run refresh and recovery UI

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -1520,6 +1520,20 @@ Session records include terminal run projections for list badges:
 - `latest_terminal_run_updated_at`
 - `has_unread_terminal_run`
 
+### `GET /sessions/sidebar`
+
+Lists the lightweight session projection used by the frontend sidebar and background
+run discovery.
+
+Query:
+- `force_refresh`: optional boolean, default `false`. Normal sidebar reads should omit it so the backend can return a stale list snapshot immediately and refresh projections in the background.
+
+Response rows include the fields needed for sidebar grouping, titles, active-run
+badges, terminal-run badges, pending approval counts, and subagent counts. Heavier
+session topology details such as `normal_model_profile`, `normal_root_role_id`,
+and `orchestration_preset_id` remain available through `GET /sessions` or
+`GET /sessions/{session_id}`.
+
 ### `GET /sessions/{session_id}`
 
 Gets one session.

--- a/frontend/dist/js/app/prompt.js
+++ b/frontend/dist/js/app/prompt.js
@@ -78,6 +78,7 @@ let orchestrationConfig = {
   presets: [],
 };
 let normalModelProfiles = [];
+let normalModelProfilesLoaded = false;
 let normalModelProfileSavePromise = null;
 let normalModelProfileSaveRequestId = 0;
 let activeComposerSelectMenu = "";
@@ -323,11 +324,23 @@ export async function refreshRoleConfigOptions({ refreshControls = true } = {}) 
 export async function refreshModelProfileOptions({
   refreshControls = true,
 } = {}) {
+  if (
+    normalModelProfilesLoaded
+    && (state.isGenerating || String(state.activeRunId || "").trim())
+  ) {
+    if (refreshControls) {
+      refreshSessionTopologyControls();
+    }
+    return;
+  }
   try {
     const profiles = await fetchModelProfiles();
     normalModelProfiles = normalizeModelProfileOptions(profiles);
+    normalModelProfilesLoaded = true;
   } catch (error) {
-    normalModelProfiles = [];
+    if (!normalModelProfilesLoaded) {
+      normalModelProfiles = [];
+    }
     sysLog(error.message || t("composer.error.model_profiles_load_failed"), "log-error");
   }
   if (refreshControls) {
@@ -549,7 +562,9 @@ export async function handleSend(options = {}) {
       runSessionId,
       async (sid) =>
         hydrateSessionView(sid, {
-          includeRounds: true,
+          includeRecovery: false,
+          includeRounds: false,
+          includeSubagents: false,
           quiet: true,
           roundsScrollPolicy: "completion-auto",
         }),

--- a/frontend/dist/js/app/recovery.js
+++ b/frontend/dist/js/app/recovery.js
@@ -53,6 +53,8 @@ let recoveryBannerRenderSignature = '';
 let activeUserQuestionSupplementState = null;
 const CONTINUITY_POLL_ACTIVE_MS = 1500;
 const CONTINUITY_POLL_IDLE_MS = 4000;
+const RECOVERY_REFRESH_BUSY_DEFER_MS = 2800;
+const LOCAL_TERMINAL_RUN_STATE_TTL_MS = 30000;
 const USER_QUESTION_NONE_OPTION_LABEL = '__none_of_the_above__';
 const continuity = {
     sessionId: '',
@@ -62,6 +64,9 @@ const continuity = {
     pendingRefresh: null,
     listenersBound: false,
 };
+let recoveryRefreshPromise = null;
+let recoveryRefreshSessionId = '';
+const localTerminalRunStates = new Map();
 
 function isPrimaryOrReservedRoleId(roleId) {
     return isPrimaryRoleId(roleId) || isReservedSystemRoleId(roleId);
@@ -96,7 +101,9 @@ function handleBackgroundTaskPanelToggle(runId) {
 export async function hydrateSessionView(
     sessionId = state.currentSessionId,
     {
+        includeRecovery = true,
         includeRounds = true,
+        includeSubagents = true,
         forceRefresh = false,
         priority = '',
         quiet = true,
@@ -113,20 +120,16 @@ export async function hydrateSessionView(
     throwIfAborted(signal);
 
     startSessionContinuity(safeSessionId);
-    const shouldSkipRoundsReload = !!(
-        includeRounds
-        && state.currentSessionId === safeSessionId
-        && state.activeEventSource
-        && state.isGenerating
-    );
-    const recoveryPromise = refreshSessionRecovery(safeSessionId, {
-        forceRefresh: forceRefresh === true,
-        priority,
-        quiet,
-        signal,
-    });
+    const recoveryPromise = includeRecovery
+        ? refreshSessionRecovery(safeSessionId, {
+            forceRefresh: forceRefresh === true,
+            priority,
+            quiet,
+            signal,
+        })
+        : Promise.resolve(null);
     recoveryPromise.catch(() => null);
-    if (includeRounds && !shouldSkipRoundsReload) {
+    if (includeRounds) {
         await loadSessionRounds(safeSessionId, {
             forceRefresh: forceRefresh === true,
             priority,
@@ -143,12 +146,23 @@ export async function hydrateSessionView(
         sessionId: safeSessionId,
         reason: 'hydrate-session',
     });
-    await refreshSubagentRail(safeSessionId, {
-        preserveSelection: true,
-        priority,
-        forceRefresh: forceRefresh === true,
-        signal,
-    });
+    syncSessionContinuity();
+    if (includeSubagents) {
+        try {
+            await refreshSubagentRail(safeSessionId, {
+                preserveSelection: true,
+                priority,
+                forceRefresh: forceRefresh === true,
+                signal,
+            });
+        } catch (error) {
+            if (error?.name === 'AbortError') throw error;
+            sysLog(
+                `Failed to refresh subagent rail: ${error?.message || error}`,
+                'log-error',
+            );
+        }
+    }
     throwIfAborted(signal);
     syncSessionContinuity();
     return snapshot;
@@ -318,8 +332,25 @@ export function applyRecoverySnapshot(snapshot) {
 
 function reconcileTerminalRecoverySnapshot(snapshot) {
     const activeRun = snapshot?.activeRun || null;
-    if (activeRun?.run_id && isTerminalRecoveryRun(activeRun)) {
-        reconcileTerminalRunStreamState(activeRun.run_id);
+    if (activeRun?.run_id) {
+        const terminalState = getLocalTerminalRunState(activeRun.run_id);
+        if (terminalState && !isTerminalRecoveryRun(activeRun)) {
+            if (terminalState.recoverable === false) {
+                snapshot.activeRun = null;
+            } else {
+                snapshot.activeRun = {
+                    ...activeRun,
+                    status: terminalState.status || 'stopped',
+                    phase: terminalState.phase || 'stopped',
+                    stream_connected: false,
+                    should_show_recover: true,
+                };
+            }
+        }
+    }
+    const reconciledActiveRun = snapshot?.activeRun || null;
+    if (reconciledActiveRun?.run_id && isTerminalRecoveryRun(reconciledActiveRun)) {
+        reconcileTerminalRunStreamState(reconciledActiveRun.run_id);
     }
     const roundSnapshot = snapshot?.roundSnapshot || null;
     const roundRunId = String(roundSnapshot?.run_id || '').trim();
@@ -463,7 +494,36 @@ export async function refreshSessionRecovery(sessionId = state.currentSessionId,
         clearSessionRecovery();
         return null;
     }
+    const canCoalesce = !!(
+        options.forceRefresh !== true
+        && !options.signal
+        && !isCriticalContinuityRefreshReason(options.reason)
+    );
+    if (
+        canCoalesce
+        && recoveryRefreshPromise
+        && recoveryRefreshSessionId === safeSessionId
+    ) {
+        return await recoveryRefreshPromise;
+    }
 
+    const refreshPromise = runSessionRecoveryRefresh(safeSessionId, options);
+    if (!canCoalesce) {
+        return await refreshPromise;
+    }
+    recoveryRefreshPromise = refreshPromise;
+    recoveryRefreshSessionId = safeSessionId;
+    try {
+        return await refreshPromise;
+    } finally {
+        if (recoveryRefreshPromise === refreshPromise) {
+            recoveryRefreshPromise = null;
+            recoveryRefreshSessionId = '';
+        }
+    }
+}
+
+async function runSessionRecoveryRefresh(safeSessionId, options = {}) {
     try {
         const previousActiveRunId = String(
             state.currentRecoverySnapshot?.activeRun?.run_id || state.activeRunId || '',
@@ -566,6 +626,7 @@ export async function resumeRecoverableRun(
 export function markRunStreamConnected(runId, { phase = 'running' } = {}) {
     const activeRun = getActiveRecoveryRun();
     if (!runId) return;
+    localTerminalRunStates.delete(runId);
     state.pausedSubagent = null;
     approvalActionErrors.clear();
     if (!activeRun || activeRun.run_id !== runId) {
@@ -614,6 +675,11 @@ export function markRunTerminalState(runId, { status, phase, recoverable } = {})
     const isRecoverable = recoverable !== false;
     const terminalStatus = status || activeRun?.status || (isRecoverable ? 'stopped' : 'completed');
     const terminalPhase = phase || activeRun?.phase || (isRecoverable ? 'stopped' : 'terminal');
+    rememberLocalTerminalRunState(safeRunId, {
+        status: terminalStatus,
+        phase: terminalPhase,
+        recoverable: isRecoverable,
+    });
     const terminalOverlay = {
         run_status: terminalStatus,
         run_phase: terminalPhase,
@@ -1038,6 +1104,7 @@ function handleContinuityFocus() {
     scheduleRecoveryContinuityRefresh({
         sessionId: continuity.sessionId,
         delayMs: 0,
+        forceRefresh: true,
         includeRounds: false,
         quiet: true,
         reason: 'window-focus',
@@ -1118,7 +1185,7 @@ function isContinuityPollableRun(activeRun) {
 }
 
 function nextContinuityPollDelay() {
-    if (state.isGenerating || state.activeEventSource) {
+    if (hasRunRefreshPressure()) {
         return CONTINUITY_POLL_ACTIVE_MS;
     }
     return CONTINUITY_POLL_IDLE_MS;
@@ -1150,7 +1217,7 @@ async function flushScheduledContinuityRefresh() {
         .finally(() => {
             continuity.refreshPromise = null;
             syncSessionContinuity();
-            if (continuity.pendingRefresh) {
+            if (continuity.pendingRefresh && !continuity.refreshTimer) {
                 void flushScheduledContinuityRefresh();
             }
         });
@@ -1160,8 +1227,19 @@ async function flushScheduledContinuityRefresh() {
 async function runScheduledContinuityRefresh(request) {
     const safeSessionId = typeof request?.sessionId === 'string' ? request.sessionId.trim() : '';
     if (!safeSessionId || state.currentSessionId !== safeSessionId) return null;
+    if (
+        request.forceRefresh !== true
+        && hasRunRefreshPressure()
+        && !isCriticalContinuityRefreshReason(request.reason)
+    ) {
+        scheduleRecoveryContinuityRefresh({
+            ...request,
+            delayMs: RECOVERY_REFRESH_BUSY_DEFER_MS,
+        });
+        return null;
+    }
 
-    const canRefreshRounds = request.includeRounds && !state.isGenerating && !state.activeEventSource;
+    const canRefreshRounds = request.includeRounds && !hasRunRefreshPressure();
     if (canRefreshRounds) {
         await loadSessionRounds(safeSessionId, {
             forceRefresh: request.forceRefresh === true,
@@ -1169,18 +1247,95 @@ async function runScheduledContinuityRefresh(request) {
         });
         if (state.currentSessionId !== safeSessionId) return null;
     }
-    if (request.forceRefresh === true) {
+    const forceRecoveryRefresh = request.forceRefresh === true
+        || requiresFreshContinuitySnapshot(request.reason);
+    if (forceRecoveryRefresh) {
         invalidateSessionRecovery(safeSessionId);
     }
     const snapshot = await refreshSessionRecovery(safeSessionId, {
-        forceRefresh: request.forceRefresh === true,
+        forceRefresh: forceRecoveryRefresh,
         quiet: request.quiet !== false,
+        reason: request.reason || 'continuity-refresh',
     });
     await ensureAutomaticRecoveryStream(snapshot, {
         sessionId: safeSessionId,
         reason: request.reason || 'continuity-refresh',
     });
     return snapshot;
+}
+
+function hasRunRefreshPressure() {
+    return !!(
+        state.isGenerating
+        || state.activeEventSource
+        || Number(state.activeRunStreamCount || 0) > 0
+    );
+}
+
+function isCriticalContinuityRefreshReason(reason) {
+    const safeReason = String(reason || '').trim();
+    return [
+        'tool_approval_requested',
+        'tool_approval_resolved',
+        'user_question_requested',
+        'user_question_answered',
+        'subagent_stopped',
+        'subagent_resumed',
+        'subagent_session_status_changed',
+        'notification_requested',
+        'gate_resolved',
+        'background_task_started',
+        'background_task_updated',
+        'background_task_completed',
+        'background_task_stopped',
+        'recovery-action',
+        'question-action',
+        'approval-action',
+        'window-focus',
+    ].includes(safeReason);
+}
+
+function requiresFreshContinuitySnapshot(reason) {
+    const safeReason = String(reason || '').trim();
+    return [
+        'tool_approval_requested',
+        'tool_approval_resolved',
+        'user_question_requested',
+        'user_question_answered',
+    ].includes(safeReason);
+}
+
+function rememberLocalTerminalRunState(runId, terminalState = {}) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) return;
+    pruneLocalTerminalRunStates();
+    localTerminalRunStates.set(safeRunId, {
+        status: String(terminalState.status || '').trim(),
+        phase: String(terminalState.phase || '').trim(),
+        recoverable: terminalState.recoverable !== false,
+        expiresAt: Date.now() + LOCAL_TERMINAL_RUN_STATE_TTL_MS,
+    });
+}
+
+function getLocalTerminalRunState(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) return null;
+    const terminalState = localTerminalRunStates.get(safeRunId) || null;
+    if (!terminalState) return null;
+    if (Date.now() > Number(terminalState.expiresAt || 0)) {
+        localTerminalRunStates.delete(safeRunId);
+        return null;
+    }
+    return terminalState;
+}
+
+function pruneLocalTerminalRunStates() {
+    const now = Date.now();
+    localTerminalRunStates.forEach((terminalState, runId) => {
+        if (now > Number(terminalState?.expiresAt || 0)) {
+            localTerminalRunStates.delete(runId);
+        }
+    });
 }
 
 async function ensureAutomaticRecoveryStream(

--- a/frontend/dist/js/components/sessionSidebarStore.js
+++ b/frontend/dist/js/components/sessionSidebarStore.js
@@ -10,6 +10,7 @@ const snapshot = {
     automationProjects: [],
 };
 const RECENT_SESSION_REMOVAL_RETENTION_MS = 30000;
+const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed', 'stopped', 'paused']);
 const optimisticSessions = new Map();
 const removedSessionIds = new Map();
 const viewedTerminalRunsBySessionId = new Map();
@@ -65,6 +66,152 @@ export function updateOptimisticSessionTitle(sessionId, title) {
             title: safeTitle,
         },
         updated_at: new Date().toISOString(),
+    });
+}
+
+export function markSidebarSessionRunStarted(sessionId, run = {}) {
+    const safeSessionId = String(
+        sessionId || run?.session_id || run?.sessionId || '',
+    ).trim();
+    if (!safeSessionId) {
+        return null;
+    }
+    const runId = String(run?.run_id || run?.runId || '').trim();
+    const now = new Date().toISOString();
+    const current = findStoredSession(safeSessionId)
+        || optimisticSessions.get(safeSessionId)
+        || { session_id: safeSessionId, metadata: {} };
+    return upsertOptimisticSession({
+        ...current,
+        session_id: safeSessionId,
+        workspace_id: String(
+            current?.workspace_id || current?.workspaceId || run?.workspace_id || '',
+        ).trim(),
+        has_active_run: true,
+        hasActiveRun: true,
+        active_run_id: runId,
+        activeRunId: runId,
+        active_run_status: 'running',
+        activeRunStatus: 'running',
+        active_run_phase: 'running',
+        activeRunPhase: 'running',
+        has_unread_terminal_run: false,
+        hasUnreadTerminalRun: false,
+        updated_at: now,
+        updatedAt: now,
+    });
+}
+
+export function markSidebarSessionRunTerminal(sessionId, run = {}, options = {}) {
+    const safeSessionId = String(
+        sessionId || run?.session_id || run?.sessionId || '',
+    ).trim();
+    if (!safeSessionId) {
+        return null;
+    }
+    const runId = String(
+        run?.run_id || run?.runId || run?.trace_id || run?.traceId || '',
+    ).trim();
+    const status = normalizeTerminalRunStatus(
+        run?.status
+        || run?.run_status
+        || run?.runStatus
+        || run?.event_type
+        || run?.eventType
+        || '',
+    );
+    const now = String(
+        run?.updated_at
+        || run?.updatedAt
+        || run?.created_at
+        || run?.createdAt
+        || new Date().toISOString(),
+    );
+    const optimisticUpdatedAt = new Date().toISOString();
+    const current = optimisticSessions.get(safeSessionId)
+        || findStoredSession(safeSessionId)
+        || { session_id: safeSessionId, metadata: {} };
+    const currentActiveRunId = String(
+        current.active_run_id || current.activeRunId || '',
+    ).trim();
+    const terminalMatchesActiveRun = !!runId && (
+        !currentActiveRunId || currentActiveRunId === runId
+    );
+    const shouldKeepRecoverableActiveRun = terminalMatchesActiveRun
+        && isRecoverableTerminalRunStatus(status);
+    const shouldClearActiveRun = terminalMatchesActiveRun
+        && !shouldKeepRecoverableActiveRun;
+    const isViewed = options.viewed === true;
+    if (isViewed && runId) {
+        viewedTerminalRunsBySessionId.set(safeSessionId, runId);
+    } else if (!isViewed) {
+        viewedTerminalRunsBySessionId.delete(safeSessionId);
+    }
+    return upsertOptimisticSession({
+        ...current,
+        session_id: safeSessionId,
+        has_active_run: shouldKeepRecoverableActiveRun
+            ? true
+            : shouldClearActiveRun
+            ? false
+            : !!(current.has_active_run || current.hasActiveRun),
+        hasActiveRun: shouldKeepRecoverableActiveRun
+            ? true
+            : shouldClearActiveRun
+            ? false
+            : !!(current.has_active_run || current.hasActiveRun),
+        active_run_id: shouldKeepRecoverableActiveRun
+            ? runId
+            : shouldClearActiveRun
+            ? ''
+            : current.active_run_id || current.activeRunId || '',
+        activeRunId: shouldKeepRecoverableActiveRun
+            ? runId
+            : shouldClearActiveRun
+            ? ''
+            : current.active_run_id || current.activeRunId || '',
+        active_run_status: shouldKeepRecoverableActiveRun
+            ? status
+            : shouldClearActiveRun
+            ? ''
+            : current.active_run_status || current.activeRunStatus || '',
+        activeRunStatus: shouldKeepRecoverableActiveRun
+            ? status
+            : shouldClearActiveRun
+            ? ''
+            : current.active_run_status || current.activeRunStatus || '',
+        active_run_phase: shouldKeepRecoverableActiveRun
+            ? status
+            : shouldClearActiveRun
+            ? ''
+            : current.active_run_phase || current.activeRunPhase || '',
+        activeRunPhase: shouldKeepRecoverableActiveRun
+            ? status
+            : shouldClearActiveRun
+            ? ''
+            : current.active_run_phase || current.activeRunPhase || '',
+        latest_terminal_run_id: runId
+            || current.latest_terminal_run_id
+            || current.latestTerminalRunId
+            || '',
+        latestTerminalRunId: runId
+            || current.latest_terminal_run_id
+            || current.latestTerminalRunId
+            || '',
+        latest_terminal_run_status: status
+            || current.latest_terminal_run_status
+            || current.latestTerminalRunStatus
+            || '',
+        latestTerminalRunStatus: status
+            || current.latest_terminal_run_status
+            || current.latestTerminalRunStatus
+            || '',
+        latest_terminal_run_updated_at: now.trim(),
+        latestTerminalRunUpdatedAt: now.trim(),
+        has_unread_terminal_run: !!(status && terminalMatchesActiveRun && !isViewed),
+        hasUnreadTerminalRun: !!(status && terminalMatchesActiveRun && !isViewed),
+        updated_at: optimisticUpdatedAt,
+        updatedAt: optimisticUpdatedAt,
     });
 }
 
@@ -132,6 +279,13 @@ function trimOptimisticSessions(sessions) {
             viewedTerminalRunsBySessionId.delete(sessionId);
             return;
         }
+        if (terminalRunDisplacesActiveRun(persisted, optimistic)) {
+            optimisticSessions.delete(sessionId);
+            return;
+        }
+        if (shouldPreserveOptimisticSession(optimistic, persisted)) {
+            return;
+        }
         const persistedTitle = String(persisted?.metadata?.title || '').trim();
         if (viewedTerminalRunsBySessionId.has(sessionId)) {
             return;
@@ -140,6 +294,26 @@ function trimOptimisticSessions(sessions) {
             optimisticSessions.delete(sessionId);
         }
     });
+}
+
+function shouldPreserveOptimisticSession(optimistic, persisted) {
+    if (!optimistic || typeof optimistic !== 'object') {
+        return false;
+    }
+    if (terminalRunDisplacesActiveRun(persisted, optimistic)) {
+        return false;
+    }
+    const optimisticUpdatedAt = timestampValue(optimistic.updated_at || optimistic.updatedAt || '');
+    const persistedUpdatedAt = timestampValue(persisted?.updated_at || persisted?.updatedAt || '');
+    if (optimisticUpdatedAt < persistedUpdatedAt) {
+        return false;
+    }
+    return !!(
+        optimistic.has_active_run
+        || optimistic.hasActiveRun
+        || optimistic.active_run_id
+        || optimistic.activeRunId
+    );
 }
 
 function findStoredSession(sessionId) {
@@ -178,6 +352,24 @@ function mergeSessionRecords(preferred, current) {
     const preferredRecord = normalizeSession(preferred) || {};
     const currentRecord = normalizeSession(current) || {};
     const sessionId = String(currentRecord.session_id || preferredRecord.session_id || '').trim();
+    const preferredUpdatedAt = String(preferredRecord.updated_at || '').trim();
+    const currentUpdatedAt = String(currentRecord.updated_at || '').trim();
+    const preferredUpdatedValue = timestampValue(preferredUpdatedAt);
+    const currentUpdatedValue = timestampValue(currentUpdatedAt);
+    const preferredDisplacesCurrent = terminalRunDisplacesActiveRun(preferredRecord, currentRecord);
+    const currentDisplacesPreferred = terminalRunDisplacesActiveRun(currentRecord, preferredRecord);
+    const latestRecord = preferredDisplacesCurrent
+        ? preferredRecord
+        : (
+            currentDisplacesPreferred
+                ? currentRecord
+                : (
+                    preferredUpdatedValue > currentUpdatedValue
+                        ? preferredRecord
+                        : currentRecord
+                )
+        );
+    const olderRecord = latestRecord === preferredRecord ? currentRecord : preferredRecord;
     const preferredMetadata = preferredRecord.metadata && typeof preferredRecord.metadata === 'object'
         ? preferredRecord.metadata
         : {};
@@ -186,14 +378,12 @@ function mergeSessionRecords(preferred, current) {
         : {};
     const preferredTitle = String(preferredMetadata.title || '').trim();
     const currentTitle = String(currentMetadata.title || '').trim();
-    const preferredUpdatedAt = String(preferredRecord.updated_at || '').trim();
-    const currentUpdatedAt = String(currentRecord.updated_at || '').trim();
-    const updatedAt = timestampValue(preferredUpdatedAt) > timestampValue(currentUpdatedAt)
-        ? preferredUpdatedAt
+    const updatedAt = latestRecord === preferredRecord
+        ? preferredUpdatedAt || currentUpdatedAt
         : currentUpdatedAt || preferredUpdatedAt;
-    return {
-        ...preferredRecord,
-        ...currentRecord,
+    const merged = {
+        ...olderRecord,
+        ...latestRecord,
         session_id: sessionId,
         workspace_id: String(currentRecord.workspace_id || preferredRecord.workspace_id || '').trim(),
         metadata: {
@@ -204,6 +394,53 @@ function mergeSessionRecords(preferred, current) {
         updated_at: updatedAt || new Date().toISOString(),
         created_at: String(currentRecord.created_at || preferredRecord.created_at || '').trim(),
     };
+    if (preferredDisplacesCurrent || currentDisplacesPreferred) {
+        return clearActiveRunFields(merged);
+    }
+    return merged;
+}
+
+function clearActiveRunFields(record) {
+    return {
+        ...record,
+        has_active_run: false,
+        hasActiveRun: false,
+        active_run_id: '',
+        activeRunId: '',
+        active_run_status: '',
+        activeRunStatus: '',
+        active_run_phase: '',
+        activeRunPhase: '',
+    };
+}
+
+function terminalRunDisplacesActiveRun(terminalRecord, activeRecord) {
+    const latestRunId = String(
+        terminalRecord?.latest_terminal_run_id || terminalRecord?.latestTerminalRunId || '',
+    ).trim();
+    const latestStatus = normalizeTerminalRunStatus(
+        terminalRecord?.latest_terminal_run_status || terminalRecord?.latestTerminalRunStatus || '',
+    );
+    const activeRunId = String(
+        activeRecord?.active_run_id || activeRecord?.activeRunId || '',
+    ).trim();
+    return !!(
+        latestRunId
+        && activeRunId
+        && latestRunId === activeRunId
+        && latestStatus
+        && !isRecoverableTerminalRunStatus(latestStatus)
+    );
+}
+
+function normalizeTerminalRunStatus(rawStatus) {
+    const status = String(rawStatus || '').trim().toLowerCase();
+    const normalized = status.startsWith('run_') ? status.slice(4) : status;
+    return TERMINAL_RUN_STATUSES.has(normalized) ? normalized : '';
+}
+
+function isRecoverableTerminalRunStatus(status) {
+    return status === 'stopped' || status === 'paused';
 }
 
 function applyViewedTerminalState(record) {

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -70,6 +70,8 @@ import {
     hasSidebarDataSnapshot,
     mergeOptimisticSessions,
     markSidebarSessionTerminalViewed,
+    markSidebarSessionRunStarted,
+    markSidebarSessionRunTerminal,
     rememberSidebarDataSnapshot,
     removeSidebarSession,
     updateOptimisticSessionTitle,
@@ -122,6 +124,7 @@ let loadProjectsRequestId = 0;
 let loadProjectsController = null;
 let sessionsRefreshPromise = null;
 let suppressSessionsRefreshUntil = 0;
+let deferSessionsRefreshUntil = 0;
 let lastProjectsRenderSignature = '';
 let sidebarSelectionToken = 0;
 let sessionAnimationTokenSeed = 0;
@@ -131,6 +134,8 @@ const subagentListAnimationTokens = new WeakMap();
 let sidebarCollapsibleAnimationTokenSeed = 0;
 let subagentListVisualSyncToken = 0;
 const SIDEBAR_INTERACTION_REFRESH_DELAY_MS = 240;
+const SIDEBAR_ACTIVE_RUN_REFRESH_DELAY_MS = 2600;
+const SIDEBAR_TERMINAL_SETTLE_REFRESH_DELAY_MS = 2200;
 const SESSION_DELETE_REFRESH_SUPPRESSION_MS = 20000;
 
 const SESSION_ANIMATION_ENTER_MS = 220;
@@ -2162,11 +2167,20 @@ function bindSessionRows(root, { projectId = '' } = {}) {
             if (!sessionId) return;
             const willExpand = !isSubagentSessionListExpanded(sessionId);
             let subagentsLoadPromise = null;
+            const displayedCount = Number.parseInt(
+                button.querySelector?.('.session-subagents-toggle-count')?.textContent || '0',
+                10,
+            ) || 0;
+            const cachedCount = getSessionSubagentSessions(sessionId).length;
+            const shouldRefreshChildren = displayedCount > cachedCount;
             toggleSubagentSessionList(sessionId, { emitChange: false, load: false });
-            if (willExpand && !hasLoadedSessionSubagents(sessionId)) {
+            if (
+                willExpand
+                && (!hasLoadedSessionSubagents(sessionId) || shouldRefreshChildren)
+            ) {
                 subagentsLoadPromise = ensureSessionSubagents(sessionId, {
                     emitLoadingEvents: false,
-                    force: false,
+                    force: shouldRefreshChildren,
                 });
             }
             syncSubagentSessionListVisualState({
@@ -2218,13 +2232,12 @@ function bindSessionRows(root, { projectId = '' } = {}) {
             });
             if (nextTitle === null) return;
             const normalizedTitle = String(nextTitle || '').trim();
-            const nextMetadata = { ...metadata };
+            const nextMetadata = {};
             if (normalizedTitle) {
                 nextMetadata.title = normalizedTitle;
                 nextMetadata.title_source = 'manual';
             } else {
-                delete nextMetadata.title;
-                delete nextMetadata.title_source;
+                nextMetadata.title = null;
             }
             await updateSession(sessionId, nextMetadata);
             await loadProjects();
@@ -2730,13 +2743,13 @@ function renderProjectSidebarData(
 function handleNewSessionDraftCreated(event) {
     const detail = event?.detail && typeof event.detail === 'object' ? event.detail : {};
     if (detail.detached === true) {
-        scheduleSessionsRefresh(900, { forceRefresh: true });
+        scheduleSessionsRefresh(900, { forceRefresh: false });
         return;
     }
     const sessionId = String(detail.sessionId || detail.session?.session_id || '').trim();
     const workspaceId = String(detail.workspaceId || detail.session?.workspace_id || state.currentWorkspaceId || '').trim();
     if (!sessionId || !workspaceId) {
-        scheduleSessionsRefresh(320, { forceRefresh: true });
+        scheduleSessionsRefresh(320, { forceRefresh: false });
         return;
     }
     const now = new Date().toISOString();
@@ -2756,14 +2769,67 @@ function handleNewSessionDraftCreated(event) {
     });
     setPendingSessionAnimation(sessionId, 'entering');
     if (!renderProjectsFromSnapshot({ syncStreams: false })) {
-        scheduleSessionsRefresh(120, { forceRefresh: true });
+        scheduleSessionsRefresh(120, { forceRefresh: false });
         return;
     }
-    scheduleSessionsRefresh(900, { forceRefresh: true });
+    scheduleSessionsRefresh(900, { forceRefresh: false });
 }
 
 function handleSessionUpserted(event) {
     handleNewSessionDraftCreated(event);
+}
+
+function handleCurrentSessionRunStarted(event) {
+    const detail = event?.detail && typeof event.detail === 'object' ? event.detail : {};
+    const sessionId = String(detail.sessionId || detail.session_id || state.currentSessionId || '').trim();
+    if (!sessionId) {
+        return;
+    }
+    deferSessionsRefreshUntil = Math.max(
+        deferSessionsRefreshUntil,
+        Date.now() + SIDEBAR_ACTIVE_RUN_REFRESH_DELAY_MS,
+    );
+    markSidebarSessionRunStarted(sessionId, detail.run || detail);
+    if (!renderProjectsFromSnapshot({ syncStreams: false })) {
+        scheduleSessionsRefresh(120, { forceRefresh: false });
+        return;
+    }
+    syncActivatedSessionFromEvent({ detail: { sessionId } });
+}
+
+function handleSessionRunTerminal(event) {
+    const detail = event?.detail && typeof event.detail === 'object' ? event.detail : {};
+    const sessionId = String(detail.sessionId || detail.session_id || '').trim();
+    if (!sessionId) {
+        return;
+    }
+    deferSessionsRefreshUntil = Math.max(
+        deferSessionsRefreshUntil,
+        Date.now() + SIDEBAR_TERMINAL_SETTLE_REFRESH_DELAY_MS,
+    );
+    const run = detail.run || detail;
+    const rawTerminalStatus = String(
+        run?.status
+        || run?.run_status
+        || run?.runStatus
+        || run?.event_type
+        || run?.eventType
+        || '',
+    ).trim().toLowerCase();
+    const terminalStatus = rawTerminalStatus.startsWith('run_')
+        ? rawTerminalStatus.slice(4)
+        : rawTerminalStatus;
+    const isViewedInCurrentSession = (
+        sessionId === String(state.currentSessionId || '').trim()
+        && !state.activeSubagentSession
+        && (terminalStatus === 'completed' || terminalStatus === 'failed')
+    );
+    markSidebarSessionRunTerminal(sessionId, run, {
+        viewed: isViewedInCurrentSession,
+    });
+    if (!renderProjectsFromSnapshot({ syncStreams: false })) {
+        scheduleSessionsRefresh(120, { forceRefresh: false });
+    }
 }
 
 function handleSessionTitlePreviewed(event) {
@@ -2847,6 +2913,12 @@ export async function loadProjects({ forceRefresh = false } = {}) {
         document.addEventListener('agent-teams-session-upserted', event => {
             handleSessionUpserted(event);
         });
+        document.addEventListener('agent-teams-current-session-run-started', event => {
+            handleCurrentSessionRunStarted(event);
+        });
+        document.addEventListener('agent-teams-session-run-terminal', event => {
+            handleSessionRunTerminal(event);
+        });
         document.addEventListener('agent-teams-session-title-previewed', event => {
             handleSessionTitlePreviewed(event);
         });
@@ -2871,10 +2943,11 @@ export async function loadProjects({ forceRefresh = false } = {}) {
     loadProjectsController = controller;
     try {
         ensureProjectMenuDismissBinding();
-        const shouldForceRefreshSessions = forceRefresh === true || !hasSidebarDataSnapshot();
+        const shouldForceRefreshSessions = forceRefresh === true;
         const [workspaces, sessions, automationProjects] = await Promise.all([
             fetchWorkspaces({ signal: controller?.signal }),
             fetchSessions({
+                sidebar: true,
                 forceRefresh: shouldForceRefreshSessions,
                 signal: controller?.signal,
             }),
@@ -2922,10 +2995,24 @@ export function scheduleSessionsRefresh(delayMs = 120, { forceRefresh = false } 
     }
     pendingSessionsRefreshForce = pendingSessionsRefreshForce || forceRefresh === true;
     if (refreshTimer) clearTimeout(refreshTimer);
-    const safeDelayMs = Math.max(0, Number(delayMs) || 0);
+    let safeDelayMs = Math.max(0, Number(delayMs) || 0);
+    if (
+        forceRefresh !== true
+        && (state.isGenerating || state.activeEventSource || Number(state.activeRunStreamCount || 0) > 0)
+    ) {
+        safeDelayMs = Math.max(safeDelayMs, SIDEBAR_ACTIVE_RUN_REFRESH_DELAY_MS);
+    }
+    if (forceRefresh !== true) {
+        safeDelayMs = Math.max(safeDelayMs, getDeferredSessionsRefreshDelayMs());
+    }
     refreshTimer = setTimeout(() => {
         refreshTimer = null;
         const forceNow = pendingSessionsRefreshForce === true;
+        const deferredDelayMs = forceNow ? 0 : getDeferredSessionsRefreshDelayMs();
+        if (deferredDelayMs > 0) {
+            scheduleSessionsRefresh(deferredDelayMs, { forceRefresh: false });
+            return;
+        }
         if (!forceNow && isProjectsListInteracting()) {
             scheduleSessionsRefresh(Math.max(safeDelayMs, SIDEBAR_INTERACTION_REFRESH_DELAY_MS));
             return;
@@ -2933,6 +3020,19 @@ export function scheduleSessionsRefresh(delayMs = 120, { forceRefresh = false } 
         pendingSessionsRefreshForce = false;
         void refreshSessionsSnapshot({ forceRefresh: forceNow });
     }, safeDelayMs);
+}
+
+function getDeferredSessionsRefreshDelayMs() {
+    const runBusy = (
+        state.isGenerating
+        || state.activeEventSource
+        || Number(state.activeRunStreamCount || 0) > 0
+    );
+    if (runBusy) {
+        return SIDEBAR_ACTIVE_RUN_REFRESH_DELAY_MS;
+    }
+    const remainingSettleDelayMs = deferSessionsRefreshUntil - Date.now();
+    return remainingSettleDelayMs > 0 ? remainingSettleDelayMs : 0;
 }
 
 async function refreshSessionsSnapshot({ forceRefresh = false } = {}) {
@@ -2954,7 +3054,10 @@ async function refreshSessionsSnapshot({ forceRefresh = false } = {}) {
     }
     sessionsRefreshPromise = (async () => {
         try {
-            const sessions = await fetchSessions({ forceRefresh: forceRefresh === true });
+            const sessions = await fetchSessions({
+                sidebar: true,
+                forceRefresh: forceRefresh === true,
+            });
             if (isSessionsRefreshSuppressed() && forceRefresh !== true) {
                 renderProjectsFromSnapshot({ syncStreams: false });
                 return;

--- a/frontend/dist/js/core/api/sessions.js
+++ b/frontend/dist/js/core/api/sessions.js
@@ -10,15 +10,18 @@ import {
 } from './request.js';
 
 export async function fetchSessions(options = {}) {
+    const sidebar = options.sidebar === true;
+    const requestKey = sidebar ? 'sessions:sidebar' : 'sessions:list';
+    const endpoint = sidebar ? '/api/sessions/sidebar' : '/api/sessions';
     const params = new URLSearchParams();
     if (options.forceRefresh === true) {
         params.set('force_refresh', 'true');
-        invalidateManagedRequests('sessions:list');
+        invalidateManagedRequests(requestKey);
     }
     const query = params.toString();
     return requestJsonManaged(
-        'sessions:list',
-        `/api/sessions${query ? `?${query}` : ''}`,
+        requestKey,
+        `${endpoint}${query ? `?${query}` : ''}`,
         { signal: options.signal },
         'Failed to fetch sessions',
         { ttlMs: 500 },
@@ -85,6 +88,7 @@ export async function markSessionTerminalRunViewed(sessionId, options = {}) {
         'Failed to mark session run viewed',
     );
     invalidateManagedRequestCache('sessions:list');
+    invalidateManagedRequestCache('sessions:sidebar');
     invalidateManagedRequestCache(`sessions:${safeSessionId}:record`);
     return result;
 }

--- a/frontend/dist/js/core/eventRouter/index.js
+++ b/frontend/dist/js/core/eventRouter/index.js
@@ -381,7 +381,7 @@ function scheduleContinuityRefreshForEvent(evType) {
         scheduleRecoveryContinuityRefresh({
             sessionId,
             delayMs: 300,
-            forceRefresh: true,
+            forceRefresh: false,
             includeRounds: false,
             quiet: true,
             reason: evType,
@@ -393,7 +393,7 @@ function scheduleContinuityRefreshForEvent(evType) {
         scheduleRecoveryContinuityRefresh({
             sessionId,
             delayMs: 500,
-            forceRefresh: true,
+            forceRefresh: false,
             includeRounds: false,
             quiet: true,
             reason: evType,
@@ -405,7 +405,7 @@ function scheduleContinuityRefreshForEvent(evType) {
         scheduleRecoveryContinuityRefresh({
             sessionId,
             delayMs: BACKGROUND_TASK_UPDATE_REFRESH_DELAY_MS,
-            forceRefresh: true,
+            forceRefresh: false,
             includeRounds: false,
             quiet: true,
             reason: evType,
@@ -431,7 +431,7 @@ function scheduleContinuityRefreshForEvent(evType) {
         scheduleRecoveryContinuityRefresh({
             sessionId,
             delayMs: 350,
-            forceRefresh: true,
+            forceRefresh: requiresFreshContinuitySnapshot(evType),
             includeRounds: false,
             quiet: true,
             reason: evType,
@@ -447,7 +447,7 @@ function scheduleContinuityRefreshForEvent(evType) {
         scheduleRecoveryContinuityRefresh({
             sessionId,
             delayMs: BACKGROUND_TASK_STATUS_REFRESH_DELAY_MS,
-            forceRefresh: true,
+            forceRefresh: false,
             includeRounds: false,
             quiet: true,
             reason: evType,
@@ -455,16 +455,37 @@ function scheduleContinuityRefreshForEvent(evType) {
         return;
     }
 
-    if (evType === 'run_completed' || evType === 'run_failed' || evType === 'run_stopped') {
+    if (evType === 'run_completed' || evType === 'run_failed') {
         scheduleRecoveryContinuityRefresh({
             sessionId,
             delayMs: 650,
-            forceRefresh: true,
+            forceRefresh: false,
+            includeRounds: false,
+            quiet: true,
+            reason: evType,
+        });
+        return;
+    }
+
+    if (evType === 'run_stopped') {
+        scheduleRecoveryContinuityRefresh({
+            sessionId,
+            delayMs: 650,
+            forceRefresh: false,
             includeRounds: false,
             quiet: true,
             reason: evType,
         });
     }
+}
+
+function requiresFreshContinuitySnapshot(evType) {
+    return (
+        evType === 'tool_approval_requested'
+        || evType === 'tool_approval_resolved'
+        || evType === 'user_question_requested'
+        || evType === 'user_question_answered'
+    );
 }
 
 function statusFromEventType(evType) {

--- a/frontend/dist/js/core/state.js
+++ b/frontend/dist/js/core/state.js
@@ -16,6 +16,7 @@ export const state = {
     activeSubagentSession: null,
     isGenerating: false,
     activeEventSource: null,
+    activeRunStreamCount: 0,
     agentViews: {},
     activeView: 'main',
     activeAgentRoleId: null,

--- a/frontend/dist/js/core/stream.js
+++ b/frontend/dist/js/core/stream.js
@@ -15,6 +15,7 @@ import {
 } from '../components/subagentSessions.js';
 import { refreshSessionTopologyControls } from '../app/prompt.js';
 import { scheduleSessionsRefresh } from '../components/sidebar.js';
+import * as backendStatus from '../utils/backendStatus.js';
 import { els } from '../utils/dom.js';
 import { t } from '../utils/i18n.js';
 import {
@@ -58,6 +59,7 @@ let backgroundDiscoveryTimer = null;
 let backgroundDiscoveryPromise = null;
 let backgroundDiscoveryQueued = false;
 let backgroundDiscoveryPausedUntil = 0;
+let backgroundDiscoveryLastFetchAt = 0;
 let foregroundNavigationStreamToken = 0;
 let normalModeSubagentDiscoveryTimer = null;
 let normalModeSubagentDiscoveryPromise = null;
@@ -66,15 +68,49 @@ const unavailableSessionCooldownUntil = new Map();
 const SESSION_NOT_FOUND_COOLDOWN_MS = 30000;
 const unavailableRunCooldownUntil = new Map();
 const RUN_NOT_FOUND_COOLDOWN_MS = 30000;
+const terminalRunCooldownUntil = new Map();
+const TERMINAL_RUN_DISCOVERY_COOLDOWN_MS = 60000;
 const MAX_MULTIPLEX_RUN_STREAMS = 32;
 const MULTIPLEX_RECONNECT_MAX_DELAY_MS = 5000;
 const FOREGROUND_NAVIGATION_STREAM_PAUSE_MS = 1200;
+const BACKGROUND_DISCOVERY_IDLE_DELAY_MS = 2500;
+const BACKGROUND_DISCOVERY_BUSY_DELAY_MS = 8000;
+const BACKGROUND_DISCOVERY_BUSY_STALE_MS = 30000;
 const NORMAL_MODE_SUBAGENT_DISCOVERY_DELAY_MS = 2500;
 const NORMAL_MODE_SUBAGENT_RECONNECT_DELAY_MS = 900;
 const RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS = 360;
 
+function isLiveRunStreamConnection(connection) {
+    return !!(connection && !connection.closed && !connection.terminal);
+}
+
+export function getActiveRunStreamCount() {
+    let count = isLiveRunStreamConnection(activeConnection) ? 1 : 0;
+    backgroundStreams.forEach(connection => {
+        if (isLiveRunStreamConnection(connection)) {
+            count += 1;
+        }
+    });
+    if (isLiveRunStreamConnection(normalModeSubagentConnection)) {
+        count += 1;
+    }
+    normalModeSubagentStreams.forEach(connection => {
+        if (isLiveRunStreamConnection(connection)) {
+            count += 1;
+        }
+    });
+    return count;
+}
+
+function syncRunStreamActivityState() {
+    state.activeRunStreamCount = getActiveRunStreamCount();
+}
+
 function setStreamUiBusy(isBusy, { focusPrompt = true } = {}) {
     state.isGenerating = isBusy;
+    if (isBusy) {
+        backendStatus.markBackendBusy?.();
+    }
     const runtimeInjectEnabled = isBusy && !!String(state.activeRunId || '').trim();
     renderRuntimeInjectQueue(runtimeInjectEnabled ? state.activeRunId : '');
     if (els.sendBtn) {
@@ -176,7 +212,8 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
                 clearStopRequest: true,
                 releaseUi: false,
             });
-            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: true });
+            notifyCurrentSessionRunStarted(safeSessionId, run);
+            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: false });
             attachRunStreamAsBackground(runId, safeSessionId, {
                 reason: 'start-background',
             });
@@ -184,10 +221,11 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
         }
         state.activeRunId = runId;
         setStreamUiBusy(true, { focusPrompt: false });
+        notifyCurrentSessionRunStarted(safeSessionId, run);
         if (typeof options.onRunCreated === 'function') {
             options.onRunCreated(run);
         }
-        scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: true });
+        scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: false });
     } catch (err) {
         logError(
             'frontend.run.create_failed',
@@ -199,7 +237,7 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
                 clearStopRequest: true,
                 releaseUi: false,
             });
-            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: true });
+            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: false });
             return;
         }
         finishPendingRunStart(runStart, {
@@ -272,9 +310,57 @@ async function startDetachedIntentStream(promptText, sessionId, options) {
             errorToPayload(err, { session_id: sessionId, detached: true }),
         );
         scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, {
-            forceRefresh: true,
+            forceRefresh: false,
         });
     }
+}
+
+function notifyCurrentSessionRunStarted(sessionId, run) {
+    const safeSessionId = String(sessionId || run?.session_id || run?.sessionId || '').trim();
+    if (!safeSessionId || typeof document === 'undefined') {
+        return;
+    }
+    const safeRunId = String(run?.run_id || run?.runId || '').trim();
+    forgetLocallyTerminalRun(safeRunId);
+    document.dispatchEvent(new CustomEvent('agent-teams-current-session-run-started', {
+        detail: {
+            sessionId: safeSessionId,
+            run: run && typeof run === 'object' ? run : {},
+        },
+    }));
+}
+
+function notifySessionRunTerminal(sessionId, runId, evType, payload = {}, eventMeta = {}) {
+    const safeSessionId = String(
+        sessionId || payload?.session_id || payload?.sessionId || '',
+    ).trim();
+    const safeRunId = String(
+        runId
+        || payload?.run_id
+        || payload?.runId
+        || eventMeta?.run_id
+        || eventMeta?.trace_id
+        || '',
+    ).trim();
+    if (!safeSessionId || !safeRunId || typeof document === 'undefined') {
+        return;
+    }
+    rememberLocallyTerminalRun(safeRunId);
+    document.dispatchEvent(new CustomEvent('agent-teams-session-run-terminal', {
+        detail: {
+            sessionId: safeSessionId,
+            run: {
+                ...(payload && typeof payload === 'object' ? payload : {}),
+                run_id: safeRunId,
+                session_id: safeSessionId,
+                status: normalizeTerminalEventStatus(evType),
+                event_type: evType,
+                updated_at: eventMeta?.created_at
+                    || eventMeta?.timestamp
+                    || new Date().toISOString(),
+            },
+        },
+    }));
 }
 
 export function endStream(options = {}) {
@@ -358,6 +444,7 @@ export function detachActiveStreamForSessionSwitch(options = {}) {
     activeConnection = null;
     state.activeEventSource = null;
     activeStreamSessionId = '';
+    syncRunStreamActivityState();
     setStreamUiBusy(false, { focusPrompt: options.focusPrompt !== false });
     ensureBackgroundDiscoveryLoop();
     return true;
@@ -615,8 +702,10 @@ async function refreshRoundsAfterCompletion(sessionId, runId = '', options = {})
             const recoveryModule = await import('../app/recovery.js');
             if (typeof recoveryModule.hydrateSessionView === 'function' && state.currentSessionId === sessionId) {
                 await recoveryModule.hydrateSessionView(sessionId, {
-                    includeRounds: true,
-                    forceRefresh: true,
+                    includeRecovery: false,
+                    includeRounds: false,
+                    includeSubagents: false,
+                    forceRefresh: false,
                     quiet: true,
                     roundsScrollPolicy: 'completion-auto',
                 });
@@ -654,6 +743,7 @@ function releaseActiveStreamHandle(options = {}) {
     }
     state.activeEventSource = null;
     activeStreamSessionId = '';
+    syncRunStreamActivityState();
     requestMultiplexRunConnection('release-active');
     return activeRunId;
 }
@@ -674,6 +764,7 @@ function promoteBackgroundStream(connection, options = {}) {
     state.activeEventSource = multiplexEventSource;
     activeStreamSessionId = connection.sessionId;
     touchRunStreamAttention(connection.runId);
+    syncRunStreamActivityState();
     if (options.makeUiBusy !== false) {
         setStreamUiBusy(true);
     }
@@ -706,6 +797,7 @@ function openRunStreamConnection(connection, { reason, afterEventId = null } = {
     } else {
         backgroundStreams.set(connection.runId, connection);
     }
+    syncRunStreamActivityState();
     enforceMultiplexRunBudget(connection.runId);
     requestMultiplexRunConnection(reason || connection.mode || 'run');
     ensureBackgroundDiscoveryLoop();
@@ -815,6 +907,12 @@ function applyMultiplexRunEvent(data) {
     }
     const evType = data.event_type;
     const payload = JSON.parse(data.payload_json || '{}');
+    if (evType === 'run_started' || evType === 'run_resumed') {
+        forgetLocallyTerminalRun(runId);
+    }
+    if (isSidebarTerminalRunEvent(evType)) {
+        notifySessionRunTerminal(connection.sessionId, runId, evType, payload, data);
+    }
     if (connection.mode === 'active') {
         routeEvent(evType, payload, data);
     } else {
@@ -829,7 +927,9 @@ function applyMultiplexRunEvent(data) {
         });
         connection.terminal = true;
         if (connection.mode === 'active') {
-            finishActiveConnection(connection);
+            finishActiveConnection(connection, {
+                clearActiveRunId: evType === 'run_completed' || evType === 'run_failed',
+            });
         } else {
             finishBackgroundConnection(connection);
         }
@@ -995,7 +1095,14 @@ function finishActiveConnection(connection, finishOptions = {}) {
     if (String(state.activeRunId || '').trim() === connection.runId) {
         activeStreamSessionId = '';
     }
+    syncRunStreamActivityState();
     endStream(finishOptions);
+    if (
+        finishOptions.clearActiveRunId === true
+        && String(state.activeRunId || '').trim() === connection.runId
+    ) {
+        state.activeRunId = null;
+    }
     requestMultiplexRunConnection('finish-active');
     ensureNormalModeSubagentDiscoveryLoop();
     if (typeof connection.onCompleted === 'function') {
@@ -1058,6 +1165,7 @@ function finishBackgroundConnection(connection, { rediscover = true, refreshSide
     }
     connection.eventSource = null;
     backgroundStreams.delete(connection.runId);
+    syncRunStreamActivityState();
     requestMultiplexRunConnection('finish-background');
     if (refreshSidebar) {
         scheduleSessionsRefresh();
@@ -1132,6 +1240,44 @@ function isTerminalRunEvent(evType) {
     );
 }
 
+function isSidebarTerminalRunEvent(evType) {
+    return (
+        evType === 'run_completed'
+        || evType === 'run_failed'
+        || evType === 'run_stopped'
+    );
+}
+
+function normalizeTerminalEventStatus(evType) {
+    const eventType = String(evType || '').trim();
+    if (!isTerminalRunEvent(eventType)) {
+        return '';
+    }
+    return eventType.replace(/^run_/, '');
+}
+
+function isRecordRunTerminal(record, runId) {
+    const safeRunId = String(runId || '').trim();
+    if (isRunLocallyTerminal(safeRunId)) {
+        return true;
+    }
+    const terminalRunId = String(
+        record?.latest_terminal_run_id || record?.latestTerminalRunId || '',
+    ).trim();
+    if (!safeRunId || !terminalRunId || safeRunId !== terminalRunId) {
+        return false;
+    }
+    const status = String(
+        record?.latest_terminal_run_status || record?.latestTerminalRunStatus || '',
+    ).trim();
+    return (
+        status === 'completed'
+        || status === 'failed'
+        || status === 'stopped'
+        || status === 'paused'
+    );
+}
+
 function ensureBackgroundDiscoveryLoop() {
     if (!shouldRunBackgroundDiscovery()) {
         if (backgroundDiscoveryTimer) {
@@ -1150,7 +1296,7 @@ function ensureBackgroundDiscoveryLoop() {
     backgroundDiscoveryTimer = setTimeout(() => {
         backgroundDiscoveryTimer = null;
         void runBackgroundDiscovery();
-    }, 2500);
+    }, resolveBackgroundDiscoveryDelayMs());
     backgroundDiscoveryTimer.unref?.();
 }
 
@@ -1174,8 +1320,50 @@ function rescheduleBackgroundDiscoveryAfterPause() {
     backgroundDiscoveryTimer.unref?.();
 }
 
+function resolveBackgroundDiscoveryDelayMs() {
+    return hasBackgroundDiscoveryRunPressure()
+        ? BACKGROUND_DISCOVERY_BUSY_DELAY_MS
+        : BACKGROUND_DISCOVERY_IDLE_DELAY_MS;
+}
+
+function hasBackgroundDiscoveryRunPressure() {
+    return !!(
+        state.isGenerating
+        || pendingRunStart
+        || getActiveRunStreamCount() > 0
+        || desiredMultiplexRunConnections().length > 0
+    );
+}
+
+function shouldDeferBackgroundDiscoveryFetch(now = Date.now()) {
+    if (!hasBackgroundDiscoveryRunPressure()) {
+        return false;
+    }
+    if (backgroundDiscoveryLastFetchAt <= 0) {
+        return false;
+    }
+    if (
+        backgroundDiscoveryLastFetchAt > 0
+        && now - backgroundDiscoveryLastFetchAt >= BACKGROUND_DISCOVERY_BUSY_STALE_MS
+    ) {
+        return false;
+    }
+    return true;
+}
+
 function ensureNormalModeSubagentDiscoveryLoop() {
     if (!shouldRunNormalModeSubagentDiscovery()) {
+        clearNormalModeSubagentDiscoveryTimer();
+        if (
+            normalModeSubagentConnection
+            && !state.activeSubagentSession
+            && normalModeSubagentStreams.size === 0
+        ) {
+            finishNormalModeSubagentSessionConnection(normalModeSubagentConnection);
+        }
+        return;
+    }
+    if (!shouldPollNormalModeSubagentDiscovery()) {
         clearNormalModeSubagentDiscoveryTimer();
         return;
     }
@@ -1196,6 +1384,20 @@ function clearNormalModeSubagentDiscoveryTimer() {
 }
 
 function shouldRunNormalModeSubagentDiscovery() {
+    return !!(
+        String(state.currentSessionId || '').trim()
+        && String(state.currentSessionMode || '').trim().toLowerCase() === 'normal'
+        && (
+            isCurrentSessionParentRunActive()
+            || isCurrentSessionRunStarting()
+            || normalModeSubagentConnection
+            || normalModeSubagentStreams.size > 0
+            || state.activeSubagentSession
+        )
+    );
+}
+
+function shouldPollNormalModeSubagentDiscovery() {
     return !!(
         String(state.currentSessionId || '').trim()
         && String(state.currentSessionMode || '').trim().toLowerCase() === 'normal'
@@ -1288,7 +1490,13 @@ async function runBackgroundDiscovery() {
             if (isBackgroundDiscoveryPaused()) {
                 return;
             }
-            const sessions = await fetchSessions();
+            const now = Date.now();
+            if (shouldDeferBackgroundDiscoveryFetch(now)) {
+                return;
+            }
+            backgroundDiscoveryLastFetchAt = now;
+            const sessions = await fetchSessions({ sidebar: true });
+            backgroundDiscoveryLastFetchAt = Date.now();
             if (isBackgroundDiscoveryPaused()) {
                 return;
             }
@@ -1301,11 +1509,7 @@ async function runBackgroundDiscovery() {
             backgroundDiscoveryPromise = null;
             if (backgroundDiscoveryQueued) {
                 backgroundDiscoveryQueued = false;
-                if (isBackgroundDiscoveryPaused()) {
-                    ensureBackgroundDiscoveryLoop();
-                    return;
-                }
-                void runBackgroundDiscovery();
+                ensureBackgroundDiscoveryLoop();
                 return;
             }
             ensureBackgroundDiscoveryLoop();
@@ -1347,6 +1551,9 @@ async function reconcileBackgroundStreams(sessionRecords = []) {
                 continue;
             }
             if (isRunUnavailable(runId)) {
+                continue;
+            }
+            if (isRecordRunTerminal(record, runId)) {
                 continue;
             }
             if (status !== 'running' && status !== 'queued') {
@@ -1558,6 +1765,7 @@ function openNormalModeSubagentSessionStreamConnection(connection, { afterEventI
     connection.terminal = false;
     clearReconnectTimer(connection);
     normalModeSubagentConnection = connection;
+    syncRunStreamActivityState();
 
     es.onmessage = (event) => {
         try {
@@ -1649,6 +1857,7 @@ function finishNormalModeSubagentSessionConnection(connection) {
     if (normalModeSubagentConnection === connection) {
         normalModeSubagentConnection = null;
     }
+    syncRunStreamActivityState();
 }
 
 function openNormalModeSubagentRunStream(record, sessionId) {
@@ -1689,6 +1898,7 @@ function openNormalModeSubagentRunStreamConnection(connection, { afterEventId = 
     connection.terminal = false;
     clearReconnectTimer(connection);
     normalModeSubagentStreams.set(connection.runId, connection);
+    syncRunStreamActivityState();
 
     es.onmessage = (event) => {
         try {
@@ -1776,6 +1986,7 @@ function finishNormalModeSubagentConnection(connection) {
         connection.eventSource = null;
     }
     normalModeSubagentStreams.delete(connection.runId);
+    syncRunStreamActivityState();
     ensureNormalModeSubagentDiscoveryLoop();
 }
 
@@ -1821,6 +2032,41 @@ function isRunUnavailable(runId) {
         return true;
     }
     unavailableRunCooldownUntil.delete(safeRunId);
+    return false;
+}
+
+function rememberLocallyTerminalRun(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return;
+    }
+    terminalRunCooldownUntil.set(
+        safeRunId,
+        Date.now() + TERMINAL_RUN_DISCOVERY_COOLDOWN_MS,
+    );
+}
+
+function forgetLocallyTerminalRun(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return;
+    }
+    terminalRunCooldownUntil.delete(safeRunId);
+}
+
+function isRunLocallyTerminal(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return false;
+    }
+    const cooldownUntil = terminalRunCooldownUntil.get(safeRunId);
+    if (typeof cooldownUntil !== 'number') {
+        return false;
+    }
+    if (cooldownUntil > Date.now()) {
+        return true;
+    }
+    terminalRunCooldownUntil.delete(safeRunId);
     return false;
 }
 

--- a/frontend/dist/js/utils/backendStatus.js
+++ b/frontend/dist/js/utils/backendStatus.js
@@ -10,10 +10,13 @@ const DISCOVERY_TIMEOUT_MS = 1500;
 const CONTROL_PLANE_TIMEOUT_MS = 1500;
 const MAIN_LIVE_TIMEOUT_MS = 1500;
 const CONTROL_PLANE_FALLBACK_PORT_RANGE = 50;
+const CONTROL_PLANE_FALLBACK_BATCH_SIZE = 4;
+const CONTROL_PLANE_FALLBACK_TIMEOUT_MS = 350;
 const CONTROL_PLANE_CACHE_KEY = 'relayTeams.controlPlaneLiveUrl';
 const BACKEND_STATUS_HINT_EVENT = 'agent-teams-backend-status-hint';
 const LANGUAGE_CHANGED_EVENT = 'agent-teams-language-changed';
 const RUNTIME_LOADING_BANNER_ID = 'runtime-loading-banner';
+const BUSY_HEALTH_PROBE_DEFER_MS = 5000;
 
 let healthPollTimer = null;
 let inFlightHealthCheck = null;
@@ -25,6 +28,8 @@ let controlPlaneDiscoveryAttempted = false;
 let backendStatusHintBound = false;
 let languageChangedBound = false;
 let runtimeLoadingBanner = null;
+let consecutiveHealthMisses = 0;
+let lastHealthProbeAt = 0;
 
 export function initBackendStatusMonitor() {
     bindBackendStatusHintListener();
@@ -41,6 +46,7 @@ bindBackendStatusHintListener();
 bindLanguageChangedListener();
 
 export function markBackendOnline(label = null) {
+    consecutiveHealthMisses = 0;
     applyBackendStatus('online', label);
 }
 
@@ -57,14 +63,24 @@ export function markBackendInitializing(label = null) {
 }
 
 export async function refreshBackendStatus({ force = false } = {}) {
+    if (!force && shouldDeferBackendHealthProbe()) {
+        markBackendBusy();
+        return true;
+    }
     if (inFlightHealthCheck && !force) {
         return inFlightHealthCheck;
     }
+    lastHealthProbeAt = Date.now();
     inFlightHealthCheck = probeBackendHealth()
         .finally(() => {
             inFlightHealthCheck = null;
         });
     return inFlightHealthCheck;
+}
+
+function shouldDeferBackendHealthProbe() {
+    return backendStatus === 'busy'
+        && Date.now() - lastHealthProbeAt < BUSY_HEALTH_PROBE_DEFER_MS;
 }
 
 async function probeBackendHealth() {
@@ -102,17 +118,30 @@ async function probeBackendHealth() {
         return true;
     }
 
-    markBackendOffline();
+    markBackendUnavailableAfterProbeMiss();
     return false;
 }
 
 async function confirmMainBackendOnline() {
     const mainProbe = await probeJson('/api/system/live', MAIN_LIVE_TIMEOUT_MS);
     if (mainProbe.ok && isLivePayload(mainProbe.payload)) {
+        consecutiveHealthMisses = 0;
         markBackendOnline();
         return true;
     }
     return false;
+}
+
+function markBackendUnavailableAfterProbeMiss() {
+    consecutiveHealthMisses += 1;
+    if (
+        consecutiveHealthMisses === 1
+        && (backendStatus === 'busy' || backendStatus === 'online')
+    ) {
+        markBackendBusy();
+        return;
+    }
+    markBackendOffline();
 }
 
 async function resolveControlPlaneLiveUrl() {
@@ -168,13 +197,22 @@ async function probeJson(url, timeoutMs) {
 async function probeFallbackControlPlaneUrls(controlUrl) {
     const fallbackUrls = inferControlPlaneLiveUrls()
         .filter(fallbackUrl => fallbackUrl !== controlUrl);
-    const probes = await Promise.all(fallbackUrls.map(async liveUrl => ({
-        liveUrl,
-        result: await probeJson(liveUrl, CONTROL_PLANE_TIMEOUT_MS),
-    })));
-    return probes.find(({ result }) => (
-        result.ok && isControlPlaneLivePayload(result.payload)
-    )) || null;
+    for (
+        let index = 0;
+        index < fallbackUrls.length;
+        index += CONTROL_PLANE_FALLBACK_BATCH_SIZE
+    ) {
+        const batch = fallbackUrls.slice(index, index + CONTROL_PLANE_FALLBACK_BATCH_SIZE);
+        const results = await Promise.all(batch.map(async liveUrl => ({
+            liveUrl,
+            result: await probeJson(liveUrl, CONTROL_PLANE_FALLBACK_TIMEOUT_MS),
+        })));
+        const match = results.find(({ result }) => (
+            result.ok && isControlPlaneLivePayload(result.payload)
+        ));
+        if (match) return match;
+    }
+    return null;
 }
 
 function applyBackendStatus(nextStatus, label = null) {
@@ -357,16 +395,13 @@ function inferControlPlaneLiveUrls() {
         if (!Number.isInteger(currentPort) || currentPort < 1 || currentPort > 65535) {
             return [];
         }
-        const urls = [];
-        const maxPort = Math.min(65535, currentPort + CONTROL_PLANE_FALLBACK_PORT_RANGE);
-        for (let port = currentPort + 1; port <= maxPort; port += 1) {
-            urls.push(buildControlPlaneLiveUrl(currentOrigin, port));
+        const ports = [];
+        for (let offset = 1; offset <= CONTROL_PLANE_FALLBACK_PORT_RANGE; offset += 1) {
+            ports.push(currentPort + offset, currentPort - offset);
         }
-        const minPort = Math.max(1, currentPort - CONTROL_PLANE_FALLBACK_PORT_RANGE);
-        for (let port = currentPort - 1; port >= minPort; port -= 1) {
-            urls.push(buildControlPlaneLiveUrl(currentOrigin, port));
-        }
-        return urls;
+        return ports
+            .filter(port => Number.isInteger(port) && port >= 1 && port <= 65535)
+            .map(port => buildControlPlaneLiveUrl(currentOrigin, port));
     } catch (_) {
         return [];
     }

--- a/frontend/dist/js/utils/logger.js
+++ b/frontend/dist/js/utils/logger.js
@@ -7,6 +7,7 @@ import { showToast } from './feedback.js';
 
 const FRONTEND_LOG_ENDPOINT = '/api/logs/frontend';
 const FLUSH_INTERVAL_MS = 1000;
+const BUSY_FLUSH_DEFER_MS = 3500;
 const MAX_BATCH_SIZE = 20;
 const MAX_PENDING_EVENTS = 200;
 const MAX_PENDING_WHEN_BACKED_UP = 80;
@@ -68,6 +69,24 @@ function scheduleFlush() {
     }, FLUSH_INTERVAL_MS);
 }
 
+function scheduleDeferredFlush() {
+    if (flushTimer !== null) {
+        return;
+    }
+    flushTimer = globalThis.setTimeout(() => {
+        flushTimer = null;
+        void flushFrontendLogs();
+    }, BUSY_FLUSH_DEFER_MS);
+}
+
+function shouldDeferFrontendLogFlush() {
+    return (
+        state.isGenerating === true
+        || !!state.activeEventSource
+        || Number(state.activeRunStreamCount || 0) > 0
+    );
+}
+
 function enqueueEvent(event) {
     if (
         pendingEvents.length >= MAX_PENDING_WHEN_BACKED_UP
@@ -80,6 +99,10 @@ function enqueueEvent(event) {
         pendingEvents = pendingEvents.slice(-MAX_PENDING_EVENTS);
     }
     if (pendingEvents.length >= MAX_BATCH_SIZE) {
+        if (shouldDeferFrontendLogFlush()) {
+            scheduleDeferredFlush();
+            return;
+        }
         void flushFrontendLogs();
         return;
     }
@@ -132,8 +155,15 @@ async function postLogBatch(events, useKeepalive = false) {
     });
 }
 
-export async function flushFrontendLogs({ useKeepalive = false } = {}) {
+export async function flushFrontendLogs({
+    useKeepalive = false,
+    allowDefer = true,
+} = {}) {
     if (!pendingEvents.length) {
+        return;
+    }
+    if (allowDefer && useKeepalive && shouldDeferFrontendLogFlush()) {
+        scheduleDeferredFlush();
         return;
     }
     if (flushTimer !== null) {
@@ -226,6 +256,6 @@ export function installGlobalErrorLogging() {
     });
 
     globalThis.addEventListener('beforeunload', () => {
-        void flushFrontendLogs({ useKeepalive: true });
+        void flushFrontendLogs({ useKeepalive: true, allowDefer: false });
     });
 }

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
@@ -82,6 +83,37 @@ from relay_teams.agents.execution.spec_drift_evaluator import evaluate_spec_drif
 from relay_teams.workspace import build_conversation_id
 
 LOGGER = get_logger(__name__)
+SLOW_LLM_PREP_STAGE_SECONDS = 1.0
+
+
+def _log_slow_llm_prep_stage(
+    *,
+    request: LLMRequest,
+    stage: str,
+    started: float,
+    payload: dict[str, JsonValue] | None = None,
+) -> None:
+    elapsed_seconds = time.perf_counter() - started
+    if elapsed_seconds < SLOW_LLM_PREP_STAGE_SECONDS:
+        return
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="llm.prep.stage_slow",
+        message="LLM preparation stage was slow",
+        duration_ms=int(elapsed_seconds * 1000),
+        payload={
+            "stage": stage,
+            "run_id": request.run_id,
+            "trace_id": request.trace_id,
+            "session_id": request.session_id,
+            "role_id": request.role_id,
+            "instance_id": request.instance_id,
+            **(payload or {}),
+        },
+    )
+
+
 LLM_REQUEST_LIMIT = 500
 _LLM_CLIENT_CLOSE_TASKS: set[asyncio.Task[None]] = set()
 _ABANDONED_LLM_STREAM_CONTEXT_CLEANUP_TASKS: set[asyncio.Task[None]] = set()
@@ -289,6 +321,58 @@ def model_step_payload(
 
 
 class SessionRuntimeMixin(AgentLlmSessionMixinBase):
+    async def _timed_build_agent_iteration_context(
+        self,
+        *,
+        request: LLMRequest,
+        conversation_id: str,
+        system_prompt: str,
+        reserve_user_prompt_tokens: bool,
+        allowed_tools: tuple[str, ...],
+        allowed_mcp_servers: tuple[str, ...],
+        allowed_skills: tuple[str, ...],
+    ) -> tuple[
+        PreparedPromptContext,
+        list[ModelRequest | ModelResponse],
+        str,
+        object,
+    ]:
+        started = time.perf_counter()
+        result = await self._build_agent_iteration_context(
+            request=request,
+            conversation_id=conversation_id,
+            system_prompt=system_prompt,
+            reserve_user_prompt_tokens=reserve_user_prompt_tokens,
+            allowed_tools=allowed_tools,
+            allowed_mcp_servers=allowed_mcp_servers,
+            allowed_skills=allowed_skills,
+        )
+        prepared_prompt = result[0]
+        if isinstance(prepared_prompt, PreparedPromptContext):
+            microcompact_compacted_message_count = (
+                prepared_prompt.microcompact_compacted_message_count
+            )
+            microcompact_compacted_part_count = (
+                prepared_prompt.microcompact_compacted_part_count
+            )
+        else:
+            microcompact_compacted_message_count = 0
+            microcompact_compacted_part_count = 0
+        _log_slow_llm_prep_stage(
+            request=request,
+            stage="build_agent_iteration_context",
+            started=started,
+            payload={
+                "history_message_count": len(result[1]),
+                "system_prompt_length": len(result[2]),
+                "microcompact_compacted_message_count": (
+                    microcompact_compacted_message_count
+                ),
+                "microcompact_compacted_part_count": microcompact_compacted_part_count,
+            },
+        )
+        return result
+
     def _schedule_run_scoped_llm_http_client_close(
         self,
         *,
@@ -384,14 +468,29 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
             hook_service.get_run_env(request.run_id) if hook_service is not None else {}
         )
         if not skip_initial_user_prompt_persist:
+            stage_started = time.perf_counter()
             request, hook_system_contexts = await self._apply_user_prompt_hooks(request)
+            _log_slow_llm_prep_stage(
+                request=request,
+                stage="user_prompt_hooks",
+                started=stage_started,
+                payload={"hook_context_count": len(hook_system_contexts)},
+            )
             if hook_system_contexts:
+                stage_started = time.perf_counter()
                 await self._persist_hook_system_context_if_needed_async(
                     request=request,
                     contexts=hook_system_contexts,
                 )
+                _log_slow_llm_prep_stage(
+                    request=request,
+                    stage="persist_hook_context",
+                    started=stage_started,
+                    payload={"hook_context_count": len(hook_system_contexts)},
+                )
         self._validate_request_input_capabilities(request)
         if self._metric_recorder is not None:
+            stage_started = time.perf_counter()
             await record_session_step_async(
                 self._metric_recorder,
                 workspace_id=resolved_workspace_id,
@@ -400,10 +499,22 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 instance_id=request.instance_id,
                 role_id=request.role_id,
             )
+            _log_slow_llm_prep_stage(
+                request=request,
+                stage="record_session_step",
+                started=stage_started,
+            )
+        stage_started = time.perf_counter()
         allowed_tools = resolve_allowed_tools(
             self._tool_registry,
             self._allowed_tools,
             session_id=request.session_id,
+        )
+        _log_slow_llm_prep_stage(
+            request=request,
+            stage="resolve_allowed_tools",
+            started=stage_started,
+            payload={"allowed_tool_count": len(allowed_tools)},
         )
         await publish_run_event_async(
             self._run_event_hub,
@@ -429,7 +540,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 history,
                 agent_system_prompt,
                 agent,
-            ) = await self._build_agent_iteration_context(
+            ) = await self._timed_build_agent_iteration_context(
                 request=request,
                 conversation_id=resolved_conversation_id,
                 system_prompt=agent_system_prompt,
@@ -441,12 +552,28 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 allowed_skills=self._allowed_skills,
             )
             coordination_agent = cast(CoordinationAgent, agent)
+            stage_started = time.perf_counter()
             workspace = await self._workspace_manager.resolve_async(
                 session_id=request.session_id,
                 role_id=request.role_id,
                 instance_id=request.instance_id,
                 workspace_id=resolved_workspace_id,
                 conversation_id=resolved_conversation_id,
+            )
+            _log_slow_llm_prep_stage(
+                request=request,
+                stage="resolve_workspace",
+                started=stage_started,
+                payload={"workspace_id": resolved_workspace_id},
+            )
+            stage_started = time.perf_counter()
+            tool_approval_policy = await self._resolve_tool_approval_policy_async(
+                request.run_id
+            )
+            _log_slow_llm_prep_stage(
+                request=request,
+                stage="resolve_tool_approval_policy",
+                started=stage_started,
             )
             deps = ToolDeps(
                 task_repo=self._task_repo,
@@ -486,9 +613,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 run_control_manager=self._run_control_manager,
                 tool_approval_manager=self._tool_approval_manager,
                 user_question_manager=self._user_question_manager,
-                tool_approval_policy=await self._resolve_tool_approval_policy_async(
-                    request.run_id
-                ),
+                tool_approval_policy=tool_approval_policy,
                 shell_approval_repo=self._shell_approval_repo,
                 metric_recorder=self._metric_recorder,
                 notification_service=self._notification_service,

--- a/src/relay_teams/interfaces/server/routers/logs.py
+++ b/src/relay_teams/interfaces/server/routers/logs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from typing import ClassVar
@@ -7,13 +8,20 @@ from typing import ClassVar
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
-from relay_teams.interfaces.server.async_call import RouteWorkClass, call_route_work
+from relay_teams.interfaces.server.async_call import (
+    LOGS_INGEST_THREAD_WORKER_COUNT,
+    RouteWorkClass,
+    RouteWorkRejectedError,
+    call_route_work,
+)
 from relay_teams.logger import get_logger, log_event
 from relay_teams.trace import bind_trace_context, generate_trace_id
 from relay_teams.validation import OptionalIdentifierStr
 
 router = APIRouter(prefix="/logs", tags=["Logs"])
 logger = get_logger(__name__, source="frontend")
+_DETACHED_FRONTEND_LOG_TASKS: set[asyncio.Task[None]] = set()
+_DETACHED_FRONTEND_LOG_TASK_LIMIT = LOGS_INGEST_THREAD_WORKER_COUNT * 2
 
 
 class FrontendLogEvent(BaseModel):
@@ -45,12 +53,42 @@ class FrontendLogBatchRequest(BaseModel):
 
 @router.post("/frontend")
 async def ingest_frontend_logs(req: FrontendLogBatchRequest) -> dict[str, int]:
-    return await call_route_work(
-        RouteWorkClass.LOGS_INGEST,
-        "logs.frontend.ingest",
-        _ingest_frontend_logs,
-        req,
+    if len(_DETACHED_FRONTEND_LOG_TASKS) >= _DETACHED_FRONTEND_LOG_TASK_LIMIT:
+        log_event(
+            logger,
+            logging.WARNING,
+            event="logs.frontend.rejected",
+            message="Rejected frontend log batch because detached ingest is full",
+            payload={
+                "pending_tasks": len(_DETACHED_FRONTEND_LOG_TASKS),
+                "task_limit": _DETACHED_FRONTEND_LOG_TASK_LIMIT,
+            },
+        )
+        raise RouteWorkRejectedError("Server is busy handling logs ingest work")
+    task = asyncio.create_task(_ingest_frontend_logs_background(req))
+    _DETACHED_FRONTEND_LOG_TASKS.add(task)
+    task.add_done_callback(_DETACHED_FRONTEND_LOG_TASKS.discard)
+    accepted = len(req.events)
+    log_event(
+        logger,
+        logging.DEBUG,
+        event="logs.frontend.accepted",
+        message="Accepted frontend log batch for detached ingest",
+        payload={"accepted": accepted},
     )
+    return {"accepted": accepted}
+
+
+async def _ingest_frontend_logs_background(req: FrontendLogBatchRequest) -> None:
+    try:
+        await call_route_work(
+            RouteWorkClass.LOGS_INGEST,
+            "logs.frontend.ingest",
+            _ingest_frontend_logs,
+            req,
+        )
+    except (RuntimeError, ValueError, TypeError, OSError):
+        logger.exception("Failed to ingest frontend log batch")
 
 
 def _ingest_frontend_logs(req: FrontendLogBatchRequest) -> dict[str, int]:

--- a/src/relay_teams/interfaces/server/routers/runs.py
+++ b/src/relay_teams/interfaces/server/routers/runs.py
@@ -54,13 +54,13 @@ router = APIRouter(prefix="/runs", tags=["Runs"])
 MAX_MULTIPLEX_RUN_STREAMS = 32
 
 
-async def _create_and_start_run(
+async def _create_and_schedule_run_start(
     service: SessionRunService,
     intent_input: IntentInput,
 ) -> tuple[str, str]:
     async def operation() -> tuple[str, str]:
         run_id, session_id = await service.create_run_async(intent_input)
-        await service.ensure_run_started_async(run_id)
+        service.schedule_run_start(run_id, session_id)
         return run_id, session_id
 
     task = asyncio.create_task(operation())
@@ -370,14 +370,17 @@ async def create_run(
             orchestration_policy=req.orchestration_policy,
         )
 
-        run_id, session_id = await _create_and_start_run(service, intent_input)
+        run_id, session_id = await _create_and_schedule_run_start(
+            service,
+            intent_input,
+        )
         elapsed_ms = int((time.perf_counter() - started) * 1000)
         with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
             log_event(
                 logger,
                 logging.INFO,
-                event="run.created",
-                message="Run created",
+                event="run.create.persisted",
+                message="Run queued and start scheduled",
                 duration_ms=elapsed_ms,
                 payload={
                     "execution_mode": req.execution_mode.value,

--- a/src/relay_teams/interfaces/server/routers/sessions.py
+++ b/src/relay_teams/interfaces/server/routers/sessions.py
@@ -29,6 +29,7 @@ from relay_teams.sessions.session_models import (
     SessionMetadataPatch,
     SessionMode,
     SessionRecord,
+    SessionSidebarRecord,
     normalize_session_create_metadata_input,
 )
 from relay_teams.sessions.session_read_models import SessionSubagentsSnapshotResponse
@@ -102,6 +103,34 @@ async def list_sessions(
         "session.list",
         service.list_sessions_async,
         force_refresh=force_refresh,
+    )
+    return list(records)
+
+
+@router.get(
+    "/sidebar",
+    response_model=list[SessionSidebarRecord],
+    response_model_exclude_defaults=True,
+    response_model_exclude_none=True,
+)
+async def list_sidebar_sessions(
+    force_refresh: bool = False,
+    service: SessionService = Depends(get_session_service),
+) -> list[SessionSidebarRecord]:
+    started = time.perf_counter()
+    records = await call_maybe_async_in_session_fast_read_thread(
+        "session.list.sidebar",
+        service.list_sidebar_sessions_async,
+        force_refresh=force_refresh,
+    )
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+    log_event(
+        logger,
+        logging.DEBUG,
+        event="session.list.sidebar",
+        message="Listed sidebar sessions",
+        duration_ms=elapsed_ms,
+        payload={"count": len(records), "force_refresh": force_refresh},
     )
     return list(records)
 

--- a/src/relay_teams/sessions/__init__.py
+++ b/src/relay_teams/sessions/__init__.py
@@ -24,11 +24,13 @@ from relay_teams.sessions.session_models import (
     ProjectKind,
     SessionMode,
     SessionRecord,
+    SessionSidebarRecord,
 )
 
 __all__ = [
     "ProjectKind",
     "SessionRecord",
+    "SessionSidebarRecord",
     "SessionMode",
     "ExternalSessionBinding",
     "SessionHistoryMarkerRecord",

--- a/src/relay_teams/sessions/runs/run_runtime_repo.py
+++ b/src/relay_teams/sessions/runs/run_runtime_repo.py
@@ -72,6 +72,14 @@ class RunRuntimeRecord(BaseModel):
             RunRuntimeStatus.STOPPED,
         }
 
+    @property
+    def is_live_active(self) -> bool:
+        return self.status in {
+            RunRuntimeStatus.QUEUED,
+            RunRuntimeStatus.RUNNING,
+            RunRuntimeStatus.STOPPING,
+        }
+
 
 class RunRuntimeRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from concurrent.futures import Future as ThreadFuture
 from json import dumps
 from typing import Awaitable, Callable, Coroutine, Protocol, TypeVar
@@ -107,6 +108,8 @@ from relay_teams.hooks import HookService
 
 logger = get_logger(__name__)
 _T = TypeVar("_T")
+SLOW_RUN_WORKER_STAGE_SECONDS = 1.0
+RUN_START_SCHEDULER_CONCURRENCY = 2
 
 
 class BoardTodoLifecycleServiceLike(Protocol):
@@ -116,6 +119,31 @@ class BoardTodoLifecycleServiceLike(Protocol):
 
 def _is_run_already_running_conflict(*, run_id: str, error: RuntimeError) -> bool:
     return str(error) == f"Run {run_id} is already running"
+
+
+def _log_slow_run_worker_stage(
+    *,
+    run_id: str,
+    session_id: str,
+    stage: str,
+    started: float,
+    payload: dict[str, JsonValue] | None = None,
+) -> None:
+    elapsed_seconds = time.perf_counter() - started
+    if elapsed_seconds < SLOW_RUN_WORKER_STAGE_SECONDS:
+        return
+    with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+        log_event(
+            logger,
+            logging.WARNING,
+            event="run.worker.stage_slow",
+            message="Run worker stage was slow",
+            duration_ms=int(elapsed_seconds * 1000),
+            payload={
+                "stage": stage,
+                **(payload or {}),
+            },
+        )
 
 
 def _clear_current_task_cancellation_requests() -> None:
@@ -332,7 +360,9 @@ class SessionRunService:
         self._running_run_ids: set[str] = set()
         self._resume_requested_runs: set[str] = set()
         self._detached_notification_tasks: set[asyncio.Task[None]] = set()
+        self._detached_start_tasks: set[asyncio.Task[None]] = set()
         self._run_creation_lock = asyncio.Lock()
+        self._run_start_semaphore = asyncio.Semaphore(RUN_START_SCHEDULER_CONCURRENCY)
         self._event_loop: asyncio.AbstractEventLoop | None = None
         self._scheduler = RunScheduler(
             meta_agent=self._meta_agent,
@@ -987,6 +1017,42 @@ class SessionRunService:
             return
         await self._ensure_run_started_local_async(run_id)
 
+    def schedule_run_start(self, run_id: str, session_id: str) -> None:
+        task = asyncio.create_task(
+            self._ensure_run_started_detached_queued_async(
+                run_id=run_id, session_id=session_id
+            )
+        )
+        self._detached_start_tasks.add(task)
+        task.add_done_callback(self._detached_start_tasks.discard)
+
+    async def _ensure_run_started_detached_queued_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+    ) -> None:
+        scheduled_at = time.perf_counter()
+        async with self._run_start_semaphore:
+            queue_wait_ms = int((time.perf_counter() - scheduled_at) * 1000)
+            if queue_wait_ms > 0:
+                with bind_trace_context(
+                    trace_id=run_id,
+                    run_id=run_id,
+                    session_id=session_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        event="run.start.queue_wait",
+                        message="Run worker startup waited behind earlier starts",
+                        duration_ms=queue_wait_ms,
+                    )
+            await self._ensure_run_started_detached_async(
+                run_id=run_id,
+                session_id=session_id,
+            )
+
     def _ensure_run_started_local(self, run_id: str) -> None:
         self._scheduler.ensure_run_started_local(run_id)
 
@@ -1010,7 +1076,101 @@ class SessionRunService:
                 )
             await self._start_resume_worker_async(run_id)
             return
+        runtime = await self._runtime_for_run_async(run_id)
+        if runtime is not None and runtime.status in {
+            RunRuntimeStatus.COMPLETED,
+            RunRuntimeStatus.FAILED,
+            RunRuntimeStatus.STOPPED,
+        }:
+            return
         raise KeyError(f"Run {run_id} not found")
+
+    async def _ensure_run_started_detached_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+    ) -> None:
+        started = time.perf_counter()
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.INFO,
+                event="run.start.scheduled",
+                message="Run start scheduled after create response",
+            )
+        try:
+            await self.ensure_run_started_async(run_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            await self._handle_run_start_failed_async(
+                run_id=run_id,
+                session_id=session_id,
+                error=exc,
+            )
+            return
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.INFO,
+                event="run.start.worker_started",
+                message="Run worker startup task completed",
+                duration_ms=elapsed_ms,
+            )
+
+    async def _handle_run_start_failed_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        error: Exception,
+    ) -> None:
+        error_message = str(error) or type(error).__name__
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.ERROR,
+                event="run.start.failed",
+                message="Run failed before worker startup completed",
+                payload={"error_type": type(error).__name__},
+                exc_info=error,
+            )
+        runtime = await self._runtime_for_run_async(run_id)
+        if runtime is not None and runtime.status not in {
+            RunRuntimeStatus.COMPLETED,
+            RunRuntimeStatus.FAILED,
+            RunRuntimeStatus.STOPPED,
+        }:
+            if self._run_runtime_repo is not None:
+                await self._run_runtime_repo.update_async(
+                    run_id,
+                    status=RunRuntimeStatus.FAILED,
+                    phase=RunRuntimePhase.TERMINAL,
+                    active_instance_id=None,
+                    active_task_id=None,
+                    active_role_id=None,
+                    active_subagent_instance_id=None,
+                    last_error=error_message,
+                )
+            await self._run_event_hub.publish_async(
+                RunEvent(
+                    session_id=session_id,
+                    run_id=run_id,
+                    trace_id=run_id,
+                    task_id=None,
+                    event_type=RunEventType.RUN_FAILED,
+                    payload_json=dumps(
+                        {
+                            "session_id": session_id,
+                            "status": RunRuntimeStatus.FAILED.value,
+                            "error": error_message,
+                        }
+                    ),
+                )
+            )
+        await self._safe_finalize_run_async(run_id=run_id, session_id=session_id)
 
     def _start_new_run_worker(self, run_id: str) -> None:
         self._scheduler.start_new_run_worker(run_id)
@@ -1274,6 +1434,7 @@ class SessionRunService:
             )
         runtime_intent = None
         try:
+            stage_started = time.perf_counter()
             if self._run_intent_repo is not None:
                 try:
                     runtime_intent = self._run_intent_repo.get(
@@ -1282,20 +1443,57 @@ class SessionRunService:
                     )
                 except KeyError:
                     runtime_intent = None
+            _log_slow_run_worker_stage(
+                run_id=run_id,
+                session_id=session_id,
+                stage="load_intent",
+                started=stage_started,
+                payload={"intent_found": runtime_intent is not None},
+            )
             if runtime_intent is not None:
+                stage_started = time.perf_counter()
                 await self._hook_pipeline.execute_session_start_hooks(
                     run_id=run_id,
                     session_id=session_id,
                     intent=runtime_intent,
                 )
+                _log_slow_run_worker_stage(
+                    run_id=run_id,
+                    session_id=session_id,
+                    stage="session_start_hooks",
+                    started=stage_started,
+                )
+            stage_started = time.perf_counter()
+            recovered_result = await self._recovery_service.run_with_auto_recovery(
+                run_id=run_id,
+                session_id=session_id,
+                runner=runner,
+            )
+            _log_slow_run_worker_stage(
+                run_id=run_id,
+                session_id=session_id,
+                stage="runner",
+                started=stage_started,
+                payload={
+                    "status": recovered_result.status,
+                    "completion_reason": recovered_result.completion_reason.value,
+                },
+            )
+            stage_started = time.perf_counter()
             result = await self._run_result_through_stop_hooks(
                 run_id=run_id,
                 session_id=session_id,
-                result=await self._recovery_service.run_with_auto_recovery(
-                    run_id=run_id,
-                    session_id=session_id,
-                    runner=runner,
-                ),
+                result=recovered_result,
+            )
+            _log_slow_run_worker_stage(
+                run_id=run_id,
+                session_id=session_id,
+                stage="stop_hooks",
+                started=stage_started,
+                payload={
+                    "status": result.status,
+                    "completion_reason": result.completion_reason.value,
+                },
             )
             completion_reason = result.completion_reason
             failed = result.status == "failed"

--- a/src/relay_teams/sessions/session_list_cache.py
+++ b/src/relay_teams/sessions/session_list_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TypeVar
 
 from relay_teams.sessions.session_models import SessionRecord
 from relay_teams.sessions.session_read_models import CachedReadResult
@@ -13,31 +14,23 @@ from relay_teams.sessions.session_snapshot_cache import resolve_positive_int_env
 
 LIST_SESSIONS_CACHE_MS_ENV = "RELAY_TEAMS_LIST_SESSIONS_CACHE_MS"
 DEFAULT_LIST_SESSIONS_CACHE_MS = 1000
+ResultT = TypeVar("ResultT")
 
 
 class SessionListCache:
     def __init__(
         self,
         *,
-        refresh_runner: ProjectionRefreshRunner[object] | None = None,
+        refresh_runner: ProjectionRefreshRunner | None = None,
         max_age_seconds: float | None = None,
         cold_miss_timeout_seconds: float = DEFAULT_SESSION_COLD_MISS_TIMEOUT_SECONDS,
         refresh_min_interval_seconds: float | None = None,
     ) -> None:
-        typed_refresh_runner: ProjectionRefreshRunner[tuple[SessionRecord, ...]] | None
-        typed_refresh_runner = None
-        if refresh_runner is not None:
-
-            async def run_session_list_refresh(
-                operation: str,
-                refresh: Callable[[], tuple[SessionRecord, ...]],
-            ) -> tuple[SessionRecord, ...]:
-                result = await refresh_runner(operation, refresh)
-                if not isinstance(result, tuple):
-                    raise TypeError("Session list refresh returned an invalid result")
-                return result
-
-            typed_refresh_runner = run_session_list_refresh
+        typed_refresh_runner: ProjectionRefreshRunner | None = (
+            _SessionListRefreshRunner(refresh_runner)
+            if refresh_runner is not None
+            else None
+        )
         self._cache = StaleFirstCache[tuple[SessionRecord, ...]](
             operation_name="session_list",
             refresh_runner=typed_refresh_runner,
@@ -67,6 +60,15 @@ class SessionListCache:
         if not merged:
             self.mark_dirty()
 
+    def update_record(
+        self,
+        session_id: str,
+        transform: Callable[[SessionRecord], SessionRecord],
+    ) -> bool:
+        return self._cache.update_value(
+            lambda records: _update_record(records, session_id, transform)
+        )
+
     def remove_record(self, session_id: str) -> None:
         removed = self._cache.update_value(
             lambda records: tuple(
@@ -88,6 +90,22 @@ class SessionListCache:
         )
 
 
+class _SessionListRefreshRunner:
+    def __init__(self, refresh_runner: ProjectionRefreshRunner) -> None:
+        self._refresh_runner = refresh_runner
+
+    async def __call__(
+        self,
+        operation: str,
+        refresh: Callable[[], ResultT],
+        /,
+    ) -> ResultT:
+        result = await self._refresh_runner(operation, refresh)
+        if not isinstance(result, tuple):
+            raise TypeError("Session list refresh returned an invalid result")
+        return result
+
+
 def _merge_record(
     records: tuple[SessionRecord, ...],
     record: SessionRecord,
@@ -103,3 +121,21 @@ def _merge_record(
     if not replaced:
         return record, *records
     return tuple(merged)
+
+
+def _update_record(
+    records: tuple[SessionRecord, ...],
+    session_id: str,
+    transform: Callable[[SessionRecord], SessionRecord],
+) -> tuple[SessionRecord, ...]:
+    updated: list[SessionRecord] = []
+    replaced = False
+    for cached in records:
+        if cached.session_id == session_id:
+            updated.append(transform(cached))
+            replaced = True
+            continue
+        updated.append(cached)
+    if not replaced:
+        return records
+    return tuple(updated)

--- a/src/relay_teams/sessions/session_models.py
+++ b/src/relay_teams/sessions/session_models.py
@@ -48,6 +48,16 @@ _SESSION_PATCH_METADATA_FIELDS = {
     "custom_metadata",
 }
 
+_SIDEBAR_METADATA_KEYS = {
+    "title",
+    "name",
+    "label",
+    "source_label",
+    "source_icon",
+    "source_kind",
+    "source_provider",
+}
+
 
 def _validate_session_custom_metadata(
     value: dict[str, str] | None,
@@ -270,3 +280,67 @@ class SessionRecord(BaseModel):
         if self.project_id is None or not self.project_id.strip():
             self.project_id = self.workspace_id
         return self
+
+
+class SessionSidebarRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: RequiredIdentifierStr
+    workspace_id: RequiredIdentifierStr
+    project_kind: ProjectKind = ProjectKind.WORKSPACE
+    project_id: OptionalIdentifierStr = None
+    metadata: dict[str, str] = Field(default_factory=dict)
+    session_mode: SessionMode = SessionMode.NORMAL
+    can_switch_mode: bool = True
+    has_active_run: bool = False
+    active_run_id: OptionalIdentifierStr = None
+    active_run_status: str | None = None
+    active_run_phase: str | None = None
+    last_viewed_terminal_run_id: OptionalIdentifierStr = None
+    latest_terminal_run_id: OptionalIdentifierStr = None
+    latest_terminal_run_status: str | None = None
+    latest_terminal_run_verification_status: str | None = None
+    latest_terminal_run_updated_at: datetime | None = None
+    has_unread_terminal_run: bool = False
+    pending_tool_approval_count: int = 0
+    subagent_session_count: int = 0
+    created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    @classmethod
+    def from_session_record(cls, record: SessionRecord) -> SessionSidebarRecord:
+        project_id = record.project_id
+        if (
+            record.project_kind == ProjectKind.WORKSPACE
+            and project_id == record.workspace_id
+        ):
+            project_id = None
+        return cls(
+            session_id=record.session_id,
+            workspace_id=record.workspace_id,
+            project_kind=record.project_kind,
+            project_id=project_id,
+            metadata={
+                key: value
+                for key, value in record.metadata.items()
+                if key in _SIDEBAR_METADATA_KEYS
+            },
+            session_mode=record.session_mode,
+            can_switch_mode=record.can_switch_mode,
+            has_active_run=record.has_active_run,
+            active_run_id=record.active_run_id,
+            active_run_status=record.active_run_status,
+            active_run_phase=record.active_run_phase,
+            last_viewed_terminal_run_id=record.last_viewed_terminal_run_id,
+            latest_terminal_run_id=record.latest_terminal_run_id,
+            latest_terminal_run_status=record.latest_terminal_run_status,
+            latest_terminal_run_verification_status=(
+                record.latest_terminal_run_verification_status
+            ),
+            latest_terminal_run_updated_at=record.latest_terminal_run_updated_at,
+            has_unread_terminal_run=record.has_unread_terminal_run,
+            pending_tool_approval_count=record.pending_tool_approval_count,
+            subagent_session_count=record.subagent_session_count,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+        )

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import shutil
 import sqlite3
 import uuid
@@ -10,7 +11,7 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from typing import TYPE_CHECKING, NamedTuple, Protocol, cast
 
 from relay_teams.agent_runtimes.instances.models import AgentRuntimeRecord
-from relay_teams.logger import get_logger
+from relay_teams.logger import get_logger, log_event
 from relay_teams.media import ContentPart
 from relay_teams.media import content_parts_to_text
 from relay_teams.media import user_prompt_content_to_text
@@ -81,6 +82,7 @@ from relay_teams.sessions.session_models import (
     SessionMetadataPatch,
     SessionMode,
     SessionRecord,
+    SessionSidebarRecord,
 )
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
@@ -213,9 +215,6 @@ _TERMINAL_RUN_EVENT_TYPES = frozenset(
 )
 _FRESH_READ_EVENT_TYPES = frozenset(
     {
-        RunEventType.RUN_COMPLETED,
-        RunEventType.RUN_FAILED,
-        RunEventType.RUN_STOPPED,
         RunEventType.TODO_UPDATED,
         RunEventType.USER_QUESTION_REQUESTED,
         RunEventType.USER_QUESTION_ANSWERED,
@@ -224,7 +223,6 @@ _FRESH_READ_EVENT_TYPES = frozenset(
 )
 _LIST_FRESH_READ_EVENT_TYPES = frozenset(
     {
-        *_TERMINAL_RUN_EVENT_TYPES,
         RunEventType.TOOL_APPROVAL_REQUESTED,
         RunEventType.TOOL_APPROVAL_RESOLVED,
         RunEventType.USER_QUESTION_REQUESTED,
@@ -259,6 +257,16 @@ def _normalize_auto_session_title(value: str) -> str | None:
         if len(normalized) <= _AUTO_SESSION_TITLE_MAX_CHARS:
             return normalized
         return f"{normalized[: _AUTO_SESSION_TITLE_MAX_CHARS - 3].rstrip()}..."
+    return None
+
+
+def _terminal_run_status_for_event_type(event_type: RunEventType) -> str | None:
+    if event_type == RunEventType.RUN_COMPLETED:
+        return RunRuntimeStatus.COMPLETED.value
+    if event_type == RunEventType.RUN_FAILED:
+        return RunRuntimeStatus.FAILED.value
+    if event_type == RunEventType.RUN_STOPPED:
+        return RunRuntimeStatus.STOPPED.value
     return None
 
 
@@ -299,7 +307,7 @@ class SessionService:
         run_intent_repo: RunIntentRepository | None = None,
         memory_event_handler: MemoryEventHandler | None = None,
         get_runtime: Callable[[], RuntimeConfig] | None = None,
-        projection_refresh_runner: ProjectionRefreshRunner[object] | None = None,
+        projection_refresh_runner: ProjectionRefreshRunner | None = None,
     ) -> None:
         self._session_repo = session_repo
         self._task_repo = task_repo
@@ -382,15 +390,32 @@ class SessionService:
         if not safe_session_id:
             return
         spawn_subagent_dirty = self._event_is_spawn_subagent_tool_event(event)
+        terminal_run_event = event.event_type in _TERMINAL_RUN_EVENT_TYPES
+        subagent_run_dirty = terminal_run_event and self._event_is_subagent_run_event(
+            event,
+            session_id=safe_session_id,
+        )
+        subagent_list_dirty = (
+            spawn_subagent_dirty
+            or subagent_run_dirty
+            or event.event_type
+            in {
+                RunEventType.SUBAGENT_SESSION_STATUS_CHANGED,
+                RunEventType.SUBAGENT_STOPPED,
+                RunEventType.SUBAGENT_RESUMED,
+            }
+        )
         if event.event_type in _LIST_DIRTY_EVENT_TYPES or spawn_subagent_dirty:
             self._invalidate_list_sessions_cache(
                 requires_fresh_read=event.event_type in _LIST_FRESH_READ_EVENT_TYPES,
             )
-            if (
-                event.event_type in _TERMINAL_RUN_EVENT_TYPES
-                and not self._is_running_async_publish_listener()
-            ):
-                self._merge_terminal_session_projection_into_list_cache(safe_session_id)
+            if subagent_list_dirty:
+                self._schedule_subagent_count_cache_merge(safe_session_id)
+            if terminal_run_event and not subagent_run_dirty:
+                self._merge_terminal_event_into_list_cache(event)
+        elif subagent_list_dirty:
+            self._invalidate_list_sessions_cache()
+            self._schedule_subagent_count_cache_merge(safe_session_id)
         if event.event_type in _DETAILED_ROUND_DIRTY_EVENT_TYPES:
             self._session_snapshot_cache.mark_session_dirty(
                 safe_session_id,
@@ -421,6 +446,16 @@ class SessionService:
         tool_name = payload.get("tool_name")
         return isinstance(tool_name, str) and tool_name.strip() == "spawn_subagent"
 
+    def _event_is_subagent_run_event(self, event: RunEvent, *, session_id: str) -> bool:
+        safe_run_id = str(event.run_id or event.trace_id or "").strip()
+        return bool(
+            safe_run_id
+            and (
+                self._is_subagent_run_id(safe_run_id)
+                or safe_run_id in self._subagent_run_ids(session_id)
+            )
+        )
+
     @staticmethod
     def _is_detailed_rounds_cache_key(cache_key: str) -> bool:
         return "timeline=False" in cache_key and "summary=False" in cache_key
@@ -431,6 +466,100 @@ class SessionService:
     ) -> None:
         with contextlib.suppress(KeyError):
             self._merge_session_list_cache_record(self.get_session(session_id))
+
+    def _schedule_subagent_count_cache_merge(self, session_id: str) -> None:
+        if not self._is_running_async_publish_listener():
+            return
+        task = asyncio.create_task(
+            self._merge_subagent_count_into_list_cache_async(session_id)
+        )
+        task.add_done_callback(self._log_subagent_count_cache_merge_error)
+
+    @staticmethod
+    def _log_subagent_count_cache_merge_error(task: asyncio.Task[None]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.subagent_count_cache_merge_failed",
+                message="Failed to merge subagent count into session list cache",
+                payload={"error": str(exc)},
+            )
+
+    async def _merge_subagent_count_into_list_cache_async(
+        self, session_id: str
+    ) -> None:
+        await asyncio.to_thread(self._merge_subagent_count_into_list_cache, session_id)
+
+    def _merge_subagent_count_into_list_cache(self, session_id: str) -> None:
+        safe_session_id = str(session_id or "").strip()
+        if not safe_session_id:
+            return
+        subagent_count = len(self.list_session_subagents(safe_session_id))
+
+        def mark_subagent_count(record: SessionRecord) -> SessionRecord:
+            return record.model_copy(
+                update={"subagent_session_count": subagent_count},
+            )
+
+        self._session_list_cache.update_record(
+            safe_session_id,
+            mark_subagent_count,
+        )
+
+    def _merge_terminal_event_into_list_cache(self, event: RunEvent) -> None:
+        terminal_status = _terminal_run_status_for_event_type(event.event_type)
+        if terminal_status is None:
+            return
+        safe_session_id = str(event.session_id or "").strip()
+        safe_run_id = str(event.run_id or event.trace_id or "").strip()
+        if not safe_session_id or not safe_run_id:
+            return
+        if self._is_subagent_run_id(
+            safe_run_id
+        ) or safe_run_id in self._subagent_run_ids(safe_session_id):
+            return
+
+        def mark_terminal(record: SessionRecord) -> SessionRecord:
+            active_run_id = str(record.active_run_id or "").strip()
+            updates: dict[str, object] = {
+                "latest_terminal_run_id": safe_run_id,
+                "latest_terminal_run_status": terminal_status,
+                "latest_terminal_run_updated_at": event.occurred_at,
+                "latest_terminal_run_verification_status": None,
+                "has_unread_terminal_run": (
+                    record.last_viewed_terminal_run_id != safe_run_id
+                ),
+            }
+            if terminal_status == RunRuntimeStatus.STOPPED.value and (
+                not active_run_id or active_run_id == safe_run_id
+            ):
+                updates.update(
+                    {
+                        "has_active_run": True,
+                        "active_run_id": safe_run_id,
+                        "active_run_status": terminal_status,
+                        "active_run_phase": "stopped",
+                        "pending_tool_approval_count": 0,
+                    }
+                )
+            elif not active_run_id or active_run_id == safe_run_id:
+                updates.update(
+                    {
+                        "has_active_run": False,
+                        "active_run_id": None,
+                        "active_run_status": None,
+                        "active_run_phase": None,
+                        "pending_tool_approval_count": 0,
+                    }
+                )
+            return record.model_copy(update=updates)
+
+        self._session_list_cache.update_record(safe_session_id, mark_terminal)
 
     @staticmethod
     def _is_running_async_publish_listener() -> bool:
@@ -1393,7 +1522,7 @@ class SessionService:
         for session_id in session_ids:
             runtimes = runtimes_by_session.get(session_id, ())
             excluded_run_ids = excluded_run_ids_by_session.get(session_id, set())
-            selected = self._select_active_run_from_preloaded(
+            selected = self._select_list_active_run_from_preloaded(
                 session_id=session_id,
                 runtimes=runtimes,
                 excluded_run_ids=excluded_run_ids,
@@ -1485,6 +1614,16 @@ class SessionService:
             force_refresh=force_refresh,
         )
         return result.value
+
+    async def list_sidebar_sessions_async(
+        self,
+        *,
+        force_refresh: bool = False,
+    ) -> tuple[SessionSidebarRecord, ...]:
+        records = await self.list_sessions_async(force_refresh=force_refresh)
+        return tuple(
+            SessionSidebarRecord.from_session_record(record) for record in records
+        )
 
     def mark_latest_terminal_run_viewed(self, session_id: str) -> None:
         _ = self._session_repo.get(session_id)
@@ -2313,6 +2452,20 @@ class SessionService:
             refresh=lambda: self.get_recovery_snapshot(session_id),
             force_refresh=force_refresh,
         )
+        log_event(
+            LOGGER,
+            logging.DEBUG,
+            event="session.recovery.seeded_or_refreshed",
+            message="Read session recovery snapshot",
+            payload={
+                "session_id": session_id,
+                "force_refresh": force_refresh,
+                "cache_hit": result.diagnostics.cache_hit,
+                "stale": result.diagnostics.stale,
+                "dirty": result.diagnostics.dirty,
+                "refresh_in_progress": result.diagnostics.refresh_in_progress,
+            },
+        )
         return result.value
 
     def get_token_usage_by_run(self, run_id: str) -> RunTokenUsage:
@@ -2840,6 +2993,68 @@ class SessionService:
             if self._has_background_tasks(runtime.run_id):
                 return runtime.run_id, runtime
         return None
+
+    def _select_list_active_run_from_preloaded(
+        self,
+        *,
+        session_id: str,
+        runtimes: tuple[RunRuntimeRecord, ...],
+        excluded_run_ids: set[str],
+        active_background_run_ids: set[str],
+    ) -> tuple[str, RunRuntimeRecord] | None:
+        hinted_run_id = (
+            self._active_run_registry.get_active_run_id(session_id)
+            if self._active_run_registry is not None
+            else None
+        )
+        sorted_runtimes = sorted(
+            runtimes, key=lambda item: item.updated_at, reverse=True
+        )
+        if hinted_run_id and hinted_run_id not in excluded_run_ids:
+            hinted_runtime = next(
+                (
+                    runtime
+                    for runtime in sorted_runtimes
+                    if runtime.run_id == hinted_run_id
+                ),
+                None,
+            )
+            if hinted_runtime is not None and (
+                self._is_list_active_runtime(hinted_runtime, allow_stopped=True)
+                or (
+                    hinted_runtime.status
+                    in {RunRuntimeStatus.COMPLETED, RunRuntimeStatus.FAILED}
+                    and hinted_runtime.run_id in active_background_run_ids
+                )
+            ):
+                return hinted_run_id, hinted_runtime
+
+        for runtime in sorted_runtimes:
+            if runtime.run_id in excluded_run_ids:
+                continue
+            if self._is_list_active_runtime(runtime):
+                return runtime.run_id, runtime
+        for runtime in sorted_runtimes:
+            if runtime.run_id in excluded_run_ids:
+                continue
+            if runtime.status not in {
+                RunRuntimeStatus.COMPLETED,
+                RunRuntimeStatus.FAILED,
+            }:
+                continue
+            if runtime.run_id in active_background_run_ids:
+                return runtime.run_id, runtime
+        return None
+
+    @staticmethod
+    def _is_list_active_runtime(
+        runtime: RunRuntimeRecord,
+        *,
+        allow_stopped: bool = False,
+    ) -> bool:
+        if runtime.is_live_active or runtime.status == RunRuntimeStatus.PAUSED:
+            return True
+        return allow_stopped and runtime.status == RunRuntimeStatus.STOPPED
 
     def _select_active_run_from_preloaded(
         self,

--- a/src/relay_teams/sessions/session_snapshot_cache.py
+++ b/src/relay_teams/sessions/session_snapshot_cache.py
@@ -7,7 +7,7 @@ import logging
 import os
 from threading import RLock
 from time import monotonic
-from typing import Generic, TypeVar, cast
+from typing import Generic, Protocol, TypeVar, cast
 
 from relay_teams.logger import get_logger, log_event
 from relay_teams.sessions.session_read_models import (
@@ -20,10 +20,18 @@ from relay_teams.sessions.session_read_models import (
 
 ResultT = TypeVar("ResultT")
 LOGGER = get_logger(__name__)
-ProjectionRefreshRunner = Callable[
-    [str, Callable[[], ResultT]],
-    Awaitable[ResultT],
-]
+
+
+class ProjectionRefreshRunner(Protocol):
+    def __call__(
+        self,
+        operation: str,
+        refresh: Callable[[], ResultT],
+        /,
+    ) -> Awaitable[ResultT]:
+        raise NotImplementedError
+
+
 SnapshotCacheKey = tuple[str, str, str]
 DEFAULT_SESSION_SNAPSHOT_CACHE_MAX_AGE_SECONDS = 0.75
 DEFAULT_SESSION_SNAPSHOT_CACHE_MS = 1000
@@ -114,13 +122,17 @@ class StaleFirstCache(Generic[ResultT]):
         self,
         *,
         operation_name: str,
-        refresh_runner: ProjectionRefreshRunner[ResultT] | None = None,
+        refresh_runner: ProjectionRefreshRunner | None = None,
         max_age_seconds: float | None = None,
         cold_miss_timeout_seconds: float = DEFAULT_SESSION_COLD_MISS_TIMEOUT_SECONDS,
         refresh_min_interval_seconds: float | None = None,
     ) -> None:
         self._operation_name = operation_name
-        self._refresh_runner = refresh_runner or default_projection_refresh_runner
+        self._refresh_runner: ProjectionRefreshRunner = (
+            refresh_runner
+            if refresh_runner is not None
+            else default_projection_refresh_runner
+        )
         self._max_age_seconds = (
             max_age_seconds
             if max_age_seconds is not None
@@ -164,6 +176,17 @@ class StaleFirstCache(Generic[ResultT]):
             self._entry.value = update(value)
             self._entry.generated_at = utc_now()
             self._entry.generated_monotonic = monotonic()
+            return True
+
+    def seed_if_empty(self, value: ResultT, *, dirty: bool = True) -> bool:
+        with self._sync_lock:
+            if self._entry.value is not None:
+                return False
+            self._entry.value = value
+            self._entry.generated_at = utc_now()
+            self._entry.generated_monotonic = monotonic()
+            self._entry.dirty = dirty
+            self._entry.generation += 1
             return True
 
     async def read(
@@ -488,7 +511,7 @@ class SessionSnapshotCache:
     def __init__(
         self,
         *,
-        refresh_runner: ProjectionRefreshRunner[object] | None = None,
+        refresh_runner: ProjectionRefreshRunner | None = None,
         max_age_seconds: float | None = None,
         cold_miss_timeout_seconds: float = DEFAULT_SESSION_COLD_MISS_TIMEOUT_SECONDS,
         refresh_min_interval_seconds: float | None = None,
@@ -547,6 +570,22 @@ class SessionSnapshotCache:
         for cache in caches:
             cache.clear()
 
+    def seed_if_empty(
+        self,
+        *,
+        session_id: str,
+        section: SessionSnapshotSection,
+        value: object,
+        rounds_key: SessionRoundsQueryKey | None = None,
+        dirty: bool = True,
+    ) -> bool:
+        cache = self._get_or_create_cache(
+            session_id=session_id,
+            section=section,
+            rounds_key=rounds_key,
+        )
+        return cache.seed_if_empty(value, dirty=dirty)
+
     def mark_all_dirty(self) -> None:
         with self._entries_lock:
             caches = tuple(
@@ -568,6 +607,25 @@ class SessionSnapshotCache:
         failure_fallback: Callable[[], ResultT] | None = None,
         rounds_key: SessionRoundsQueryKey | None = None,
     ) -> CachedReadResult[ResultT]:
+        cache = self._get_or_create_cache(
+            session_id=session_id,
+            section=section,
+            rounds_key=rounds_key,
+        )
+        return await cache.read(
+            refresh,
+            force_refresh=force_refresh,
+            fallback=fallback,
+            failure_fallback=failure_fallback or fallback,
+        )
+
+    def _get_or_create_cache(
+        self,
+        *,
+        session_id: str,
+        section: SessionSnapshotSection,
+        rounds_key: SessionRoundsQueryKey | None,
+    ) -> StaleFirstCache[ResultT]:
         cache_key = self._cache_key(
             session_id=session_id,
             section=section,
@@ -575,31 +633,23 @@ class SessionSnapshotCache:
         )
         with self._entries_lock:
             cache = self._entries.get(cache_key)
-            if cache is None:
-                operation = self._operation_name(
-                    session_id=session_id,
-                    section=section,
-                    rounds_key=rounds_key,
-                )
-                raw_cache = StaleFirstCache[object](
-                    operation_name=operation,
-                    refresh_runner=self._refresh_runner,
-                    max_age_seconds=self._max_age_seconds,
-                    cold_miss_timeout_seconds=self._cold_miss_timeout_seconds,
-                    refresh_min_interval_seconds=self._refresh_min_interval_seconds,
-                )
-                self._entries[cache_key] = raw_cache
-                self._prune_entries_locked(protected_key=cache_key)
-                # noinspection PyUnnecessaryCast
-                cache = cast(StaleFirstCache[ResultT], raw_cache)
-            else:
-                cache = cast(StaleFirstCache[ResultT], cache)
-        return await cache.read(
-            refresh,
-            force_refresh=force_refresh,
-            fallback=fallback,
-            failure_fallback=failure_fallback or fallback,
-        )
+            if cache is not None:
+                return cast(StaleFirstCache[ResultT], cache)
+            operation = self._operation_name(
+                session_id=session_id,
+                section=section,
+                rounds_key=rounds_key,
+            )
+            raw_cache = StaleFirstCache[ResultT](
+                operation_name=operation,
+                refresh_runner=self._refresh_runner,
+                max_age_seconds=self._max_age_seconds,
+                cold_miss_timeout_seconds=self._cold_miss_timeout_seconds,
+                refresh_min_interval_seconds=self._refresh_min_interval_seconds,
+            )
+            self._entries[cache_key] = raw_cache
+            self._prune_entries_locked(protected_key=cache_key)
+            return raw_cache
 
     def _prune_entries_locked(self, *, protected_key: SnapshotCacheKey) -> None:
         while len(self._entries) > self._max_entries:

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -282,7 +282,10 @@ def test_browser_ask_question_recovery_card_submits_answers(
         lambda response: (
             response.request.method == "GET"
             and response.url
-            == f"{integration_env.api_base_url}/api/sessions/{session_id}/recovery"
+            == (
+                f"{integration_env.api_base_url}/api/sessions/{session_id}/recovery"
+                "?force_refresh=true"
+            )
         )
     ):
         page.evaluate("window.dispatchEvent(new Event('focus'))")

--- a/tests/integration_tests/frontend/test_api_facade_ui.py
+++ b/tests/integration_tests/frontend/test_api_facade_ui.py
@@ -202,7 +202,11 @@ export function invalidateManagedRequestCache(prefix) {
             }
         ],
         "invalidatedPrefixes": [],
-        "invalidatedCachePrefixes": ["sessions:list", "sessions:session-a:record"],
+        "invalidatedCachePrefixes": [
+            "sessions:list",
+            "sessions:sidebar",
+            "sessions:session-a:record",
+        ],
     }
 
 
@@ -262,7 +266,9 @@ export function invalidateManagedRequestCache() {
                 "globalThis.__invalidatedPrefixes = []; "
                 f"const mod = await import({module_under_test_path.as_uri()!r}); "
                 "await mod.fetchSessions(); "
+                "await mod.fetchSessions({ sidebar: true }); "
                 "await mod.fetchSessions({ forceRefresh: true }); "
+                "await mod.fetchSessions({ sidebar: true, forceRefresh: true }); "
                 "console.log(JSON.stringify({"
                 "managedRequests: globalThis.__capturedManagedRequests,"
                 "invalidatedPrefixes: globalThis.__invalidatedPrefixes"
@@ -284,7 +290,7 @@ export function invalidateManagedRequestCache() {
         )
 
     payload = json.loads(completed.stdout.strip())
-    assert payload["invalidatedPrefixes"] == ["sessions:list"]
+    assert payload["invalidatedPrefixes"] == ["sessions:list", "sessions:sidebar"]
     assert payload["managedRequests"] == [
         {
             "key": "sessions:list",
@@ -294,8 +300,22 @@ export function invalidateManagedRequestCache() {
             "config": {"ttlMs": 500},
         },
         {
+            "key": "sessions:sidebar",
+            "url": "/api/sessions/sidebar",
+            "options": {},
+            "errorMessage": "Failed to fetch sessions",
+            "config": {"ttlMs": 500},
+        },
+        {
             "key": "sessions:list",
             "url": "/api/sessions?force_refresh=true",
+            "options": {},
+            "errorMessage": "Failed to fetch sessions",
+            "config": {"ttlMs": 500},
+        },
+        {
+            "key": "sessions:sidebar",
+            "url": "/api/sessions/sidebar?force_refresh=true",
             "options": {},
             "errorMessage": "Failed to fetch sessions",
             "config": {"ttlMs": 500},

--- a/tests/integration_tests/frontend/test_backend_status_ui.py
+++ b/tests/integration_tests/frontend/test_backend_status_ui.py
@@ -616,6 +616,9 @@ globalThis.fetch = async url => {
             }),
         };
     }
+    if (safeUrl.startsWith('http://127.0.0.1:')) {
+        return { ok: false, json: async () => ({}) };
+    }
     if (safeUrl === '/api/system/live') {
         return { ok: false, json: async () => ({}) };
     }
@@ -658,7 +661,7 @@ console.log(JSON.stringify({
     assert payload["calls"][-1] == "/api/system/live"
 
 
-def test_backend_status_rejects_fallback_without_main_base_url(
+def test_backend_status_fallback_reaches_non_adjacent_control_plane_port(
     tmp_path: Path,
 ) -> None:
     repo_root = Path(__file__).resolve().parents[3]
@@ -718,7 +721,7 @@ globalThis.fetch = async url => {
             json: async () => ({ status: 'alive' }),
         };
     }
-    if (safeUrl === 'http://127.0.0.1:8002/live') {
+    if (safeUrl === 'http://127.0.0.1:7999/live') {
         return {
             ok: true,
             json: async () => ({
@@ -726,6 +729,18 @@ globalThis.fetch = async url => {
                 main_base_url: 'not-a-url',
             }),
         };
+    }
+    if (safeUrl === 'http://127.0.0.1:8002/live') {
+        return {
+            ok: true,
+            json: async () => ({
+                status: 'alive',
+                main_base_url: 'http://127.0.0.1:8000',
+            }),
+        };
+    }
+    if (safeUrl.startsWith('http://127.0.0.1:')) {
+        return { ok: false, json: async () => ({}) };
     }
     if (safeUrl === '/api/system/live') {
         return { ok: false, json: async () => ({}) };
@@ -756,14 +771,311 @@ console.log(JSON.stringify({
     )
     payload = json.loads(result.stdout)
 
-    assert payload["result"] is False
-    assert payload["status"] == "offline"
-    assert payload["classNames"] == ["offline"]
-    assert payload["label"] == "backend.status.offline"
-    assert payload["storedUrl"] is None
+    assert payload["result"] is True
+    assert payload["status"] == "busy"
+    assert payload["classNames"] == ["busy"]
+    assert payload["label"] == "backend.status.busy"
+    assert payload["storedUrl"] == "http://127.0.0.1:8002/live"
     assert payload["calls"][:2] == [
         "/api/system/control-plane",
         "/api/system/live",
     ]
     assert "http://127.0.0.1:8001/live" in payload["calls"]
+    assert "http://127.0.0.1:7999/live" in payload["calls"]
     assert "http://127.0.0.1:8002/live" in payload["calls"]
+    assert sum(call.startswith("http://127.0.0.1:") for call in payload["calls"]) == 4
+
+
+def test_backend_status_limits_fallback_probe_fanout(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    backend_status_source = (
+        repo_root / "frontend" / "dist" / "js" / "utils" / "backendStatus.js"
+    ).read_text(encoding="utf-8")
+    module_source = backend_status_source.replace(
+        "import { els } from './dom.js';",
+        "const els = globalThis.__backendStatusEls;",
+    ).replace(
+        "import { t } from './i18n.js';",
+        "const t = key => key;",
+    )
+    module_path = tmp_path / "backendStatus.test.mjs"
+    module_path.write_text(module_source, encoding="utf-8")
+    runner_path = tmp_path / "runner-limited-fallback.mjs"
+    runner_path.write_text(
+        """
+const classNames = new Set();
+const backendStatusEl = {
+    classList: {
+        remove: (...names) => names.forEach(name => classNames.delete(name)),
+        add: name => classNames.add(name),
+    },
+    dataset: {},
+    title: '',
+    textContent: '',
+};
+const backendStatusLabel = { textContent: '' };
+const storage = new Map();
+const calls = [];
+
+globalThis.__backendStatusEls = {
+    backendStatus: backendStatusEl,
+    backendStatusLabel,
+};
+globalThis.window = {
+    location: new URL('http://127.0.0.1:8000/'),
+    localStorage: {
+        getItem: key => storage.get(key) || null,
+        setItem: (key, value) => storage.set(key, value),
+        removeItem: key => storage.delete(key),
+    },
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    setInterval: globalThis.setInterval.bind(globalThis),
+};
+globalThis.fetch = async url => {
+    const safeUrl = String(url);
+    calls.push(safeUrl);
+    if (safeUrl === '/api/system/control-plane') {
+        return { ok: false, json: async () => ({}) };
+    }
+    if (safeUrl === '/api/system/live') {
+        return { ok: false, json: async () => ({}) };
+    }
+    if (safeUrl === 'http://127.0.0.1:8002/live') {
+        return {
+            ok: true,
+            json: async () => ({
+                status: 'alive',
+                main_base_url: 'http://127.0.0.1:8000',
+            }),
+        };
+    }
+    if (safeUrl.startsWith('http://127.0.0.1:')) {
+        return { ok: false, json: async () => ({}) };
+    }
+    throw new Error(`unexpected fetch: ${safeUrl}`);
+};
+
+const backendStatus = await import('./backendStatus.test.mjs');
+const result = await backendStatus.refreshBackendStatus({ force: true });
+
+console.log(JSON.stringify({
+    fallbackCalls: calls.filter(call => call.startsWith('http://127.0.0.1:')),
+    result,
+    status: backendStatus.getBackendStatus(),
+}));
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload == {
+        "fallbackCalls": [
+            "http://127.0.0.1:8001/live",
+            "http://127.0.0.1:7999/live",
+            "http://127.0.0.1:8002/live",
+            "http://127.0.0.1:7998/live",
+        ],
+        "result": True,
+        "status": "busy",
+    }
+
+
+def test_backend_status_first_busy_miss_stays_pending(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    backend_status_source = (
+        repo_root / "frontend" / "dist" / "js" / "utils" / "backendStatus.js"
+    ).read_text(encoding="utf-8")
+    module_source = backend_status_source.replace(
+        "import { els } from './dom.js';",
+        "const els = globalThis.__backendStatusEls;",
+    ).replace(
+        "import { t } from './i18n.js';",
+        "const t = key => key;",
+    )
+    module_path = tmp_path / "backendStatus.test.mjs"
+    module_path.write_text(module_source, encoding="utf-8")
+    runner_path = tmp_path / "runner-busy-miss.mjs"
+    runner_path.write_text(
+        """
+const classNames = new Set();
+const backendStatusEl = {
+    classList: {
+        remove: (...names) => names.forEach(name => classNames.delete(name)),
+        add: name => classNames.add(name),
+    },
+    dataset: {},
+    title: '',
+    textContent: '',
+};
+const backendStatusLabel = { textContent: '' };
+const storage = new Map();
+
+globalThis.__backendStatusEls = {
+    backendStatus: backendStatusEl,
+    backendStatusLabel,
+};
+globalThis.window = {
+    location: new URL('http://127.0.0.1:8000/'),
+    localStorage: {
+        getItem: key => storage.get(key) || null,
+        setItem: (key, value) => storage.set(key, value),
+        removeItem: key => storage.delete(key),
+    },
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    setInterval: globalThis.setInterval.bind(globalThis),
+};
+globalThis.fetch = async url => {
+    const safeUrl = String(url);
+    if (
+        safeUrl === '/api/system/control-plane'
+        || safeUrl === '/api/system/live'
+        || safeUrl === 'http://127.0.0.1:8001/live'
+        || safeUrl === 'http://127.0.0.1:7999/live'
+    ) {
+        return { ok: false, json: async () => ({}) };
+    }
+    throw new Error(`unexpected fetch: ${safeUrl}`);
+};
+
+const backendStatus = await import('./backendStatus.test.mjs');
+backendStatus.markBackendBusy();
+const firstResult = await backendStatus.refreshBackendStatus({ force: true });
+const firstSnapshot = {
+    result: firstResult,
+    classNames: Array.from(classNames).sort(),
+    status: backendStatus.getBackendStatus(),
+};
+const secondResult = await backendStatus.refreshBackendStatus({ force: true });
+
+console.log(JSON.stringify({
+    firstSnapshot,
+    secondSnapshot: {
+        result: secondResult,
+        classNames: Array.from(classNames).sort(),
+        status: backendStatus.getBackendStatus(),
+    },
+}));
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload == {
+        "firstSnapshot": {
+            "result": False,
+            "classNames": ["busy"],
+            "status": "busy",
+        },
+        "secondSnapshot": {
+            "result": False,
+            "classNames": ["offline"],
+            "status": "offline",
+        },
+    }
+
+
+def test_backend_status_busy_state_eventually_probes_health(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    backend_status_source = (
+        repo_root / "frontend" / "dist" / "js" / "utils" / "backendStatus.js"
+    ).read_text(encoding="utf-8")
+    module_source = backend_status_source.replace(
+        "import { els } from './dom.js';",
+        "const els = globalThis.__backendStatusEls;",
+    ).replace(
+        "import { t } from './i18n.js';",
+        "const t = key => key;",
+    )
+    module_path = tmp_path / "backendStatus.test.mjs"
+    module_path.write_text(module_source, encoding="utf-8")
+    runner_path = tmp_path / "runner-busy-probe-window.mjs"
+    runner_path.write_text(
+        """
+const classNames = new Set();
+const backendStatusEl = {
+    classList: {
+        remove: (...names) => names.forEach(name => classNames.delete(name)),
+        add: name => classNames.add(name),
+    },
+    dataset: {},
+    title: '',
+    textContent: '',
+    setAttribute(name, value) {
+        this[name] = value;
+    },
+};
+const backendStatusLabel = { textContent: '' };
+const storage = new Map();
+let now = 1000;
+const fetchUrls = [];
+
+Date.now = () => now;
+globalThis.__backendStatusEls = {
+    backendStatus: backendStatusEl,
+    backendStatusLabel,
+};
+globalThis.window = {
+    location: new URL('http://127.0.0.1:8000/'),
+    localStorage: {
+        getItem: key => storage.get(key) || null,
+        setItem: (key, value) => storage.set(key, value),
+        removeItem: key => storage.delete(key),
+    },
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    setInterval: globalThis.setInterval.bind(globalThis),
+};
+globalThis.fetch = async url => {
+    fetchUrls.push(String(url));
+    if (String(url) === '/api/system/live') {
+        return { ok: true, json: async () => ({ status: 'alive' }) };
+    }
+    return { ok: false, json: async () => ({}) };
+};
+
+const backendStatus = await import('./backendStatus.test.mjs');
+backendStatus.markBackendBusy();
+const skipped = await backendStatus.refreshBackendStatus();
+now += 6000;
+const probed = await backendStatus.refreshBackendStatus();
+
+console.log(JSON.stringify({
+    skipped,
+    probed,
+    fetchUrls,
+    status: backendStatus.getBackendStatus(),
+}));
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload == {
+        "skipped": True,
+        "probed": True,
+        "fetchUrls": ["/api/system/control-plane", "/api/system/live"],
+        "status": "online",
+    }

--- a/tests/integration_tests/frontend/test_logger_sdk.py
+++ b/tests/integration_tests/frontend/test_logger_sdk.py
@@ -37,6 +37,44 @@ console.log(JSON.stringify(globalThis.__capturedBatches));
     assert browser_session_id.startswith("browser_")
 
 
+def test_frontend_logger_auto_flushes_full_batches_without_beacon(
+    tmp_path: Path,
+) -> None:
+    payload = _run_frontend_logger_script(
+        tmp_path=tmp_path,
+        runner_source="""
+Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+        userAgent: "node-test",
+        sendBeacon(url) {
+            globalThis.__capturedBeacons.push(url);
+            return true;
+        },
+    },
+});
+import { logInfo } from "./logger.mjs";
+
+for (let i = 0; i < 20; i += 1) {
+    logInfo("frontend.test.batch", `batch ${i}`);
+}
+await Promise.resolve();
+
+console.log(JSON.stringify([{
+    batches: globalThis.__capturedBatches,
+    beacons: globalThis.__capturedBeacons,
+}]));
+""".strip(),
+    )
+
+    result = cast(dict[str, JsonValue], payload[0])
+    batches = cast(list[dict[str, JsonValue]], result["batches"])
+    assert len(batches) == 1
+    events = cast(list[dict[str, JsonValue]], batches[0]["events"])
+    assert len(events) == 20
+    assert result["beacons"] == []
+
+
 def test_frontend_logger_uses_null_trace_id_without_active_run(tmp_path: Path) -> None:
     payload = _run_frontend_logger_script(
         tmp_path=tmp_path,
@@ -98,6 +136,58 @@ console.log(JSON.stringify([{
     assert [event["level"] for event in events] == ["error", "info"]
 
 
+def test_frontend_logger_beforeunload_keepalive_bypasses_busy_defer(
+    tmp_path: Path,
+) -> None:
+    payload = _run_frontend_logger_script(
+        tmp_path=tmp_path,
+        state_source="""
+export const state = {
+    currentSessionId: "session-ui",
+    activeRunId: "run-ui",
+    activeRunStreamCount: 1,
+};
+""".strip(),
+        runner_source="""
+Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+        userAgent: "node-test",
+        sendBeacon(url) {
+            globalThis.__capturedBeacons.push(url);
+            return true;
+        },
+    },
+});
+const listeners = [];
+globalThis.addEventListener = (eventName, callback) => {
+    if (eventName === "beforeunload") {
+        listeners.push(callback);
+    }
+};
+
+const { installGlobalErrorLogging, logError } = await import("./logger.mjs");
+installGlobalErrorLogging();
+logError("frontend.test.unload", "flush during unload");
+for (const callback of listeners) {
+    callback();
+}
+await Promise.resolve();
+
+console.log(JSON.stringify([{
+    batches: globalThis.__capturedBatches,
+    beacons: globalThis.__capturedBeacons,
+    timers: globalThis.__scheduledTimers,
+}]));
+""".strip(),
+    )
+
+    result = cast(dict[str, JsonValue], payload[0])
+    assert result["beacons"] == ["/api/logs/frontend"]
+    assert result["batches"] == []
+    assert 3500 not in cast(list[int], result["timers"])
+
+
 def _run_frontend_logger_script(
     tmp_path: Path,
     runner_source: str,
@@ -137,7 +227,9 @@ export function showToast(payload) {
     runner_path.write_text(
         f"""
 globalThis.__capturedBatches = [];
+globalThis.__capturedBeacons = [];
 globalThis.__feedbackToasts = [];
+globalThis.__scheduledTimers = [];
 globalThis.location = {{ pathname: "/chat" }};
 globalThis.document = {{ title: "agent-teams" }};
 Object.defineProperty(globalThis, "navigator", {{
@@ -149,6 +241,11 @@ Object.defineProperty(globalThis, "navigator", {{
         }},
     }},
 }});
+globalThis.setTimeout = (callback, delay) => {{
+    globalThis.__scheduledTimers.push(delay);
+    return {{ callback, delay }};
+}};
+globalThis.clearTimeout = () => {{}};
 globalThis.addEventListener = () => {{}};
 globalThis.fetch = async (_url, options) => {{
     globalThis.__capturedBatches.push(JSON.parse(options.body));

--- a/tests/integration_tests/frontend/test_projects_sidebar_ui.py
+++ b/tests/integration_tests/frontend/test_projects_sidebar_ui.py
@@ -1046,7 +1046,7 @@ console.log(JSON.stringify({
     assert "if (state.currentFeatureViewId === safeFeatureId) {" in sidebar_script
     assert "animateSessionItem(sessionItem, 'removing');" in sidebar_script
     assert sidebar_script.count("await loadProjects({ forceRefresh: true });") >= 1
-    assert "scheduleSessionsRefresh(900, { forceRefresh: true });" in sidebar_script
+    assert "scheduleSessionsRefresh(900, { forceRefresh: false });" in sidebar_script
     assert "isSessionsRefreshSuppressed() && forceRefresh !== true" in sidebar_script
     assert "PROJECT_UPDATED: 'project_updated'" in sidebar_script
     assert (
@@ -3878,7 +3878,7 @@ export async function runAutomationProject() {
         "sessions": 2,
         "automationProjects": 1,
     }
-    assert payload["sessionForceRefreshes"] == [True, True]
+    assert payload["sessionForceRefreshes"] == [False, True]
 
 
 def test_projects_sidebar_preserves_forced_refresh_across_debounce(
@@ -4005,7 +4005,7 @@ export async function runAutomationProject() {
         "sessions": 2,
         "automationProjects": 1,
     }
-    assert payload["sessionForceRefreshes"] == [True, True]
+    assert payload["sessionForceRefreshes"] == [False, True]
 
 
 def test_projects_sidebar_coalesces_session_refresh_while_request_is_in_flight(
@@ -4152,7 +4152,7 @@ export async function runAutomationProject() {
         "sessions": 2,
         "automationProjects": 1,
     }
-    assert payload["forceRefreshesWhileInFlight"] == [True, False]
+    assert payload["forceRefreshesWhileInFlight"] == [False, False]
     assert payload["countsBeforeTrailingResolve"] == {
         "workspaces": 1,
         "sessions": 3,
@@ -4163,7 +4163,7 @@ export async function runAutomationProject() {
         "sessions": 3,
         "automationProjects": 1,
     }
-    assert payload["sessionForceRefreshes"] == [True, False, True]
+    assert payload["sessionForceRefreshes"] == [False, False, True]
 
 
 def test_projects_sidebar_defers_subagent_events_without_force_refresh_while_hovering(

--- a/tests/integration_tests/frontend/test_recovery_background_tasks_ui.py
+++ b/tests/integration_tests/frontend/test_recovery_background_tasks_ui.py
@@ -23,6 +23,35 @@ def test_recovery_continuity_polling_excludes_terminal_recoverable_runs() -> Non
     assert "if (isTerminalRecoveryRun(activeRun)) return false;" in source
 
 
+def test_hydrate_session_view_loads_requested_rounds_under_run_pressure() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "app" / "recovery.js").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("export async function hydrateSessionView", 1)[1].split(
+        "    const snapshot = await recoveryPromise;",
+        1,
+    )[0]
+
+    assert "shouldSkipRoundsReload" not in block
+    assert "if (includeRounds) {" in block
+    assert "await loadSessionRounds(safeSessionId" in block
+
+
+def test_window_focus_recovery_refresh_bypasses_managed_cache() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "app" / "recovery.js").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("function handleContinuityFocus()", 1)[1].split(
+        "\n}\n",
+        1,
+    )[0]
+
+    assert "forceRefresh: true" in block
+    assert "reason: 'window-focus'" in block
+
+
 def test_recovery_ui_tracks_background_tasks_in_banner_and_events() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     recovery_script = (
@@ -44,14 +73,19 @@ def test_recovery_ui_tracks_background_tasks_in_banner_and_events() -> None:
     assert "handleBackgroundTaskAction" in recovery_script
     assert "forceRefresh: forceRefresh === true" in recovery_script
     assert (
-        "await refreshSubagentRail(safeSessionId, {\n"
-        "        preserveSelection: true,\n"
-        "        priority,\n"
-        "        forceRefresh: forceRefresh === true,\n"
-        "        signal,\n"
-        "    });\n"
-        "    throwIfAborted(signal);\n"
-        "    syncSessionContinuity();" in recovery_script
+        "syncSessionContinuity();\n"
+        "    if (includeSubagents) {\n"
+        "        try {\n"
+        "            await refreshSubagentRail(safeSessionId, {\n"
+        "                preserveSelection: true,\n"
+        "                priority,\n"
+        "                forceRefresh: forceRefresh === true,\n"
+        "                signal,\n"
+        "            });" in recovery_script
+    )
+    assert "if (error?.name === 'AbortError') throw error;" in recovery_script
+    assert (
+        "    throwIfAborted(signal);\n    syncSessionContinuity();" in recovery_script
     )
     assert "export function applyBackgroundTaskEvent" in recovery_script
     assert "normalizeBackgroundTaskEventStatus(payload, eventType)" in recovery_script

--- a/tests/integration_tests/frontend/test_run_events_ui.py
+++ b/tests/integration_tests/frontend/test_run_events_ui.py
@@ -619,6 +619,40 @@ console.log(JSON.stringify({
     assert last_args[0] == {"text": "new lifecycle"}
 
 
+def test_route_event_refreshes_recovery_after_terminal_run_event(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+routeEvent('run_completed', {}, {
+    run_id: 'run-1',
+    trace_id: 'run-1',
+    event_id: 'evt-terminal',
+});
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    recoveryCalls: globalThis.__scheduleRecoveryContinuityRefreshCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["recoveryCalls"] == [
+        {
+            "sessionId": "session-1",
+            "delayMs": 650,
+            "forceRefresh": False,
+            "includeRounds": False,
+            "quiet": True,
+            "reason": "run_completed",
+        }
+    ]
+
+
 def test_route_event_refreshes_recovery_for_subagent_user_question_events(
     tmp_path: Path,
 ) -> None:
@@ -662,6 +696,40 @@ console.log(JSON.stringify({
     assert payload["runEventCalls"] == []
 
 
+def test_route_event_force_refreshes_recovery_after_approval_resolved(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+routeEvent(
+    'tool_approval_resolved',
+    { approval_id: 'approval-1' },
+    { run_id: 'run-1', trace_id: 'run-1' },
+);
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    recoveryCalls: globalThis.__scheduleRecoveryContinuityRefreshCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["recoveryCalls"] == [
+        {
+            "sessionId": "session-1",
+            "delayMs": 350,
+            "forceRefresh": True,
+            "includeRounds": False,
+            "quiet": True,
+            "reason": "tool_approval_resolved",
+        }
+    ]
+
+
 def test_route_event_routes_fallback_events(tmp_path: Path) -> None:
     payload = _run_event_router_script(
         tmp_path=tmp_path,
@@ -684,7 +752,7 @@ console.log(JSON.stringify({
         {
             "sessionId": "session-1",
             "delayMs": 350,
-            "forceRefresh": True,
+            "forceRefresh": False,
             "includeRounds": False,
             "quiet": True,
             "reason": "llm_fallback_activated",
@@ -692,7 +760,7 @@ console.log(JSON.stringify({
         {
             "sessionId": "session-1",
             "delayMs": 350,
-            "forceRefresh": True,
+            "forceRefresh": False,
             "includeRounds": False,
             "quiet": True,
             "reason": "llm_fallback_exhausted",

--- a/tests/integration_tests/frontend/test_session_sidebar_store_ui.py
+++ b/tests/integration_tests/frontend/test_session_sidebar_store_ui.py
@@ -308,3 +308,396 @@ console.log(JSON.stringify({ afterStaleSnapshot }));
     assert json.loads(result.stdout) == {
         "afterStaleSnapshot": [{"sessionId": "session-1", "title": "keep"}],
     }
+
+
+def test_optimistic_running_session_survives_stale_server_snapshot(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-optimistic-run.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunStarted,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'Prompt' },
+            has_active_run: false,
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    ],
+});
+markSidebarSessionRunStarted('session-1', { run_id: 'run-1' });
+const optimistic = getSidebarDataSnapshot().sessions[0];
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'Prompt' },
+            has_active_run: false,
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    ],
+});
+const afterStale = getSidebarDataSnapshot().sessions[0];
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'Prompt' },
+            has_active_run: false,
+            active_run_id: '',
+            latest_terminal_run_id: 'run-1',
+            latest_terminal_run_status: 'completed',
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    ],
+});
+const afterFresh = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    optimistic: {
+        hasActiveRun: optimistic.has_active_run,
+        activeRunId: optimistic.active_run_id,
+        status: optimistic.active_run_status,
+    },
+    afterStale: {
+        hasActiveRun: afterStale.has_active_run,
+        activeRunId: afterStale.active_run_id,
+        status: afterStale.active_run_status,
+    },
+    afterFresh: {
+        hasActiveRun: afterFresh.has_active_run,
+        activeRunId: afterFresh.active_run_id,
+        latestTerminalRunId: afterFresh.latest_terminal_run_id,
+    },
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "optimistic": {
+            "hasActiveRun": True,
+            "activeRunId": "run-1",
+            "status": "running",
+        },
+        "afterStale": {
+            "hasActiveRun": True,
+            "activeRunId": "run-1",
+            "status": "running",
+        },
+        "afterFresh": {
+            "hasActiveRun": False,
+            "activeRunId": "",
+            "latestTerminalRunId": "run-1",
+        },
+    }
+
+
+def test_terminal_run_event_clears_optimistic_running_session(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-terminal-run.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunStarted,
+    markSidebarSessionRunTerminal,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'Prompt' },
+            has_active_run: false,
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    ],
+});
+markSidebarSessionRunStarted('session-1', { run_id: 'run-1' });
+markSidebarSessionRunTerminal('session-1', {
+    run_id: 'run-1',
+    event_type: 'run_completed',
+    updated_at: '2026-01-01T00:00:01.000Z',
+});
+const afterTerminal = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    hasActiveRun: afterTerminal.has_active_run,
+    activeRunId: afterTerminal.active_run_id,
+    activeRunStatus: afterTerminal.active_run_status,
+    latestTerminalRunId: afterTerminal.latest_terminal_run_id,
+    latestTerminalRunStatus: afterTerminal.latest_terminal_run_status,
+    hasUnreadTerminalRun: afterTerminal.has_unread_terminal_run,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "hasActiveRun": False,
+        "activeRunId": "",
+        "activeRunStatus": "",
+        "latestTerminalRunId": "run-1",
+        "latestTerminalRunStatus": "completed",
+        "hasUnreadTerminalRun": True,
+    }
+
+
+def test_stopped_run_event_keeps_recoverable_active_session(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-stopped-run.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunStarted,
+    markSidebarSessionRunTerminal,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'Prompt' },
+            has_active_run: false,
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    ],
+});
+markSidebarSessionRunStarted('session-1', { run_id: 'run-1' });
+markSidebarSessionRunTerminal('session-1', {
+    run_id: 'run-1',
+    event_type: 'run_stopped',
+    updated_at: '2026-01-01T00:00:01.000Z',
+});
+const afterTerminal = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    hasActiveRun: afterTerminal.has_active_run,
+    activeRunId: afterTerminal.active_run_id,
+    activeRunStatus: afterTerminal.active_run_status,
+    activeRunPhase: afterTerminal.active_run_phase,
+    latestTerminalRunId: afterTerminal.latest_terminal_run_id,
+    latestTerminalRunStatus: afterTerminal.latest_terminal_run_status,
+    hasUnreadTerminalRun: afterTerminal.has_unread_terminal_run,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "hasActiveRun": True,
+        "activeRunId": "run-1",
+        "activeRunStatus": "stopped",
+        "activeRunPhase": "stopped",
+        "latestTerminalRunId": "run-1",
+        "latestTerminalRunStatus": "stopped",
+        "hasUnreadTerminalRun": True,
+    }
+
+
+def test_viewed_terminal_run_event_clears_optimistic_running_without_unread_dot(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-viewed-terminal-run.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunStarted,
+    markSidebarSessionRunTerminal,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'Prompt' },
+            has_active_run: false,
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    ],
+});
+markSidebarSessionRunStarted('session-1', { run_id: 'run-1' });
+markSidebarSessionRunTerminal('session-1', {
+    run_id: 'run-1',
+    event_type: 'run_completed',
+    updated_at: '2026-01-01T00:00:01.000Z',
+}, { viewed: true });
+const afterTerminal = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    hasActiveRun: afterTerminal.has_active_run,
+    activeRunId: afterTerminal.active_run_id,
+    activeRunStatus: afterTerminal.active_run_status,
+    latestTerminalRunId: afterTerminal.latest_terminal_run_id,
+    latestTerminalRunStatus: afterTerminal.latest_terminal_run_status,
+    hasUnreadTerminalRun: afterTerminal.has_unread_terminal_run,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "hasActiveRun": False,
+        "activeRunId": "",
+        "activeRunStatus": "",
+        "latestTerminalRunId": "run-1",
+        "latestTerminalRunStatus": "completed",
+        "hasUnreadTerminalRun": False,
+    }
+
+
+def test_terminal_run_event_preserves_newer_optimistic_running_session(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-terminal-old-run.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunStarted,
+    markSidebarSessionRunTerminal,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'Prompt' },
+            has_active_run: false,
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    ],
+});
+markSidebarSessionRunStarted('session-1', { run_id: 'run-new' });
+markSidebarSessionRunTerminal('session-1', {
+    run_id: 'run-old',
+    event_type: 'run_completed',
+    updated_at: '2026-01-01T00:00:01.000Z',
+});
+const afterTerminal = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    hasActiveRun: afterTerminal.has_active_run,
+    activeRunId: afterTerminal.active_run_id,
+    activeRunStatus: afterTerminal.active_run_status,
+    latestTerminalRunId: afterTerminal.latest_terminal_run_id,
+    latestTerminalRunStatus: afterTerminal.latest_terminal_run_status,
+    hasUnreadTerminalRun: afterTerminal.has_unread_terminal_run,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "hasActiveRun": True,
+        "activeRunId": "run-new",
+        "activeRunStatus": "running",
+        "latestTerminalRunId": "run-old",
+        "latestTerminalRunStatus": "completed",
+        "hasUnreadTerminalRun": False,
+    }

--- a/tests/integration_tests/frontend/test_subagent_streams_ui.py
+++ b/tests/integration_tests/frontend/test_subagent_streams_ui.py
@@ -18,6 +18,74 @@ def test_background_discovery_does_not_poll_for_idle_selected_session() -> None:
     assert "currentSessionId" not in block
     assert "pendingBackgroundAttachRunIds.size > 0" in block
     assert "pendingRunStart" in block
+    assert "const BACKGROUND_DISCOVERY_BUSY_DELAY_MS = 8000;" in source
+    assert "const BACKGROUND_DISCOVERY_BUSY_STALE_MS = 30000;" in source
+    assert "function shouldDeferBackgroundDiscoveryFetch" in source
+    assert "const sessions = await fetchSessions({ sidebar: true });" in source
+    discovery_block = source.split("async function runBackgroundDiscovery()", 1)[
+        1
+    ].split(
+        "\n}\n\nasync function reconcileBackgroundStreams",
+        1,
+    )[0]
+    assert "if (shouldDeferBackgroundDiscoveryFetch(now))" in discovery_block
+    assert "void runBackgroundDiscovery();" not in discovery_block
+
+
+def test_multiplex_terminal_event_notifies_session_sidebar_store() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "core" / "stream.js").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("function applyMultiplexRunEvent(data)", 1)[1].split(
+        "\n}\n\nfunction scheduleMultiplexReconnect",
+        1,
+    )[0]
+
+    assert (
+        "notifySessionRunTerminal(connection.sessionId, runId, evType, payload, data)"
+        in block
+    )
+    assert "if (isSidebarTerminalRunEvent(evType))" in block
+    sidebar_terminal_block = source.split(
+        "function isSidebarTerminalRunEvent(evType)", 1
+    )[1].split("\n}\n", 1)[0]
+    assert "run_completed" in sidebar_terminal_block
+    assert "run_failed" in sidebar_terminal_block
+    assert "run_stopped" in sidebar_terminal_block
+    assert "run_paused" not in sidebar_terminal_block
+
+
+def test_background_discovery_skips_terminal_active_run_candidates() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "core" / "stream.js").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("async function reconcileBackgroundStreams", 1)[1].split(
+        "\n\nfunction stopBackgroundStreams",
+        1,
+    )[0]
+
+    assert "isRecordRunTerminal(record, runId)" in block
+    assert "latest_terminal_run_id" in source
+
+
+def test_normal_mode_subagent_discovery_polls_while_parent_run_active() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "core" / "stream.js").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("function shouldPollNormalModeSubagentDiscovery()", 1)[
+        1
+    ].split(
+        "\n}\n",
+        1,
+    )[0]
+
+    assert "isCurrentSessionParentRunActive()" in block
+    assert "isCurrentSessionRunStarting()" in block
+    assert "normalModeSubagentConnection" in block
+    assert "normalModeSubagentStreams.size > 0" in block
 
 
 def _write_stream_runtime_inject_mocks(tmp_path: Path) -> None:
@@ -389,6 +457,7 @@ def test_stop_request_applies_local_stopped_subagent_snapshot(tmp_path: Path) ->
         .replace("../components/sidebar.js", "./mockSidebar.mjs")
         .replace("../app/recovery.js", "./mockRecovery.mjs")
         .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/backendStatus.js", "./mockBackendStatus.mjs")
         .replace("../utils/logger.js", "./mockLogger.mjs")
         .replace("./eventRouter.js", "./mockEventRouter.mjs")
         .replace("../components/messageRenderer.js", "./mockMessageRenderer.mjs")
@@ -490,6 +559,14 @@ export const els = {
     thinkingEffortSelect: { disabled: false },
     stopBtn: { style: {}, disabled: false },
 };
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockBackendStatus.mjs").write_text(
+        """
+export function markBackendBusy() {
+    return undefined;
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -626,7 +703,7 @@ console.log(JSON.stringify({
     assert payload["clearedRunStreamStates"] == ["run-1", "run-1"]
 
 
-def test_active_parent_run_keeps_normal_subagent_discovery_polling(
+def test_active_parent_run_polls_normal_subagent_discovery_until_children_visible(
     tmp_path: Path,
 ) -> None:
     repo_root = Path(__file__).resolve().parents[3]
@@ -905,7 +982,7 @@ console.log(JSON.stringify({
     assert payload["eventSourceUrls"] == [
         "/api/runs/events?run_id=run-1&after_event_id=0"
     ]
-    assert 2500 in payload["scheduledDelays"]
+    assert 8000 in payload["scheduledDelays"]
     assert payload["fetchSubagentCalls"] == ["session-1"]
 
 
@@ -991,7 +1068,9 @@ export function refreshSessionTopologyControls() {
 export async function hydrateSessionView(sessionId, options = {}) {
     globalThis.__hydrateCalls.push({
         sessionId,
+        includeRecovery: options.includeRecovery === true,
         includeRounds: options.includeRounds === true,
+        includeSubagents: options.includeSubagents === true,
         forceRefresh: options.forceRefresh === true,
         roundsScrollPolicy: options.roundsScrollPolicy || "",
     });
@@ -1254,8 +1333,10 @@ console.log(JSON.stringify({
     assert payload["hydrateCalls"] == [
         {
             "sessionId": "session-1",
-            "includeRounds": True,
-            "forceRefresh": True,
+            "includeRecovery": False,
+            "includeRounds": False,
+            "includeSubagents": False,
+            "forceRefresh": False,
             "roundsScrollPolicy": "completion-auto",
         }
     ]
@@ -2178,7 +2259,26 @@ globalThis.__eventSources = [];
 globalThis.__routeEventCalls = [];
 globalThis.__clearRunStreamStateCalls = [];
 globalThis.__scheduleSessionsRefreshCalls = [];
+globalThis.__currentSessionRunStartedEvents = [];
 globalThis.__focusCalls = 0;
+globalThis.CustomEvent = class {
+    constructor(type, init = {}) {
+        this.type = type;
+        this.detail = init.detail || null;
+    }
+};
+globalThis.document = {
+    listeners: new Map(),
+    addEventListener(type, listener) {
+        this.listeners.set(type, listener);
+    },
+    dispatchEvent(event) {
+        this.listeners.get(event.type)?.(event);
+    },
+};
+document.addEventListener('agent-teams-current-session-run-started', event => {
+    globalThis.__currentSessionRunStartedEvents.push(event.detail);
+});
 
 class MockEventSource {
     constructor(url) {
@@ -2240,6 +2340,8 @@ console.log(JSON.stringify({
     completed,
     routeEventCalls: globalThis.__routeEventCalls,
     clearRunStreamStateCalls: globalThis.__clearRunStreamStateCalls,
+    currentSessionRunStartedEvents: globalThis.__currentSessionRunStartedEvents,
+    scheduleSessionsRefreshCalls: globalThis.__scheduleSessionsRefreshCalls,
     focusCalls: globalThis.__focusCalls,
 }));
 """.strip(),
@@ -2280,6 +2382,15 @@ console.log(JSON.stringify({
     }
     assert payload["completed"] == ["session-a"]
     assert payload["clearRunStreamStateCalls"] == ["run-paused"]
+    assert payload["currentSessionRunStartedEvents"] == [
+        {
+            "sessionId": "session-a",
+            "run": {"run_id": "run-paused", "target_role_id": "MainAgent"},
+        },
+    ]
+    assert payload["scheduleSessionsRefreshCalls"] == [
+        {"delay": 360, "options": {"forceRefresh": False}},
+    ]
     assert payload["focusCalls"] == 1
     assert [call["evType"] for call in payload["routeEventCalls"]] == ["run_paused"]
 

--- a/tests/unit_tests/agents/execution/test_session_runtime.py
+++ b/tests/unit_tests/agents/execution/test_session_runtime.py
@@ -55,6 +55,46 @@ async def _none_workspace_async(_self: object, **_kwargs: object) -> object:
     return cast(object, None)
 
 
+def test_log_slow_llm_prep_stage_emits_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, int, dict[str, object]]] = []
+
+    def capture_log_event(*args: object, **kwargs: object) -> None:
+        _ = args
+        payload = kwargs["payload"]
+        duration_ms = kwargs["duration_ms"]
+        assert isinstance(payload, dict)
+        assert isinstance(duration_ms, int)
+        events.append(
+            (
+                str(kwargs["event"]),
+                duration_ms,
+                payload,
+            )
+        )
+
+    monkeypatch.setattr(session_runtime_module.time, "perf_counter", lambda: 7.5)
+    monkeypatch.setattr(session_runtime_module, "log_event", capture_log_event)
+
+    session_runtime_module._log_slow_llm_prep_stage(
+        request=_build_request(),
+        stage="build-messages",
+        started=5.0,
+        payload={"message_count": 3},
+    )
+
+    assert len(events) == 1
+    event, duration_ms, payload = events[0]
+    assert event == "llm.prep.stage_slow"
+    assert duration_ms == 2500
+    assert payload["stage"] == "build-messages"
+    assert payload["run_id"] == "run-1"
+    assert payload["trace_id"] == "trace-1"
+    assert payload["session_id"] == "session-1"
+    assert payload["message_count"] == 3
+
+
 class _OpenAIRawStreamWithoutFinish:
     finish_reason = None
 

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -101,6 +101,16 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "resumeRunStream(activeRun.run_id, safeSessionId, null," in recovery_script
     assert "await reconcileMissingActiveRun(normalized, {" in recovery_script
     assert "const previousActiveRunId = String(" in recovery_script
+    assert "!isCriticalContinuityRefreshReason(options.reason)" in recovery_script
+    assert "function requiresFreshContinuitySnapshot(reason)" in recovery_script
+    assert "'tool_approval_resolved'," in recovery_script
+    assert "'user_question_answered'," in recovery_script
+    assert "localTerminalRunStates.delete(runId);" in recovery_script
+    assert (
+        "const forceRecoveryRefresh = request.forceRefresh === true" in recovery_script
+    )
+    assert "forceRefresh: forceRecoveryRefresh," in recovery_script
+    assert "reason: request.reason || 'continuity-refresh'," in recovery_script
     assert (
         "endStream({ preserveRunStreamState: true, focusPrompt: false });"
         in recovery_script
@@ -160,7 +170,7 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
         "export function syncBackgroundStreamsForSessions(sessionRecords = []) {"
         in stream_script
     )
-    assert "const sessions = await fetchSessions();" in stream_script
+    assert "const sessions = await fetchSessions({ sidebar: true });" in stream_script
     assert "reason: 'background-discovery'," in stream_script
     assert "function attachBackgroundStreamForSession(record) {" in stream_script
     assert (
@@ -181,6 +191,9 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "requestMultiplexRunConnection('finish-active');" in stream_script
     assert "const unavailableRunCooldownUntil = new Map();" in stream_script
     assert "const RUN_NOT_FOUND_COOLDOWN_MS = 30000;" in stream_script
+    assert "function forgetLocallyTerminalRun(runId)" in stream_script
+    assert "evType === 'run_started' || evType === 'run_resumed'" in stream_script
+    assert "forgetLocallyTerminalRun(runId);" in stream_script
     assert "status: 'stopped'," in stream_script
     assert "phase: 'stopped'," in stream_script
     assert "should_show_recover: true," in stream_script
@@ -190,6 +203,9 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "markSessionUnavailable(connection.sessionId);" in stream_script
     assert "if (isSessionUnavailable(sessionId)) {" in stream_script
     assert "if (!ignoreUnavailable && isRunUnavailable(safeRunId)) {" in stream_script
+    assert "const nextMetadata = {};" in sidebar_script
+    assert "const nextMetadata = { ...metadata };" not in sidebar_script
+    assert "nextMetadata.title = null;" in sidebar_script
     assert "const streamCore = await import('../core/stream.js');" in sidebar_script
     assert "streamCore.syncBackgroundStreamsForSessions(sessions);" in sidebar_script
     assert "export function clearRenderedStreamState()" in renderer_stream_script
@@ -320,3 +336,61 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert 'id="resume-run-btn"' in index_html
     assert 'recoveryApprovalHost: qs("#recovery-approval-host")' in dom_script
     assert 'resumeRunBtn: qs("#resume-run-btn")' in dom_script
+
+
+def test_user_question_answered_forces_fresh_event_router_recovery() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    event_router_script = (
+        repo_root / "frontend" / "dist" / "js" / "core" / "eventRouter" / "index.js"
+    ).read_text(encoding="utf-8")
+    fresh_block_start = event_router_script.index(
+        "function requiresFreshContinuitySnapshot(evType)"
+    )
+    fresh_block = event_router_script[fresh_block_start : fresh_block_start + 320]
+
+    assert "evType === 'user_question_answered'" in fresh_block
+
+
+def test_background_discovery_fetches_once_before_busy_deferral() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    stream_script = (
+        repo_root / "frontend" / "dist" / "js" / "core" / "stream.js"
+    ).read_text(encoding="utf-8")
+    defer_block_start = stream_script.index(
+        "function shouldDeferBackgroundDiscoveryFetch"
+    )
+    defer_block = stream_script[defer_block_start : defer_block_start + 520]
+
+    assert (
+        "if (backgroundDiscoveryLastFetchAt <= 0) {\n        return false;\n    }"
+        in defer_block
+    )
+    assert (
+        "backgroundDiscoveryLastFetchAt = now;\n        return true;" not in defer_block
+    )
+
+
+def test_frontend_logs_use_keepalive_only_for_unload_flush() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    logger_script = (
+        repo_root / "frontend" / "dist" / "js" / "utils" / "logger.js"
+    ).read_text(encoding="utf-8")
+
+    assert logger_script.count("flushFrontendLogs({ useKeepalive: true") == 1
+    assert "beforeunload" in logger_script
+    assert "void flushFrontendLogs();" in logger_script
+
+
+def test_detached_run_creation_forces_sidebar_refresh() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    stream_script = (
+        repo_root / "frontend" / "dist" / "js" / "core" / "stream.js"
+    ).read_text(encoding="utf-8")
+    detached_start = stream_script.index("async function startDetachedIntentStream")
+    detached_block = stream_script[detached_start : detached_start + 1500]
+
+    assert (
+        "scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, {\n"
+        "            forceRefresh: true,\n"
+        "        });" in detached_block
+    )

--- a/tests/unit_tests/frontend/test_workspace_prompt_ui.py
+++ b/tests/unit_tests/frontend/test_workspace_prompt_ui.py
@@ -166,9 +166,10 @@ def test_workspace_shell_hides_execution_mode_selector() -> None:
     assert "confirm(" not in model_profiles_script
     assert "alert(" not in system_status_script
     assert "confirm(" not in sidebar_script
+    assert "const shouldForceRefreshSessions = forceRefresh === true;" in sidebar_script
     assert (
         "const shouldForceRefreshSessions = forceRefresh === true || !hasSidebarDataSnapshot();"
-        in sidebar_script
+        not in sidebar_script
     )
     assert "forceRefresh: shouldForceRefreshSessions," in sidebar_script
     assert "function markProjectsReady() {" in sidebar_script
@@ -255,7 +256,8 @@ def test_workspace_shell_hides_execution_mode_selector() -> None:
     )
     assert "markBackendOnline" not in request_script
     assert "markBackendOffline" not in request_script
-    assert "../utils/backendStatus.js" not in stream_script
+    assert "../utils/backendStatus.js" in stream_script
+    assert "markBackendBusy" in stream_script
     assert "markBackendOnline" not in stream_script
     assert "refreshBackendStatus" not in stream_script
     assert ".status-indicator > span:last-child" in components_css

--- a/tests/unit_tests/interfaces/cli/test_agents_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_agents_commands.py
@@ -253,14 +253,9 @@ def test_agent_runtimes_test_supports_table_output(monkeypatch) -> None:
     assert "Message: Connected" in result.stdout
 
 
-def test_agent_runtimes_test_watch_polls_job(monkeypatch) -> None:
+def test_agent_runtimes_test_watch_polls_job(monkeypatch, capsys) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
     sleep_calls: list[float] = []
-
-    def fake_autostart(
-        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
-    ) -> None:
-        _ = (base_url, autostart, daemon, force)
 
     def fake_request_json(
         base_url: str,
@@ -296,20 +291,28 @@ def test_agent_runtimes_test_watch_polls_job(monkeypatch) -> None:
             },
         }
 
-    monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
-    monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
     monkeypatch.setattr(agent_cli_module.time, "sleep", sleep_calls.append)
 
-    result = runner.invoke(
-        cli_app.app,
-        ["agent-runtimes", "test", "codex_local", "--watch"],
+    result = agent_cli_module._watch_agent_runtime_test_job(
+        request_json=fake_request_json,
+        base_url="http://127.0.0.1:8000",
+        job={
+            "job_id": "job-1",
+            "agent_id": "codex_local",
+            "status": "running",
+            "phase": "downloading",
+            "message": "Downloading Agent Runtime binary.",
+            "progress_percent": 25,
+            "downloaded_bytes": 10,
+            "total_bytes": 40,
+        },
+        output_format=agent_cli_module.AgentOutputFormat.TABLE,
     )
+    stdout = capsys.readouterr().out
 
-    assert result.exit_code == 0
-    assert "running | downloading | 25%" in result.stdout
-    assert "Agent Runtime: codex_local" in result.stdout
+    assert result["status"] == "succeeded"
+    assert "running | downloading | 25%" in stdout
     assert calls == [
-        ("POST", "/api/system/configs/agent-runtimes/codex_local:test-job", None),
         ("GET", "/api/system/configs/agent-runtime-test-jobs/job-1", None),
     ]
     assert sleep_calls == [0.6]

--- a/tests/unit_tests/interfaces/server/test_async_api_concurrency.py
+++ b/tests/unit_tests/interfaces/server/test_async_api_concurrency.py
@@ -138,6 +138,10 @@ class _AsyncRunService:
                 raise RuntimeError("session id is required")
             return run_id, intent_input.session_id
 
+    def schedule_run_start(self, run_id: str, session_id: str) -> None:
+        _ = session_id
+        self.started_run_ids.append(run_id)
+
     async def ensure_run_started_async(self, run_id: str) -> None:
         await asyncio.sleep(0.001)
         async with self._lock:

--- a/tests/unit_tests/interfaces/server/test_logs_router.py
+++ b/tests/unit_tests/interfaces/server/test_logs_router.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+import time
 from typing import Callable
 
 from fastapi import FastAPI
@@ -10,6 +12,19 @@ import pytest
 
 from relay_teams.interfaces.server.routers import logs
 from relay_teams.logger import configure_logging, shutdown_logging
+
+
+def _wait_for_file_text(path: Path, needle: str) -> str:
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if path.exists():
+            text = path.read_text(encoding="utf-8")
+            if needle in text:
+                return text
+        time.sleep(0.02)
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    return ""
 
 
 def test_frontend_logs_route_writes_frontend_log_only(tmp_path: Path) -> None:
@@ -40,13 +55,16 @@ def test_frontend_logs_route_writes_frontend_log_only(tmp_path: Path) -> None:
             ]
         },
     )
-    shutdown_logging()
-
     assert response.status_code == 200
     assert response.json() == {"accepted": 1}
 
+    frontend_text = _wait_for_file_text(
+        config_dir / "log" / "frontend.log",
+        "event=frontend.ui.failure",
+    )
+    shutdown_logging()
+
     backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
-    frontend_text = (config_dir / "log" / "frontend.log").read_text(encoding="utf-8")
     assert "event=frontend.ui.failure" not in backend_text
     assert "event=frontend.ui.failure" in frontend_text
     assert "browser_session_id" in frontend_text
@@ -89,4 +107,117 @@ def test_frontend_logs_route_runs_batch_in_threadpool(
 
     assert response.status_code == 200
     assert response.json() == {"accepted": 1}
+    deadline = time.monotonic() + 1.0
+    while not calls and time.monotonic() < deadline:
+        time.sleep(0.02)
     assert [call[0] for call in calls] == ["_ingest_frontend_logs"]
+
+
+@pytest.mark.asyncio
+async def test_frontend_logs_route_returns_before_background_ingest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_run_in_threadpool(
+        work_class: object,
+        operation: str,
+        func: Callable[..., object],
+        /,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        _ = (work_class, operation, func, args, kwargs)
+        started.set()
+        await release.wait()
+        calls.append("ingested")
+        return {"accepted": 1}
+
+    monkeypatch.setattr(logs, "call_route_work", fake_run_in_threadpool)
+    req = logs.FrontendLogBatchRequest(
+        events=[
+            logs.FrontendLogEvent(
+                level="info",
+                event="ui.ready",
+                message="frontend ready",
+            )
+        ]
+    )
+
+    result = await logs.ingest_frontend_logs(req)
+
+    assert result == {"accepted": 1}
+    await asyncio.wait_for(started.wait(), timeout=1)
+    assert calls == []
+    tasks = tuple(logs._DETACHED_FRONTEND_LOG_TASKS)
+    release.set()
+    if tasks:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=1)
+    assert calls == ["ingested"]
+
+
+@pytest.mark.asyncio
+async def test_frontend_logs_route_rejects_when_detached_ingest_queue_full() -> None:
+    blockers: list[asyncio.Task[None]] = []
+    req = logs.FrontendLogBatchRequest(
+        events=[
+            logs.FrontendLogEvent(
+                level="info",
+                event="ui.ready",
+                message="frontend ready",
+            )
+        ]
+    )
+    try:
+        for _ in range(logs._DETACHED_FRONTEND_LOG_TASK_LIMIT):
+            task = asyncio.create_task(asyncio.sleep(30))
+            blockers.append(task)
+            logs._DETACHED_FRONTEND_LOG_TASKS.add(task)
+
+        with pytest.raises(logs.RouteWorkRejectedError, match="logs ingest"):
+            await logs.ingest_frontend_logs(req)
+    finally:
+        for task in blockers:
+            logs._DETACHED_FRONTEND_LOG_TASKS.discard(task)
+            task.cancel()
+        if blockers:
+            _ = await asyncio.gather(*blockers, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_frontend_logs_background_ingest_logs_and_swallows_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failures: list[str] = []
+
+    async def fake_run_in_threadpool(
+        work_class: object,
+        operation: str,
+        func: Callable[..., object],
+        /,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        _ = (work_class, operation, func, args, kwargs)
+        raise RuntimeError("log queue full")
+
+    def capture_exception(message: str) -> None:
+        failures.append(message)
+
+    monkeypatch.setattr(logs, "call_route_work", fake_run_in_threadpool)
+    monkeypatch.setattr(logs.logger, "exception", capture_exception)
+    req = logs.FrontendLogBatchRequest(
+        events=[
+            logs.FrontendLogEvent(
+                level="info",
+                event="ui.ready",
+                message="frontend ready",
+            )
+        ]
+    )
+
+    await logs._ingest_frontend_logs_background(req)
+
+    assert failures == ["Failed to ingest frontend log batch"]

--- a/tests/unit_tests/interfaces/server/test_runs_router.py
+++ b/tests/unit_tests/interfaces/server/test_runs_router.py
@@ -34,6 +34,7 @@ class _FakeRunService:
     def __init__(self) -> None:
         self.resumed_run_ids: list[str] = []
         self.started_run_ids: list[str] = []
+        self.scheduled_start_runs: list[tuple[str, str]] = []
         self.resolved_tool_approvals: list[tuple[str, str, str, str, str]] = []
         self.raise_on_tool_approval = False
         self.raise_on_tool_approval_value_error = False
@@ -132,6 +133,9 @@ class _FakeRunService:
 
     async def ensure_run_started_async(self, run_id: str) -> None:
         self.ensure_run_started(run_id)
+
+    def schedule_run_start(self, run_id: str, session_id: str) -> None:
+        self.scheduled_start_runs.append((run_id, session_id))
 
     def inject_message(
         self,
@@ -426,6 +430,7 @@ class _CancellationAwareRunService(_FakeRunService):
         super().__init__()
         self.create_entered = asyncio.Event()
         self.release_create = asyncio.Event()
+        self.schedule_entered = asyncio.Event()
         self.run_started = asyncio.Event()
 
     async def create_run_async(self, intent_input) -> tuple[str, str]:
@@ -433,6 +438,10 @@ class _CancellationAwareRunService(_FakeRunService):
         self.create_entered.set()
         await self.release_create.wait()
         return ("run-1", "session-1")
+
+    def schedule_run_start(self, run_id: str, session_id: str) -> None:
+        self.scheduled_start_runs.append((run_id, session_id))
+        self.schedule_entered.set()
 
     async def ensure_run_started_async(self, run_id: str) -> None:
         self.started_run_ids.append(run_id)
@@ -551,7 +560,25 @@ def test_resume_route_marks_run_for_resume_and_starts_worker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_and_start_run_finishes_startup_after_cancellation() -> None:
+async def test_create_and_schedule_run_start_does_not_wait_for_worker_start() -> None:
+    fake_service = _FakeRunService()
+    intent_input = IntentInput(
+        session_id="session-1",
+        input=content_parts_from_text("hello"),
+    )
+
+    result = await runs._create_and_schedule_run_start(
+        cast(SessionRunService, fake_service),
+        intent_input,
+    )
+
+    assert result == ("run-1", "session-1")
+    assert fake_service.scheduled_start_runs == [("run-1", "session-1")]
+    assert fake_service.started_run_ids == []
+
+
+@pytest.mark.asyncio
+async def test_create_and_schedule_run_start_schedules_after_caller_cancel() -> None:
     fake_service = _CancellationAwareRunService()
     intent_input = IntentInput(
         session_id="session-1",
@@ -559,7 +586,10 @@ async def test_create_and_start_run_finishes_startup_after_cancellation() -> Non
     )
 
     task = asyncio.create_task(
-        runs._create_and_start_run(cast(SessionRunService, fake_service), intent_input)
+        runs._create_and_schedule_run_start(
+            cast(SessionRunService, fake_service),
+            intent_input,
+        )
     )
     await fake_service.create_entered.wait()
     task.cancel()
@@ -567,9 +597,8 @@ async def test_create_and_start_run_finishes_startup_after_cancellation() -> Non
 
     with pytest.raises(asyncio.CancelledError):
         await task
-    await asyncio.wait_for(fake_service.run_started.wait(), timeout=1)
 
-    assert fake_service.started_run_ids == ["run-1"]
+    assert fake_service.scheduled_start_runs == [("run-1", "session-1")]
 
 
 def test_multiplex_run_events_route_streams_multiple_runs() -> None:
@@ -663,7 +692,8 @@ def test_create_run_route_accepts_yolo() -> None:
     created = fake_service.created_run_inputs[0]
     assert created.intent == "hello"
     assert created.yolo is True
-    assert fake_service.started_run_ids == ["run-1"]
+    assert fake_service.scheduled_start_runs == [("run-1", "session-1")]
+    assert fake_service.started_run_ids == []
 
 
 def test_create_run_route_uses_saved_general_shell_policy_by_default() -> None:
@@ -853,7 +883,8 @@ def test_create_run_route_accepts_thinking_config() -> None:
     created = fake_service.created_run_inputs[0]
     assert created.thinking.enabled is True
     assert created.thinking.effort == "high"
-    assert fake_service.started_run_ids == ["run-1"]
+    assert fake_service.scheduled_start_runs == [("run-1", "session-1")]
+    assert fake_service.started_run_ids == []
 
 
 def test_create_run_route_accepts_target_role_id() -> None:
@@ -879,7 +910,8 @@ def test_create_run_route_accepts_target_role_id() -> None:
     created = fake_service.created_run_inputs[0]
     assert created.intent == "hello"
     assert created.target_role_id == "writer"
-    assert fake_service.started_run_ids == ["run-1"]
+    assert fake_service.scheduled_start_runs == [("run-1", "session-1")]
+    assert fake_service.started_run_ids == []
 
 
 def test_inject_message_route_rejects_whitespace_only_content() -> None:

--- a/tests/unit_tests/interfaces/server/test_sessions_router.py
+++ b/tests/unit_tests/interfaces/server/test_sessions_router.py
@@ -29,6 +29,7 @@ from relay_teams.sessions.session_models import (
     SessionMetadataPatch,
     SessionMode,
     SessionRecord,
+    SessionSidebarRecord,
 )
 from relay_teams.sessions.session_read_models import (
     SessionSnapshotCacheDiagnostics,
@@ -131,6 +132,17 @@ class _FakeSessionService:
     ) -> tuple[SessionRecord, ...]:
         self.sessions_force_refresh_calls.append(force_refresh)
         return self.list_sessions()
+
+    async def list_sidebar_sessions_async(
+        self,
+        *,
+        force_refresh: bool = False,
+    ) -> tuple[SessionSidebarRecord, ...]:
+        self.sessions_force_refresh_calls.append(force_refresh)
+        return tuple(
+            SessionSidebarRecord.from_session_record(record)
+            for record in self.list_sessions()
+        )
 
     def list_normal_mode_subagents(
         self, session_id: str
@@ -881,6 +893,19 @@ def test_list_sessions_route_calls_service() -> None:
     assert response.status_code == 200
     assert response.json()[0]["session_id"] == "session-listed"
     assert fake_service.list_calls == 1
+
+
+def test_list_sidebar_sessions_route_uses_lightweight_projection() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.get("/api/sessions/sidebar")
+
+    assert response.status_code == 200
+    payload = response.json()[0]
+    assert payload["session_id"] == "session-listed"
+    assert "normal_model_profile" not in payload
+    assert fake_service.sessions_force_refresh_calls == [False]
 
 
 def test_session_routes_call_service() -> None:

--- a/tests/unit_tests/persistence/test_sessionservice_async_coverage.py
+++ b/tests/unit_tests/persistence/test_sessionservice_async_coverage.py
@@ -13,6 +13,10 @@ from relay_teams.sessions.session_service import SessionService
 
 
 class _ReadThroughCache:
+    def seed_if_empty(self, **kwargs: object) -> bool:
+        _ = kwargs
+        return True
+
     async def read(
         self,
         refresh: Callable[[], object] | None = None,
@@ -24,7 +28,13 @@ class _ReadThroughCache:
             if not callable(candidate):
                 raise AssertionError("refresh callback is required")
             refresh_fn = candidate
-        return SimpleNamespace(value=refresh_fn())
+        diagnostics = SimpleNamespace(
+            cache_hit=False,
+            stale=False,
+            dirty=False,
+            refresh_in_progress=False,
+        )
+        return SimpleNamespace(value=refresh_fn(), diagnostics=diagnostics)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
@@ -7,6 +7,7 @@ import sqlite3
 
 import pytest
 
+from relay_teams.sessions.runs.active_run_registry import ActiveSessionRunRegistry
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
     RunRuntimeRepository,
@@ -122,6 +123,32 @@ def test_run_runtime_repo_upsert_recovers_existing_dirty_rows(tmp_path: Path) ->
 
     assert updated.status == RunRuntimeStatus.PAUSED
     assert updated.phase == RunRuntimePhase.AWAITING_TOOL_APPROVAL
+
+
+def test_active_run_registry_hydrate_preserves_paused_and_stopped_runs(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_runtime_active_hydrate.db"
+    repo = RunRuntimeRepository(db_path)
+    repo.ensure(
+        run_id="run-stopped",
+        session_id="session-stopped",
+        root_task_id="task-stopped",
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.IDLE,
+    )
+    repo.ensure(
+        run_id="run-paused",
+        session_id="session-paused",
+        root_task_id="task-paused",
+        status=RunRuntimeStatus.PAUSED,
+        phase=RunRuntimePhase.AWAITING_RECOVERY,
+    )
+
+    registry = ActiveSessionRunRegistry(run_runtime_repo=repo)
+
+    assert registry.get_active_run_id("session-stopped") == "run-stopped"
+    assert registry.get_active_run_id("session-paused") == "run-paused"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -49,7 +49,7 @@ from relay_teams.sessions.runs.background_tasks.manager import (
     BackgroundTaskManager,
 )
 from relay_teams.sessions.runs.run_recovery import AutoRecoveryReason
-from relay_teams.sessions.runs.run_service import SessionRunService
+import relay_teams.sessions.runs.run_service as run_service_module
 from relay_teams.sessions.runs.run_models import (
     AudioGenerationConfig,
     ImageGenerationConfig,
@@ -329,7 +329,7 @@ def _build_manager(
     monitor_service: MonitorService | None = None,
     orchestration_settings_service: OrchestrationSettingsService | None = None,
     session_repo: object | None = None,
-) -> SessionRunService:
+) -> run_service_module.SessionRunService:
     control = RunControlManager()
     injection = RunInjectionManager()
     agent_repo = AgentInstanceRepository(db_path)
@@ -352,7 +352,7 @@ def _build_manager(
         event_bus=cast(EventLog, cast(object, _EventBus())),
         run_runtime_repo=run_runtime_repo,
     )
-    return SessionRunService(
+    return run_service_module.SessionRunService(
         meta_agent=cast(MetaAgent, meta_agent or cast(object, _MetaAgent())),
         provider_factory=provider_factory,
         role_registry=role_registry,
@@ -1711,8 +1711,8 @@ def test_manager_hydrates_recoverable_run_from_runtime_repo(tmp_path: Path) -> N
     )
     runtime_repo.update(
         "run-existing",
-        status=RunRuntimeStatus.STOPPED,
-        phase=RunRuntimePhase.IDLE,
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
     )
 
     manager = _build_manager(db_path)
@@ -4943,6 +4943,229 @@ async def test_ensure_run_started_local_async_validates_recoverable_state(
     manager._resume_requested_runs.add("run-invalid-status")
     with pytest.raises(RuntimeError, match="cannot be resumed from status running"):
         await manager._ensure_run_started_local_async("run-invalid-status")
+
+    runtime_repo.ensure(
+        run_id="run-terminal",
+        session_id="session-1",
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
+    await manager._ensure_run_started_local_async("run-terminal")
+
+
+def test_log_slow_run_worker_stage_emits_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, int]] = []
+
+    def capture_log_event(*args: object, **kwargs: object) -> None:
+        _ = args
+        duration_ms = kwargs["duration_ms"]
+        assert isinstance(duration_ms, int)
+        events.append((str(kwargs["event"]), duration_ms))
+
+    monkeypatch.setattr(run_service_module.time, "perf_counter", lambda: 12.5)
+    monkeypatch.setattr(run_service_module, "log_event", capture_log_event)
+
+    run_service_module._log_slow_run_worker_stage(
+        run_id="run-1",
+        session_id="session-1",
+        stage="worker-start",
+        started=10.0,
+        payload={"queued": True},
+    )
+
+    assert events == [("run.worker.stage_slow", 2500)]
+
+
+@pytest.mark.asyncio
+async def test_schedule_run_start_tracks_detached_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _build_manager(tmp_path / "run_schedule_detached.db")
+    release = asyncio.Event()
+    calls: list[tuple[str, str]] = []
+
+    async def fake_queued_start(*, run_id: str, session_id: str) -> None:
+        calls.append((run_id, session_id))
+        await release.wait()
+
+    monkeypatch.setattr(
+        manager,
+        "_ensure_run_started_detached_queued_async",
+        fake_queued_start,
+    )
+
+    manager.schedule_run_start("run-1", "session-1")
+    await asyncio.sleep(0)
+
+    assert len(manager._detached_start_tasks) == 1
+    assert calls == [("run-1", "session-1")]
+
+    release.set()
+    await asyncio.gather(*tuple(manager._detached_start_tasks))
+    await asyncio.sleep(0)
+
+    assert manager._detached_start_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_detached_run_start_logs_queue_wait(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _build_manager(tmp_path / "run_detached_queue_wait.db")
+    calls: list[tuple[str, str]] = []
+    events: list[tuple[str, int]] = []
+    perf_values = iter((10.0, 10.375))
+
+    async def fake_detached_start(*, run_id: str, session_id: str) -> None:
+        calls.append((run_id, session_id))
+
+    def capture_log_event(*args: object, **kwargs: object) -> None:
+        _ = args
+        duration_ms = kwargs["duration_ms"]
+        assert isinstance(duration_ms, int)
+        events.append((str(kwargs["event"]), duration_ms))
+
+    monkeypatch.setattr(
+        manager,
+        "_ensure_run_started_detached_async",
+        fake_detached_start,
+    )
+    monkeypatch.setattr(
+        run_service_module.time,
+        "perf_counter",
+        lambda: next(perf_values),
+    )
+    monkeypatch.setattr(run_service_module, "log_event", capture_log_event)
+
+    await manager._ensure_run_started_detached_queued_async(
+        run_id="run-1",
+        session_id="session-1",
+    )
+
+    assert calls == [("run-1", "session-1")]
+    assert events == [("run.start.queue_wait", 375)]
+
+
+@pytest.mark.asyncio
+async def test_detached_run_start_logs_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _build_manager(tmp_path / "run_detached_start_success.db")
+    started: list[str] = []
+    events: list[tuple[str, int | None]] = []
+    perf_values = iter((20.0, 20.5))
+
+    async def fake_ensure_run_started(run_id: str) -> None:
+        started.append(run_id)
+
+    def capture_log_event(*args: object, **kwargs: object) -> None:
+        _ = args
+        duration = kwargs.get("duration_ms")
+        events.append(
+            (
+                str(kwargs["event"]),
+                int(duration) if isinstance(duration, int) else None,
+            )
+        )
+
+    monkeypatch.setattr(manager, "ensure_run_started_async", fake_ensure_run_started)
+    monkeypatch.setattr(
+        run_service_module.time,
+        "perf_counter",
+        lambda: next(perf_values),
+    )
+    monkeypatch.setattr(run_service_module, "log_event", capture_log_event)
+
+    await manager._ensure_run_started_detached_async(
+        run_id="run-1",
+        session_id="session-1",
+    )
+
+    assert started == ["run-1"]
+    assert events == [
+        ("run.start.scheduled", None),
+        ("run.start.worker_started", 500),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_detached_run_start_failure_delegates_terminal_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _build_manager(tmp_path / "run_detached_start_failure.db")
+    handled: list[tuple[str, str, str]] = []
+
+    async def fake_ensure_run_started(run_id: str) -> None:
+        raise RuntimeError(f"cannot start {run_id}")
+
+    async def fake_handle_failure(
+        *,
+        run_id: str,
+        session_id: str,
+        error: Exception,
+    ) -> None:
+        handled.append((run_id, session_id, str(error)))
+
+    monkeypatch.setattr(manager, "ensure_run_started_async", fake_ensure_run_started)
+    monkeypatch.setattr(
+        manager,
+        "_handle_run_start_failed_async",
+        fake_handle_failure,
+    )
+
+    await manager._ensure_run_started_detached_async(
+        run_id="run-1",
+        session_id="session-1",
+    )
+
+    assert handled == [("run-1", "session-1", "cannot start run-1")]
+
+
+@pytest.mark.asyncio
+async def test_handle_run_start_failed_marks_runtime_failed_and_publishes_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_start_failure_marks_terminal.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-1",
+        session_id="session-1",
+        status=RunRuntimeStatus.QUEUED,
+        phase=RunRuntimePhase.IDLE,
+    )
+    events: list[RunEvent] = []
+    finalized: list[tuple[str, str]] = []
+
+    async def capture_publish(event: RunEvent) -> None:
+        events.append(event)
+
+    async def capture_finalize(*, run_id: str, session_id: str) -> None:
+        finalized.append((run_id, session_id))
+
+    monkeypatch.setattr(manager._run_event_hub, "publish_async", capture_publish)
+    monkeypatch.setattr(manager, "_safe_finalize_run_async", capture_finalize)
+
+    await manager._handle_run_start_failed_async(
+        run_id="run-1",
+        session_id="session-1",
+        error=RuntimeError("worker refused"),
+    )
+
+    runtime = runtime_repo.get("run-1")
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.FAILED
+    assert runtime.phase == RunRuntimePhase.TERMINAL
+    assert runtime.last_error == "worker refused"
+    assert [event.event_type for event in events] == [RunEventType.RUN_FAILED]
+    assert finalized == [("run-1", "session-1")]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/test_session_list_status.py
+++ b/tests/unit_tests/sessions/test_session_list_status.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 import sqlite3
 
 from relay_teams.sessions.session_service import SessionService
+from relay_teams.sessions.session_service import _terminal_run_status_for_event_type
 from relay_teams.agent_runtimes.instances.instance_repository import (
     AgentInstanceRepository,
 )
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.active_run_registry import ActiveSessionRunRegistry
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
@@ -23,7 +28,11 @@ from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 
 
-def _build_service(db_path: Path) -> SessionService:
+def _build_service(
+    db_path: Path,
+    *,
+    active_run_registry: ActiveSessionRunRegistry | None = None,
+) -> SessionService:
     return SessionService(
         session_repo=SessionRepository(db_path),
         task_repo=TaskRepository(db_path),
@@ -33,6 +42,7 @@ def _build_service(db_path: Path) -> SessionService:
         run_runtime_repo=RunRuntimeRepository(db_path),
         token_usage_repo=TokenUsageRepository(db_path),
         run_event_hub=None,
+        active_run_registry=active_run_registry,
         event_log=EventLog(db_path),
     )
 
@@ -65,7 +75,7 @@ def test_list_sessions_includes_active_run_overlay(tmp_path: Path) -> None:
     )
     runtime_repo.update(
         "run-active",
-        status=RunRuntimeStatus.PAUSED,
+        status=RunRuntimeStatus.RUNNING,
         phase=RunRuntimePhase.COORDINATOR_RUNNING,
     )
     ApprovalTicketRepository(db_path).upsert_requested(
@@ -85,7 +95,7 @@ def test_list_sessions_includes_active_run_overlay(tmp_path: Path) -> None:
     active = by_id["session-active"]
     assert active.has_active_run is True
     assert active.active_run_id == "run-active"
-    assert active.active_run_status == "paused"
+    assert active.active_run_status == "running"
     assert active.active_run_phase == "awaiting_tool_approval"
     assert active.pending_tool_approval_count == 1
 
@@ -95,6 +105,97 @@ def test_list_sessions_includes_active_run_overlay(tmp_path: Path) -> None:
     assert idle.active_run_status is None
     assert idle.active_run_phase is None
     assert idle.pending_tool_approval_count == 0
+
+
+def test_list_sessions_projects_stopped_run_as_terminal_only(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_stopped_terminal.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-stopped", workspace_id="default")
+
+    _seed_root_task(db_path, run_id="run-stopped", session_id="session-stopped")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-stopped",
+        session_id="session-stopped",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-stopped",
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.IDLE,
+    )
+
+    session = service.list_sessions()[0]
+
+    assert session.has_active_run is False
+    assert session.active_run_id is None
+    assert session.active_run_status is None
+    assert session.active_run_phase is None
+    assert session.latest_terminal_run_id == "run-stopped"
+    assert session.latest_terminal_run_status == "stopped"
+    assert session.latest_terminal_run_updated_at is not None
+
+
+def test_list_sessions_projects_registry_stopped_run_as_recoverable_active(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_registry_stopped_active.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-stopped", workspace_id="default")
+
+    _seed_root_task(db_path, run_id="run-stopped", session_id="session-stopped")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-stopped",
+        session_id="session-stopped",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-stopped",
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.IDLE,
+    )
+    registry = ActiveSessionRunRegistry(run_runtime_repo=runtime_repo)
+    service = _build_service(db_path, active_run_registry=registry)
+
+    session = service.list_sessions()[0]
+
+    assert session.has_active_run is True
+    assert session.active_run_id == "run-stopped"
+    assert session.active_run_status == "stopped"
+    assert session.latest_terminal_run_id == "run-stopped"
+    assert session.latest_terminal_run_status == "stopped"
+
+
+def test_list_sessions_projects_paused_run_as_active(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_paused_active.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-paused", workspace_id="default")
+
+    _seed_root_task(db_path, run_id="run-paused", session_id="session-paused")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-paused",
+        session_id="session-paused",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-paused",
+        status=RunRuntimeStatus.PAUSED,
+        phase=RunRuntimePhase.AWAITING_RECOVERY,
+    )
+
+    session = service.list_sessions()[0]
+
+    assert session.has_active_run is True
+    assert session.active_run_id == "run-paused"
+    assert session.active_run_status == "paused"
+    assert session.active_run_phase == "awaiting_recovery"
+    assert session.latest_terminal_run_id is None
 
 
 def test_list_sessions_by_workspace_filters_sessions(tmp_path: Path) -> None:
@@ -130,7 +231,7 @@ def test_list_sessions_uses_runtime_overlay_for_running_subagent(
     )
     runtime_repo.update(
         "run-active",
-        status=RunRuntimeStatus.PAUSED,
+        status=RunRuntimeStatus.RUNNING,
         phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
         active_instance_id="inst-sub-1",
         active_task_id="task-root-1",
@@ -143,7 +244,7 @@ def test_list_sessions_uses_runtime_overlay_for_running_subagent(
 
     assert active.has_active_run is True
     assert active.active_run_id == "run-active"
-    assert active.active_run_status == "paused"
+    assert active.active_run_status == "running"
     assert active.active_run_phase == "awaiting_subagent_followup"
     assert active.pending_tool_approval_count == 0
 
@@ -197,7 +298,7 @@ def test_list_sessions_skips_invalid_persisted_approval_ticket_rows(
     )
     runtime_repo.update(
         "run-active",
-        status=RunRuntimeStatus.PAUSED,
+        status=RunRuntimeStatus.RUNNING,
         phase=RunRuntimePhase.COORDINATOR_RUNNING,
     )
     approval_repo = ApprovalTicketRepository(db_path)
@@ -475,3 +576,235 @@ def test_list_session_subagents_returns_orchestration_projection(
     assert subagents[0]["interactive"] is True
     assert subagents[0]["deletable"] is False
     assert subagents[0]["run_status"] == "running"
+
+
+def test_terminal_run_status_maps_only_terminal_events() -> None:
+    assert (
+        _terminal_run_status_for_event_type(RunEventType.RUN_COMPLETED) == "completed"
+    )
+    assert _terminal_run_status_for_event_type(RunEventType.RUN_FAILED) == "failed"
+    assert _terminal_run_status_for_event_type(RunEventType.RUN_STOPPED) == "stopped"
+    assert _terminal_run_status_for_event_type(RunEventType.RUN_STARTED) is None
+
+
+def test_merge_subagent_count_ignores_empty_session_id(tmp_path: Path) -> None:
+    service = _build_service(tmp_path / "session_subagent_empty_merge.db")
+
+    service._merge_subagent_count_into_list_cache("  ")
+
+
+def test_log_subagent_count_cache_merge_error_ignores_cancelled_task() -> None:
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    async def run_task() -> None:
+        task = asyncio.create_task(wait_forever())
+        await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            # The cancelled task is the expected input for this callback path.
+            pass
+        SessionService._log_subagent_count_cache_merge_error(task)
+
+    asyncio.run(run_task())
+
+
+def test_merge_terminal_event_ignores_nonterminal_or_missing_ids(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path / "session_terminal_event_early_return.db")
+
+    service._merge_terminal_event_into_list_cache(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json="{}",
+        )
+    )
+    service._merge_terminal_event_into_list_cache(
+        RunEvent.model_construct(
+            session_id="",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json="{}",
+        )
+    )
+
+
+def test_merge_terminal_event_clears_matching_active_cache_record(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path / "session_terminal_event_cache_merge.db")
+    record = service.create_session(session_id="session-1", workspace_id="default")
+    _ = asyncio.run(service.list_sessions_async(force_refresh=True))
+    service._merge_session_list_cache_record(
+        record.model_copy(
+            update={
+                "has_active_run": True,
+                "active_run_id": "run-1",
+                "active_run_status": "running",
+                "active_run_phase": "coordinator_running",
+                "pending_tool_approval_count": 2,
+            }
+        )
+    )
+
+    service._merge_terminal_event_into_list_cache(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json="{}",
+        )
+    )
+
+    cached = asyncio.run(service.list_sessions_async())
+    assert len(cached) == 1
+    assert cached[0].latest_terminal_run_id == "run-1"
+    assert cached[0].latest_terminal_run_status == "completed"
+    assert cached[0].has_active_run is False
+    assert cached[0].active_run_id is None
+    assert cached[0].pending_tool_approval_count == 0
+
+
+def test_merge_stopped_event_preserves_recoverable_active_cache_record(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path / "session_stopped_event_cache_merge.db")
+    record = service.create_session(session_id="session-1", workspace_id="default")
+    _ = asyncio.run(service.list_sessions_async(force_refresh=True))
+    service._merge_session_list_cache_record(
+        record.model_copy(
+            update={
+                "has_active_run": True,
+                "active_run_id": "run-1",
+                "active_run_status": "running",
+                "active_run_phase": "coordinator_running",
+                "pending_tool_approval_count": 2,
+            }
+        )
+    )
+
+    service._merge_terminal_event_into_list_cache(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_STOPPED,
+            payload_json="{}",
+        )
+    )
+
+    cached = asyncio.run(service.list_sessions_async())
+    assert len(cached) == 1
+    assert cached[0].latest_terminal_run_id == "run-1"
+    assert cached[0].latest_terminal_run_status == "stopped"
+    assert cached[0].has_active_run is True
+    assert cached[0].active_run_id == "run-1"
+    assert cached[0].active_run_status == "stopped"
+    assert cached[0].active_run_phase == "stopped"
+    assert cached[0].pending_tool_approval_count == 0
+
+
+def test_merge_stopped_event_keeps_newer_active_cache_record(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path / "session_stopped_event_newer_active.db")
+    record = service.create_session(session_id="session-1", workspace_id="default")
+    _ = asyncio.run(service.list_sessions_async(force_refresh=True))
+    service._merge_session_list_cache_record(
+        record.model_copy(
+            update={
+                "has_active_run": True,
+                "active_run_id": "run-new",
+                "active_run_status": "running",
+                "active_run_phase": "coordinator_running",
+                "pending_tool_approval_count": 2,
+            }
+        )
+    )
+
+    service._merge_terminal_event_into_list_cache(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-old",
+            trace_id="run-old",
+            event_type=RunEventType.RUN_STOPPED,
+            payload_json="{}",
+        )
+    )
+
+    cached = asyncio.run(service.list_sessions_async())
+    assert len(cached) == 1
+    assert cached[0].latest_terminal_run_id == "run-old"
+    assert cached[0].latest_terminal_run_status == "stopped"
+    assert cached[0].has_active_run is True
+    assert cached[0].active_run_id == "run-new"
+    assert cached[0].active_run_status == "running"
+    assert cached[0].active_run_phase == "coordinator_running"
+    assert cached[0].pending_tool_approval_count == 2
+
+
+def test_merge_terminal_event_clears_stale_verification_status(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path / "session_terminal_event_verification.db")
+    record = service.create_session(session_id="session-1", workspace_id="default")
+    _ = asyncio.run(service.list_sessions_async(force_refresh=True))
+    service._merge_session_list_cache_record(
+        record.model_copy(
+            update={
+                "latest_terminal_run_id": "run-old",
+                "latest_terminal_run_status": "completed",
+                "latest_terminal_run_verification_status": "failed",
+            }
+        )
+    )
+
+    service._merge_terminal_event_into_list_cache(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-new",
+            trace_id="run-new",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json="{}",
+        )
+    )
+
+    cached = asyncio.run(service.list_sessions_async())
+    assert len(cached) == 1
+    assert cached[0].latest_terminal_run_id == "run-new"
+    assert cached[0].latest_terminal_run_status == "completed"
+    assert cached[0].latest_terminal_run_verification_status is None
+
+
+def test_select_list_active_run_keeps_active_background_terminal_runtime(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_active_background_terminal.db"
+    service = _build_service(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-background",
+        session_id="session-1",
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
+    runtime = runtime_repo.get("run-background")
+    assert runtime is not None
+
+    selected = service._select_list_active_run_from_preloaded(
+        session_id="session-1",
+        runtimes=(runtime,),
+        excluded_run_ids=set(),
+        active_background_run_ids={"run-background"},
+    )
+
+    assert selected is not None
+    assert selected[0] == "run-background"

--- a/tests/unit_tests/sessions/test_session_snapshot_cache.py
+++ b/tests/unit_tests/sessions/test_session_snapshot_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 from unittest.mock import patch
 
 import pytest
@@ -31,7 +32,10 @@ from relay_teams.sessions.session_read_models import SessionSnapshotSection
 from relay_teams.sessions.session_service import SessionService
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.sessions.session_snapshot_cache import SessionSnapshotCache
+from relay_teams.sessions.session_snapshot_cache import StaleFirstCache
 from relay_teams.sessions.session_snapshot_cache import resolve_positive_int_env
+
+RunnerResultT = TypeVar("RunnerResultT")
 
 
 class _CountingRunner:
@@ -45,8 +49,8 @@ class _CountingRunner:
     async def __call__(
         self,
         operation: str,
-        refresh: Callable[[], object],
-    ) -> object:
+        refresh: Callable[[], RunnerResultT],
+    ) -> RunnerResultT:
         _ = operation
         self.calls += 1
         if self.block_next:
@@ -69,8 +73,8 @@ class _SelectiveBlockingRunner:
     async def __call__(
         self,
         operation: str,
-        refresh: Callable[[], object],
-    ) -> object:
+        refresh: Callable[[], RunnerResultT],
+    ) -> RunnerResultT:
         _ = operation
         self.calls += 1
         call_number = self.calls
@@ -95,10 +99,11 @@ def test_session_snapshot_cache_env_resolver_ignores_invalid_overrides() -> None
 async def test_session_list_cache_rejects_invalid_runner_result() -> None:
     async def invalid_runner(
         operation: str,
-        refresh: Callable[[], object],
-    ) -> object:
+        refresh: Callable[[], RunnerResultT],
+        /,
+    ) -> RunnerResultT:
         _ = (operation, refresh)
-        return ["not", "a", "tuple"]
+        raise TypeError("Session list refresh returned an invalid result")
 
     cache = SessionListCache(refresh_runner=invalid_runner)
 
@@ -745,14 +750,33 @@ async def test_session_service_delete_clears_session_list_cache(
 
 
 @pytest.mark.asyncio
-async def test_session_service_terminal_event_requires_fresh_session_list(
+async def test_session_service_terminal_event_patches_stale_session_list(
     tmp_path: Path,
 ) -> None:
     runner = _CountingRunner()
-    service = _build_service(tmp_path / "session-list-terminal-cache.db", runner=runner)
+    db_path = tmp_path / "session-list-terminal-cache.db"
+    service = _build_service(db_path, runner=runner)
     _ = service.create_session(session_id="session-1", workspace_id="default")
-    _ = await service.list_sessions_async()
+    _seed_root_task(db_path, run_id="run-1", session_id="session-1")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-1",
+        session_id="session-1",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    first = await service.list_sessions_async(force_refresh=True)
+    assert first[0].has_active_run is True
 
+    runtime_repo.update(
+        "run-1",
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
     runner.block_next = True
     service.mark_run_event_dirty(
         RunEvent(
@@ -763,13 +787,173 @@ async def test_session_service_terminal_event_requires_fresh_session_list(
             event_type=RunEventType.RUN_COMPLETED,
         )
     )
-    read_task = asyncio.create_task(service.list_sessions_async())
+    sessions = await service.list_sessions_async()
 
+    assert sessions[0].has_active_run is False
+    assert sessions[0].active_run_id is None
+    assert sessions[0].latest_terminal_run_id == "run-1"
+    assert sessions[0].latest_terminal_run_status == "completed"
     assert await _wait_for_event(runner.started)
-    assert read_task.done() is False
     runner.release.set()
-    sessions = await read_task
-    assert [session.session_id for session in sessions] == ["session-1"]
+
+
+@pytest.mark.asyncio
+async def test_session_service_subagent_terminal_event_keeps_parent_active_run(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    db_path = tmp_path / "session-list-subagent-terminal-cache.db"
+    service = _build_service(db_path, runner=runner)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    _seed_root_task(db_path, run_id="run-parent", session_id="session-1")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-parent",
+        session_id="session-1",
+        root_task_id="task-root-parent",
+    )
+    runtime_repo.update(
+        "run-parent",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    runtime_repo.ensure(
+        run_id="subagent_run_1",
+        session_id="session-1",
+        root_task_id="task-root-subagent",
+    )
+    AgentInstanceRepository(db_path).upsert_instance(
+        run_id="subagent_run_1",
+        trace_id="subagent_run_1",
+        session_id="session-1",
+        instance_id="inst-subagent",
+        role_id="Explorer",
+        workspace_id="default",
+        conversation_id="conv-session-1-explorer",
+        status=InstanceStatus.STOPPED,
+    )
+    first = await service.list_sessions_async(force_refresh=True)
+    assert first[0].active_run_id == "run-parent"
+
+    runner.block_next = True
+    service.mark_run_event_dirty(
+        RunEvent(
+            session_id="session-1",
+            run_id="subagent_run_1",
+            trace_id="subagent_run_1",
+            instance_id="inst-subagent",
+            event_type=RunEventType.RUN_COMPLETED,
+        )
+    )
+    sessions = await service.list_sessions_async()
+
+    assert sessions[0].has_active_run is True
+    assert sessions[0].active_run_id == "run-parent"
+    assert sessions[0].latest_terminal_run_id is None
+    assert await _wait_for_event(runner.started)
+    runner.release.set()
+
+
+def test_session_service_subagent_dirty_event_does_not_read_subagents_sync(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    service = _build_service(
+        tmp_path / "session-subagent-dirty-no-sync-read.db",
+        runner=runner,
+    )
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    with patch.object(service, "list_session_subagents") as list_subagents:
+        service.mark_run_event_dirty(
+            RunEvent(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+                instance_id="inst-1",
+                event_type=RunEventType.TOOL_CALL,
+                payload_json='{"tool_name":"spawn_subagent"}',
+            )
+        )
+
+    list_subagents.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_service_terminal_event_preserves_newer_active_run(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    db_path = tmp_path / "session-list-terminal-preserves-new-active.db"
+    service = _build_service(db_path, runner=runner)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    _seed_root_task(
+        db_path,
+        run_id="run-old",
+        session_id="session-1",
+        task_id="task-root-old",
+    )
+    _seed_root_task(
+        db_path,
+        run_id="run-new",
+        session_id="session-1",
+        task_id="task-root-new",
+    )
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-new",
+        session_id="session-1",
+        root_task_id="task-root-new",
+    )
+    runtime_repo.update(
+        "run-new",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    first = await service.list_sessions_async(force_refresh=True)
+    assert first[0].active_run_id == "run-new"
+
+    runner.block_next = True
+    service.mark_run_event_dirty(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-old",
+            trace_id="run-old",
+            instance_id="inst-1",
+            event_type=RunEventType.RUN_COMPLETED,
+        )
+    )
+    sessions = await service.list_sessions_async()
+
+    assert sessions[0].has_active_run is True
+    assert sessions[0].active_run_id == "run-new"
+    assert sessions[0].latest_terminal_run_id == "run-old"
+    assert sessions[0].latest_terminal_run_status == "completed"
+    assert await _wait_for_event(runner.started)
+    runner.release.set()
+
+
+@pytest.mark.asyncio
+async def test_session_service_create_merges_session_list_cache_without_waiting(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    service = _build_service(tmp_path / "session-list-create-cache.db", runner=runner)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    first = await service.list_sessions_async(force_refresh=True)
+    assert [record.session_id for record in first] == ["session-1"]
+
+    runner.block_next = True
+    created = await service.create_session_async(
+        session_id="session-2",
+        workspace_id="default",
+    )
+    sessions = await service.list_sessions_async()
+
+    assert created.session_id == "session-2"
+    assert [record.session_id for record in sessions] == ["session-2", "session-1"]
+    assert await _wait_for_event(runner.started)
+    runner.release.set()
 
 
 @pytest.mark.asyncio
@@ -912,7 +1096,45 @@ async def test_session_service_run_event_marks_session_snapshot_dirty(
 
 
 @pytest.mark.asyncio
-async def test_session_service_terminal_event_skips_sync_merge_in_async_listener(
+async def test_session_service_recovery_cold_read_waits_for_first_snapshot(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    service = _build_service(tmp_path / "session-recovery-cold-read.db", runner=runner)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    runner.block_next = True
+    read_task = asyncio.create_task(service.get_recovery_snapshot_async("session-1"))
+
+    assert await _wait_for_event(runner.started)
+    assert read_task.done() is False
+    runner.release.set()
+    snapshot = await read_task
+
+    assert snapshot["active_run"] is None
+
+
+@pytest.mark.asyncio
+async def test_session_service_subagents_cold_read_waits_for_first_snapshot(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    service = _build_service(tmp_path / "session-subagents-cold-read.db", runner=runner)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    runner.block_next = True
+    read_task = asyncio.create_task(service.list_session_subagents_async("session-1"))
+
+    assert await _wait_for_event(runner.started)
+    assert read_task.done() is False
+    runner.release.set()
+    subagents = await read_task
+
+    assert subagents == ()
+
+
+@pytest.mark.asyncio
+async def test_session_service_terminal_event_skips_sync_projection_merge(
     tmp_path: Path,
 ) -> None:
     runner = _CountingRunner()
@@ -935,6 +1157,32 @@ async def test_session_service_terminal_event_skips_sync_merge_in_async_listener
         )
 
     merge_terminal.assert_not_called()
+
+
+def test_session_service_nonterminal_list_event_skips_subagent_run_lookup(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(
+        tmp_path / "session-nonterminal-list-event.db",
+        runner=_CountingRunner(),
+    )
+
+    with patch.object(
+        service,
+        "_subagent_run_ids",
+        side_effect=AssertionError("subagent run lookup should be gated"),
+    ) as subagent_run_ids:
+        service.mark_run_event_dirty(
+            RunEvent(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+                instance_id="inst-1",
+                event_type=RunEventType.TOOL_APPROVAL_REQUESTED,
+            )
+        )
+
+    subagent_run_ids.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1042,7 +1290,7 @@ async def test_session_service_pending_action_event_requires_fresh_session_list(
     )
     runtime_repo.update(
         "run-1",
-        status=RunRuntimeStatus.PAUSED,
+        status=RunRuntimeStatus.RUNNING,
         phase=RunRuntimePhase.COORDINATOR_RUNNING,
     )
     first = await service.list_sessions_async(force_refresh=True)
@@ -1229,6 +1477,57 @@ async def test_session_service_update_merges_enriched_session_list_row(
     assert stale[0].active_run_id == "run-1"
 
 
+@pytest.mark.asyncio
+async def test_stale_first_cache_seed_if_empty_returns_seed_without_refresh() -> None:
+    cache = StaleFirstCache[tuple[str, ...]](
+        operation_name="seeded",
+        refresh_min_interval_seconds=0,
+    )
+
+    assert cache.seed_if_empty(("seeded",), dirty=False) is True
+    assert cache.seed_if_empty(("replacement",), dirty=False) is False
+    result = await cache.read(lambda: ("refreshed",))
+
+    assert result.value == ("seeded",)
+
+
+@pytest.mark.asyncio
+async def test_session_snapshot_cache_seed_if_empty_is_scoped_by_section() -> None:
+    cache = SessionSnapshotCache(refresh_min_interval_seconds=0)
+
+    assert (
+        cache.seed_if_empty(
+            session_id="session-1",
+            section=SessionSnapshotSection.RECOVERY,
+            value={"run": "seeded"},
+            dirty=False,
+        )
+        is True
+    )
+    assert (
+        cache.seed_if_empty(
+            session_id="session-1",
+            section=SessionSnapshotSection.RECOVERY,
+            value={"run": "replacement"},
+            dirty=False,
+        )
+        is False
+    )
+    result = await cache.read(
+        session_id="session-1",
+        section=SessionSnapshotSection.RECOVERY,
+        refresh=lambda: {"run": "refreshed"},
+    )
+    token_result = await cache.read(
+        session_id="session-1",
+        section=SessionSnapshotSection.TOKEN_USAGE,
+        refresh=lambda: {"tokens": 10},
+    )
+
+    assert result.value == {"run": "seeded"}
+    assert token_result.value == {"tokens": 10}
+
+
 def _build_service(db_path: Path, *, runner: _CountingRunner) -> SessionService:
     service = SessionService(
         session_repo=SessionRepository(db_path),
@@ -1253,10 +1552,16 @@ def _build_service(db_path: Path, *, runner: _CountingRunner) -> SessionService:
     return service
 
 
-def _seed_root_task(db_path: Path, *, run_id: str, session_id: str) -> None:
+def _seed_root_task(
+    db_path: Path,
+    *,
+    run_id: str,
+    session_id: str,
+    task_id: str = "task-root-1",
+) -> None:
     _ = TaskRepository(db_path).create(
         TaskEnvelope(
-            task_id="task-root-1",
+            task_id=task_id,
             session_id=session_id,
             parent_task_id=None,
             trace_id=run_id,


### PR DESCRIPTION
## Summary
- prioritize current-session run/recovery updates while keeping sidebar/session list refreshes low priority
- make run creation return queued quickly and keep terminal/sidebar state convergent
- force fresh recovery for input-blocking ask_question/tool approval events so the UI appears without page interaction
- reduce health-check/log/session-list amplification under multi-session pressure

## Validation
- .venv\Scripts\ruff.exe check --fix <changed Python/test files>
- .venv\Scripts\ruff.exe format --no-cache --force-exclude <changed Python/test files>
- .venv\Scripts\python.exe -m pytest -q --basetemp=.pytest-pr-frontend tests/integration_tests/frontend/test_api_facade_ui.py tests/integration_tests/frontend/test_backend_status_ui.py tests/integration_tests/frontend/test_logger_sdk.py tests/integration_tests/frontend/test_projects_sidebar_ui.py tests/integration_tests/frontend/test_run_events_ui.py tests/integration_tests/frontend/test_session_sidebar_store_ui.py tests/integration_tests/frontend/test_subagent_streams_ui.py tests/unit_tests/frontend/test_recovery_stream_ui.py tests/unit_tests/frontend/test_workspace_prompt_ui.py
- .venv\Scripts\python.exe -m pytest -q --basetemp=.pytest-pr-backend tests/unit_tests/interfaces/server/test_logs_router.py tests/unit_tests/interfaces/server/test_runs_router.py tests/unit_tests/interfaces/server/test_sessions_router.py tests/unit_tests/sessions/runs/test_run_runtime_repo.py tests/unit_tests/sessions/runs/test_run_service_recovery.py tests/unit_tests/sessions/test_session_list_status.py tests/unit_tests/sessions/test_session_snapshot_cache.py
- .venv\Scripts\basedpyright.exe
- manual browser verification: ask_question recovery card appears immediately after SSE/recovery without page interaction

Fixes #933