### PR TITLE
Clean up root temp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,13 @@ __pycache__/
 .pytest-tmp/
 .venv/
 .tmp/
+.tmp-localappdata/
+.uv-cache/
 tmp/
 *.egg-info/
 .idea/
 coverage.json
+nul
 
 tmp.db
 tmp.db-journal
@@ -38,6 +41,7 @@ package.json
 !.agent_teams/evals/datasets/manifests/
 .agent_teams/evals/datasets/manifests/*
 logs/
+output/
 src/relay_teams/builtin/skills/pptx-craft/designer/lib/html-to-pptx/dist/
 src/relay_teams/builtin/skills/pptx-craft/designer/lib/html-to-pptx/node/dist/
 .coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ relay-teams = "relay_teams.interfaces.cli.app:main"
 relay-teams-evals = "relay_teams_evals.run:app"
 
 [tool.pytest.ini_options]
-addopts = "--basetemp=.pytest-tmp"
+addopts = "--basetemp=.tmp/pytest"
 testpaths = ["tests/unit_tests", "tests/integration_tests"]
 pythonpath = ["src", "tests", "."]
 markers = [

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/scripts/cleanup_temp_artifacts.py
+++ b/scripts/cleanup_temp_artifacts.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from pathlib import Path
+import shutil
+
+
+_ROOT_TEMP_ARTIFACTS: tuple[Path, ...] = (
+    Path(".pytest-tmp"),
+    Path(".uv-cache"),
+    Path(".tmp-localappdata"),
+    Path("nul"),
+)
+
+
+def cleanup_temp_artifacts(project_root: Path) -> tuple[Path, ...]:
+    resolved_root = project_root.expanduser().resolve()
+    removed: list[Path] = []
+    for relative_path in _ROOT_TEMP_ARTIFACTS:
+        _validate_root_artifact_path(relative_path)
+        target = resolved_root / relative_path
+        if not _is_listed_path(target):
+            continue
+        if target.is_symlink():
+            _unlink_file(target)
+        elif target.is_dir():
+            shutil.rmtree(target)
+        else:
+            _unlink_file(target)
+        removed.append(relative_path)
+    return tuple(removed)
+
+
+def _validate_root_artifact_path(relative_path: Path) -> None:
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError(f"Refusing to clean unsafe artifact path: {relative_path}")
+
+
+def _is_listed_path(target: Path) -> bool:
+    return any(candidate.name == target.name for candidate in target.parent.iterdir())
+
+
+def _unlink_file(target: Path) -> None:
+    try:
+        target.unlink()
+    except PermissionError:
+        _windows_extended_path(target).unlink()
+
+
+def _windows_extended_path(target: Path) -> Path:
+    return Path(f"\\\\?\\{target}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Remove known root-level temporary artifacts."
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root to clean. Defaults to the current working directory.",
+    )
+    args = parser.parse_args(argv)
+
+    removed = cleanup_temp_artifacts(project_root=args.project_root)
+    for path in removed:
+        print(f"removed {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.bat
+++ b/setup.bat
@@ -71,6 +71,8 @@ if "%INSTALL_EVALS%"=="0" if not exist uv.lock (
 )
 
 set UV_NATIVE_TLS=1
+set "UV_CACHE_DIR=.tmp\uv-cache"
+set "UV_LINK_MODE=copy"
 if "%INSTALL_EVALS%"=="1" (
     echo Installing dependencies including dev tools and evals...
     %UV_CMD% sync --all-extras --index-strategy unsafe-best-match
@@ -99,4 +101,7 @@ if %errorlevel% neq 0 (
     echo Git Hooks install successful
 )
 
+if exist ".tmp\uv-cache" rmdir /s /q ".tmp\uv-cache" >nul 2>&1
+if exist ".tmp" rmdir ".tmp" >nul 2>&1
 echo Environment setup completed.
+exit /b 0

--- a/setup.sh
+++ b/setup.sh
@@ -78,6 +78,8 @@ if [ "$INSTALL_EVALS" = "0" ] && [ ! -f "uv.lock" ]; then
 fi
 
 export UV_NATIVE_TLS=1
+export UV_CACHE_DIR=".tmp/uv-cache"
+export UV_LINK_MODE=copy
 if [ "$INSTALL_EVALS" = "1" ]; then
   echo "Installing dependencies (including dev tools and evals)..."
   if ! run_uv sync --all-extras --index-strategy unsafe-best-match; then
@@ -106,4 +108,6 @@ else
   echo "[WARNING] Git Hooks install failed"
 fi
 
+rm -rf ".tmp/uv-cache"
+rmdir ".tmp" 2>/dev/null || true
 echo "Environment setup completed."

--- a/src/relay_teams/paths/root_paths.py
+++ b/src/relay_teams/paths/root_paths.py
@@ -10,6 +10,9 @@ _APP_CONFIG_DIR_ENV_VAR = "RELAY_TEAMS_CONFIG_DIR"
 _APP_CONFIG_DIR_NAME = ".relay-teams"
 _GIT_TOPLEVEL_CMD: tuple[str, str, str] = ("git", "rev-parse", "--show-toplevel")
 _GIT_TIMEOUT_SECONDS = 5.0
+_LEGACY_PYTEST_TEMP_DIR_NAME = ".pytest-tmp"
+_PYTEST_TEMP_PARENT_DIR_NAME = ".tmp"
+_PYTEST_TEMP_DIR_NAME = "pytest"
 
 
 def get_user_home_dir() -> Path:
@@ -62,6 +65,8 @@ def get_project_root_or_none(start_dir: Path | None = None) -> Path | None:
     marker_root = _find_git_marker_root(command_cwd)
     if marker_root is not None:
         return marker_root
+    if _is_inside_repo_pytest_temp_dir(command_cwd):
+        return None
     try:
         completed = subprocess.run(
             list(_GIT_TOPLEVEL_CMD),
@@ -91,11 +96,34 @@ def _find_git_marker_root(start_dir: Path) -> Path | None:
         current = current.parent
     candidates = (current, *current.parents)
     for candidate in candidates:
-        if candidate.name == ".pytest-tmp":
+        if _is_pytest_temp_dir(candidate):
             return None
         if (candidate / ".git").exists() and _is_valid_git_worktree_root(candidate):
             return candidate.resolve()
     return None
+
+
+def _is_pytest_temp_dir(candidate: Path) -> bool:
+    if candidate.name == _LEGACY_PYTEST_TEMP_DIR_NAME:
+        return True
+    return (
+        candidate.name == _PYTEST_TEMP_DIR_NAME
+        and candidate.parent.name == _PYTEST_TEMP_PARENT_DIR_NAME
+    )
+
+
+def _is_inside_repo_pytest_temp_dir(candidate: Path) -> bool:
+    current = candidate.expanduser()
+    if current.exists() and current.is_file():
+        current = current.parent
+    for path in (current, *current.parents):
+        if not _is_pytest_temp_dir(path):
+            continue
+        return any(
+            (parent / ".git").exists() and _is_valid_git_worktree_root(parent)
+            for parent in path.parents
+        )
+    return False
 
 
 def _is_valid_git_worktree_root(candidate: Path) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import importlib.metadata
 import inspect
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+import shutil
 import sys
 
 import pytest
@@ -45,10 +46,39 @@ _ensure_installed_mcp_package()
 
 def pytest_configure(config: pytest.Config) -> None:
     _configure_windows_asyncio_policy()
+    _ensure_basetemp_parent(config)
     config.addinivalue_line(
         "markers",
         "asyncio: mark a test function to run in an asyncio event loop",
     )
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if exitstatus != pytest.ExitCode.OK:
+        return
+    raw_basetemp = session.config.getoption("basetemp", default=None)
+    if not isinstance(raw_basetemp, str):
+        return
+    basetemp = Path(raw_basetemp)
+    expected_basetemp = Path(".tmp") / "pytest"
+    if basetemp.resolve() != expected_basetemp.resolve():
+        return
+    shutil.rmtree(basetemp, ignore_errors=True)
+    _remove_empty_directory(basetemp.parent)
+
+
+def _ensure_basetemp_parent(config: pytest.Config) -> None:
+    raw_basetemp = config.getoption("basetemp", default=None)
+    if not isinstance(raw_basetemp, str):
+        return
+    Path(raw_basetemp).parent.mkdir(parents=True, exist_ok=True)
+
+
+def _remove_empty_directory(path: Path) -> None:
+    try:
+        path.rmdir()
+    except OSError:
+        return
 
 
 def _configure_windows_asyncio_policy() -> None:

--- a/tests/unit_tests/interfaces/cli/test_setup_scripts.py
+++ b/tests/unit_tests/interfaces/cli/test_setup_scripts.py
@@ -16,8 +16,17 @@ def test_windows_setup_installs_project_entry_points() -> None:
     assert 'if "%UV_CMD%"=="" uv --version >nul 2>&1' in script
     assert 'if %errorlevel% equ 0 if "%UV_CMD%"=="" set "UV_CMD=uv"' in script
     assert "%PYTHON_CMD% -m pip install uv" in script
+    assert "Usage: setup.bat [--no-evals]" in script
+    assert 'set "INSTALL_EVALS=0"' in script
+    assert "%UV_CMD% sync --all-extras --no-group evals --locked" in script
+    assert 'set "UV_CACHE_DIR=.tmp\\uv-cache"' in script
+    assert 'set "UV_LINK_MODE=copy"' in script
     assert "%UV_CMD% sync --all-extras --index-strategy unsafe-best-match" in script
-    assert "%UV_CMD% pip install -e ." in script
+    assert "%UV_CMD% pip install -e . --no-deps" in script
+    assert "%UV_CMD% run --no-sync pre-commit install" in script
+    assert 'if exist ".tmp\\uv-cache" rmdir /s /q ".tmp\\uv-cache"' in script
+    assert 'if exist ".tmp" rmdir ".tmp"' in script
+    assert "exit /b 0" in script
 
 
 def test_posix_setup_installs_project_entry_points() -> None:
@@ -28,5 +37,13 @@ def test_posix_setup_installs_project_entry_points() -> None:
     assert "elif command -v uv >/dev/null 2>&1; then" in script
     assert "run_uv() {" in script
     assert '"$PYTHON_BIN" -m pip install uv' in script
+    assert "Usage: sh setup.sh [--no-evals]" in script
+    assert "INSTALL_EVALS=0" in script
+    assert "run_uv sync --all-extras --no-group evals --locked" in script
+    assert 'export UV_CACHE_DIR=".tmp/uv-cache"' in script
+    assert "export UV_LINK_MODE=copy" in script
     assert "run_uv sync --all-extras --index-strategy unsafe-best-match" in script
-    assert "run_uv pip install -e ." in script
+    assert "run_uv pip install -e . --no-deps" in script
+    assert "run_uv run --no-sync pre-commit install" in script
+    assert 'rm -rf ".tmp/uv-cache"' in script
+    assert 'rmdir ".tmp" 2>/dev/null || true' in script

--- a/tests/unit_tests/maintenance_scripts/__init__.py
+++ b/tests/unit_tests/maintenance_scripts/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/maintenance_scripts/test_cleanup_temp_artifacts.py
+++ b/tests/unit_tests/maintenance_scripts/test_cleanup_temp_artifacts.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+from scripts.cleanup_temp_artifacts import cleanup_temp_artifacts
+
+
+def test_cleanup_temp_artifacts_removes_only_known_root_noise(
+    tmp_path: Path,
+) -> None:
+    for directory_name in (".pytest-tmp", ".uv-cache", ".tmp-localappdata"):
+        directory = tmp_path / directory_name
+        directory.mkdir()
+        (directory / "cache.txt").write_text("cache", encoding="utf-8")
+    _write_real_file(tmp_path / "nul", "device noise")
+    for preserved_name in (".tmp", "tmp", "output", "logs"):
+        preserved = tmp_path / preserved_name
+        preserved.mkdir()
+        (preserved / "keep.txt").write_text("keep", encoding="utf-8")
+
+    removed = cleanup_temp_artifacts(tmp_path)
+
+    assert removed == (
+        Path(".pytest-tmp"),
+        Path(".uv-cache"),
+        Path(".tmp-localappdata"),
+        Path("nul"),
+    )
+    for removed_name in (".pytest-tmp", ".uv-cache", ".tmp-localappdata"):
+        assert not (tmp_path / removed_name).exists()
+    assert "nul" not in {path.name for path in tmp_path.iterdir()}
+    for preserved_name in (".tmp", "tmp", "output", "logs"):
+        assert (tmp_path / preserved_name / "keep.txt").read_text(
+            encoding="utf-8"
+        ) == "keep"
+
+
+def test_cleanup_temp_artifacts_unlinks_symlink_without_removing_target(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "important_dir"
+    target.mkdir()
+    (target / "keep.txt").write_text("keep", encoding="utf-8")
+    cache_link = tmp_path / ".uv-cache"
+    _make_directory_symlink(cache_link, target)
+
+    removed = cleanup_temp_artifacts(tmp_path)
+
+    assert removed == (Path(".uv-cache"),)
+    assert not cache_link.exists()
+    assert (target / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def _write_real_file(path: Path, content: str) -> None:
+    if sys.platform == "win32" and path.name.lower() == "nul":
+        Path(f"\\\\?\\{path.resolve()}").write_text(content, encoding="utf-8")
+        return
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_directory_symlink(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")

--- a/tests/unit_tests/paths/test_root_paths.py
+++ b/tests/unit_tests/paths/test_root_paths.py
@@ -28,6 +28,13 @@ def test_get_project_root_or_none_returns_git_root(
         assert capture_output is True
         assert text is True
         assert timeout == 5.0
+        if cwd != str(tmp_path.resolve()):
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=1,
+                stdout="",
+                stderr="fatal: not a git repository",
+            )
         assert cwd == str(tmp_path.resolve())
         return subprocess.CompletedProcess(
             args=command,
@@ -451,6 +458,79 @@ def test_find_git_marker_root_uses_parent_for_file_path(
     monkeypatch.setattr(root_paths.subprocess, "run", fake_run)
 
     assert root_paths._find_git_marker_root(file_path) == repo_dir.resolve()
+
+
+def test_find_git_marker_root_ignores_configured_pytest_temp_dir(
+    tmp_path: Path,
+) -> None:
+    repo_dir = tmp_path / "repo"
+    pytest_dir = repo_dir / ".tmp" / "pytest" / "test-case"
+    pytest_dir.mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+
+    assert root_paths._find_git_marker_root(pytest_dir) is None
+
+
+def test_get_project_root_or_none_ignores_configured_pytest_temp_dir(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo_dir = tmp_path / "repo"
+    pytest_dir = repo_dir / ".tmp" / "pytest" / "test-case"
+    pytest_dir.mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: str,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = (command, cwd, check, capture_output, text, timeout)
+        raise AssertionError("pytest temp directories must not fall back to git")
+
+    monkeypatch.setattr(root_paths.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        root_paths,
+        "_is_valid_git_worktree_root",
+        lambda candidate: candidate.resolve() == repo_dir.resolve(),
+    )
+
+    assert root_paths.get_project_root_or_none(pytest_dir) is None
+
+
+def test_get_project_root_or_none_keeps_nested_repo_inside_pytest_temp_dir(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo_dir = tmp_path / "repo"
+    nested_repo_dir = repo_dir / ".tmp" / "pytest" / "test-case" / "fixture-repo"
+    start_dir = nested_repo_dir / "src"
+    start_dir.mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+    (nested_repo_dir / ".git").mkdir()
+
+    monkeypatch.setattr(
+        root_paths,
+        "_is_valid_git_worktree_root",
+        lambda candidate: candidate.resolve() == nested_repo_dir.resolve(),
+    )
+
+    assert root_paths.get_project_root_or_none(start_dir) == nested_repo_dir.resolve()
+
+
+def test_find_git_marker_root_ignores_legacy_pytest_temp_dir(
+    tmp_path: Path,
+) -> None:
+    repo_dir = tmp_path / "repo"
+    pytest_dir = repo_dir / ".pytest-tmp" / "test-case"
+    pytest_dir.mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+
+    assert root_paths._find_git_marker_root(pytest_dir) is None
 
 
 def test_find_git_marker_root_rejects_invalid_git_marker(


### PR DESCRIPTION
## Summary
- route pytest temp files under .tmp/pytest and clean them after successful sessions
- keep setup uv caches under .tmp/uv-cache and remove empty temp parents on success
- add a maintenance cleanup script for legacy root temp noise, including Windows nul handling

## Validation
- uv run --extra dev pre-commit run --all-files
- uv run --extra dev pytest -q tests/unit_tests/paths/test_root_paths.py tests/unit_tests/interfaces/cli/test_setup_scripts.py tests/unit_tests/maintenance_scripts/test_cleanup_temp_artifacts.py
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev basedpyright

Fixes #946