### PR TITLE
Record self-iteration architecture improvements

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -336,6 +336,7 @@ State is stored under `.git/relay-teams-performance-iteration/`:
 | `reports/` | Full JSON reports with pressure metrics and log findings. |
 | `runs.jsonl` | Score history, reject reasons, and accepted status. |
 | `memory/` | Per-run records injected into future Codex prompts. |
+| `algorithm-architecture-improvements.md` | Human-readable candidate algorithm and architecture improvement notes, including rejected candidates with diffs. |
 | `score.csv` | Exported trend data from `chart` mode. |
 
 Failure policy:
@@ -346,6 +347,11 @@ Failure policy:
 - `WARNING` log findings do not automatically fail the run, but they are
   recorded in `log_findings` and passed into the next self-iteration prompt as
   improvement items.
+- Candidate runs with diffs also record `algorithm_architecture_improvements`
+  in `runs.jsonl`, per-run memory JSON, reports, and the Markdown improvement
+  log. Generated candidates are prompted to provide explicit algorithm and
+  architecture bullets; current-candidate evaluation falls back to patch and
+  score evidence when no Codex notes exist.
 - By default accepted candidates are left in the working tree for review; pass
   `--commit-accepted` to let the harness create the commit.
 

--- a/tools/performance_self_iteration/src/architecture_notes.rs
+++ b/tools/performance_self_iteration/src/architecture_notes.rs
@@ -1,0 +1,306 @@
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    command::CommandResult,
+    git_ops::PatchSnapshot,
+    scoring::{EvaluationObservation, ScoreBreakdown},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AlgorithmArchitectureImprovement {
+    pub area: String,
+    pub improvement: String,
+    pub evidence: String,
+}
+
+pub fn candidate_algorithm_architecture_improvements(
+    patch: &PatchSnapshot,
+    codex_result: Option<&CommandResult>,
+    score: &ScoreBreakdown,
+    observation: &EvaluationObservation,
+) -> Vec<AlgorithmArchitectureImprovement> {
+    if !patch.has_diff {
+        return Vec::new();
+    }
+    let changed_paths = changed_paths_from_patch(patch);
+    let extracted = codex_result
+        .into_iter()
+        .flat_map(extract_algorithm_architecture_lines)
+        .collect::<Vec<_>>();
+    if !extracted.is_empty() {
+        return extracted
+            .into_iter()
+            .take(8)
+            .map(|line| AlgorithmArchitectureImprovement {
+                area: infer_area(&changed_paths),
+                improvement: line,
+                evidence: "codex final notes".to_owned(),
+            })
+            .collect();
+    }
+    vec![AlgorithmArchitectureImprovement {
+        area: infer_area(&changed_paths),
+        improvement: fallback_improvement_summary(score, observation),
+        evidence: fallback_evidence(patch, &changed_paths),
+    }]
+}
+
+pub fn report_with_algorithm_architecture_improvements(
+    report: &Value,
+    improvements: &[AlgorithmArchitectureImprovement],
+) -> Result<Value, String> {
+    let mut value = report.clone();
+    value["algorithm_architecture_improvements"] =
+        serde_json::to_value(improvements).map_err(|error| error.to_string())?;
+    Ok(value)
+}
+
+pub fn changed_paths_from_patch(patch: &PatchSnapshot) -> Vec<String> {
+    fs::read_to_string(&patch.path)
+        .map(|diff| changed_paths_from_diff(&diff))
+        .unwrap_or_default()
+}
+
+fn extract_algorithm_architecture_lines(result: &CommandResult) -> Vec<String> {
+    let combined = format!("{}\n{}", result.stdout, result.stderr);
+    let mut lines = Vec::new();
+    let mut collecting = false;
+    let mut collected_any = false;
+    for raw_line in combined.lines() {
+        let line = raw_line.trim();
+        if is_algorithm_architecture_heading(line) {
+            collecting = true;
+            collected_any = false;
+            continue;
+        }
+        if !collecting {
+            continue;
+        }
+        if line.is_empty() {
+            if collected_any {
+                break;
+            }
+            continue;
+        }
+        if collected_any && line.starts_with('#') {
+            break;
+        }
+        if collected_any && line.ends_with(':') && !line.contains(' ') {
+            break;
+        }
+        let cleaned = clean_bullet(line);
+        if !cleaned.is_empty() {
+            lines.push(cleaned);
+            collected_any = true;
+        }
+    }
+    lines
+}
+
+fn is_algorithm_architecture_heading(line: &str) -> bool {
+    let normalized = line.trim_matches(['#', '*', ':', ' ']).to_ascii_lowercase();
+    normalized.contains("algorithm")
+        && normalized.contains("architecture")
+        && normalized.contains("improvement")
+}
+
+fn clean_bullet(line: &str) -> String {
+    line.trim_start_matches(['-', '*', ' '])
+        .trim_start_matches(|character: char| character.is_ascii_digit() || character == '.')
+        .trim()
+        .chars()
+        .take(500)
+        .collect()
+}
+
+fn changed_paths_from_diff(diff: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for line in diff.lines() {
+        let Some(rest) = line.strip_prefix("diff --git ") else {
+            continue;
+        };
+        let parts = rest.split_whitespace().collect::<Vec<_>>();
+        let Some(path) = parts.get(1).and_then(|value| value.strip_prefix("b/")) else {
+            continue;
+        };
+        if path != "/dev/null" && !paths.iter().any(|existing| existing == path) {
+            paths.push(path.to_owned());
+        }
+    }
+    paths
+}
+
+fn infer_area(changed_paths: &[String]) -> String {
+    if changed_paths.is_empty() {
+        return "unknown".to_owned();
+    }
+    let mut prefixes = changed_paths
+        .iter()
+        .filter_map(|path| path.split('/').next())
+        .filter(|prefix| !prefix.is_empty())
+        .collect::<Vec<_>>();
+    prefixes.sort_unstable();
+    prefixes.dedup();
+    if prefixes.len() == 1 {
+        prefixes[0].to_owned()
+    } else {
+        prefixes.into_iter().take(3).collect::<Vec<_>>().join(",")
+    }
+}
+
+fn fallback_improvement_summary(
+    score: &ScoreBreakdown,
+    observation: &EvaluationObservation,
+) -> String {
+    if score.accepted {
+        return format!(
+            "Accepted candidate changes the affected subsystem architecture or algorithm surface with score {:.6}.",
+            score.score
+        );
+    }
+    let failed_gates = observation
+        .gates
+        .iter()
+        .filter(|gate| !gate.passed)
+        .map(|gate| gate.name.as_str())
+        .collect::<Vec<_>>();
+    if !failed_gates.is_empty() {
+        return format!(
+            "Rejected candidate still records its attempted architecture or algorithm change; failed gates: {}.",
+            failed_gates.join(", ")
+        );
+    }
+    format!(
+        "Candidate records its attempted architecture or algorithm change for follow-up; score {:.6}.",
+        score.score
+    )
+}
+
+fn fallback_evidence(patch: &PatchSnapshot, changed_paths: &[String]) -> String {
+    let paths = if changed_paths.is_empty() {
+        "none parsed".to_owned()
+    } else {
+        changed_paths
+            .iter()
+            .take(8)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    format!(
+        "patch_sha256={} patch_bytes={} changed_paths={}",
+        patch.sha256, patch.bytes, paths
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn extracts_algorithm_architecture_section_from_codex_output() {
+        let result = CommandResult {
+            name: "codex_generation".to_owned(),
+            command: Vec::new(),
+            exit_code: 0,
+            duration_ms: 1,
+            stdout: "Algorithm architecture improvements:\n- Split queue admission from SSE streaming backpressure.\n- Added bounded cleanup ownership.\n\nOther notes\n".to_owned(),
+            stderr: String::new(),
+        };
+
+        let lines = extract_algorithm_architecture_lines(&result);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Split queue admission from SSE streaming backpressure.",
+                "Added bounded cleanup ownership."
+            ]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_patch_summary_when_codex_output_has_no_notes() {
+        let root = std::env::temp_dir().join(format!(
+            "relay-teams-architecture-notes-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let patch_path = root.join("candidate.patch");
+        fs::write(
+            &patch_path,
+            "diff --git a/src/service.py b/src/service.py\n--- a/src/service.py\n+++ b/src/service.py\n",
+        )
+        .unwrap();
+        let patch = PatchSnapshot {
+            path: patch_path,
+            has_diff: true,
+            sha256: "abc".to_owned(),
+            bytes: 12,
+        };
+        let score = ScoreBreakdown {
+            score: 0.8,
+            stability: 1.0,
+            latency: 0.5,
+            throughput: 1.0,
+            log_quality: 1.0,
+            test_quality: 1.0,
+            accepted: true,
+            reject_reasons: Vec::new(),
+            improvements: Vec::new(),
+            degradations: Vec::new(),
+        };
+        let observation = EvaluationObservation {
+            generated_diff: true,
+            gates: Vec::new(),
+            metrics: Vec::new(),
+            log_findings: Vec::new(),
+        };
+
+        let improvements =
+            candidate_algorithm_architecture_improvements(&patch, None, &score, &observation);
+        let _ = fs::remove_dir_all(root);
+
+        assert_eq!(improvements.len(), 1);
+        assert_eq!(improvements[0].area, "src");
+        assert!(improvements[0].evidence.contains("src/service.py"));
+    }
+
+    #[test]
+    fn empty_patch_has_no_algorithm_architecture_improvements() {
+        let patch = PatchSnapshot {
+            path: PathBuf::from("missing.patch"),
+            has_diff: false,
+            sha256: String::new(),
+            bytes: 0,
+        };
+        let score = ScoreBreakdown {
+            score: 0.0,
+            stability: 0.0,
+            latency: 0.0,
+            throughput: 0.0,
+            log_quality: 0.0,
+            test_quality: 0.0,
+            accepted: false,
+            reject_reasons: Vec::new(),
+            improvements: Vec::new(),
+            degradations: Vec::new(),
+        };
+        let observation = EvaluationObservation {
+            generated_diff: false,
+            gates: Vec::new(),
+            metrics: Vec::new(),
+            log_findings: Vec::new(),
+        };
+
+        let improvements =
+            candidate_algorithm_architecture_improvements(&patch, None, &score, &observation);
+
+        assert!(improvements.is_empty());
+    }
+}

--- a/tools/performance_self_iteration/src/codex.rs
+++ b/tools/performance_self_iteration/src/codex.rs
@@ -76,6 +76,7 @@ Constraints:
 - Do not create commits; the Rust harness owns accepted commits.
 - Prefer general queueing, isolation, timeout, logging, or benchmark improvements over fixture-specific behavior.
 - For repo inspection, prefer `rg`.
+- In the final notes, include a section named `Algorithm architecture improvements:` with 1-3 bullets. Each bullet should record the candidate's algorithm or architecture change, the affected subsystem, and why it should improve stability, latency, or pressure behavior.
 
 Workspace: {workspace}
 Evaluation profile: {profile}
@@ -84,7 +85,7 @@ Pressure target: base_url={base_url}, concurrency={concurrency}, duration_second
 Recent performance self-iteration memory:
 {memory}
 
-Make one concrete candidate change now. If you change performance behavior, add or update focused tests or benchmark coverage. In the final notes, state which warning/error or latency/busy failure the change addresses.
+Make one concrete candidate change now. If you change performance behavior, add or update focused tests or benchmark coverage. In the final notes, state which warning/error or latency/busy failure the change addresses and include the required algorithm architecture improvement bullets.
 "#,
         workspace = cli.workspace.display(),
         profile = cli.profile,
@@ -150,6 +151,7 @@ mod tests {
             memory: root.join("memory"),
             runs_jsonl: root.join("runs.jsonl"),
             score_csv: root.join("score.csv"),
+            algorithm_architecture_markdown: root.join("algorithm-architecture-improvements.md"),
             root,
         };
         let cli = Cli {
@@ -185,5 +187,6 @@ mod tests {
         assert!(prompt.contains("duration_seconds=300"));
         assert!(prompt.contains("sessions=24"));
         assert!(prompt.contains("base_url=http://127.0.0.1:8000"));
+        assert!(prompt.contains("Algorithm architecture improvements:"));
     }
 }

--- a/tools/performance_self_iteration/src/command.rs
+++ b/tools/performance_self_iteration/src/command.rs
@@ -248,10 +248,7 @@ where
         let mut output = Vec::new();
         let mut truncated = false;
         let mut chunk = [0_u8; 8192];
-        loop {
-            let Ok(count) = pipe.read(&mut chunk) else {
-                break;
-            };
+        while let Ok(count) = pipe.read(&mut chunk) {
             if count == 0 {
                 break;
             }

--- a/tools/performance_self_iteration/src/git_ops.rs
+++ b/tools/performance_self_iteration/src/git_ops.rs
@@ -296,13 +296,11 @@ pub fn capture_head_state(workspace: &Path) -> Result<HeadState, String> {
         .current_dir(workspace)
         .output()
         .map_err(|error| format!("failed to inspect current branch: {error}"))
-        .and_then(|output| {
+        .map(|output| {
             if output.status.success() {
-                Ok(Some(
-                    String::from_utf8_lossy(&output.stdout).trim().to_owned(),
-                ))
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
             } else {
-                Ok(None)
+                None
             }
         })?;
     Ok(HeadState { commit, branch })
@@ -883,10 +881,7 @@ fn capture_git_diff(
         thread::spawn(move || {
             let mut output = Vec::new();
             let mut buffer = [0_u8; 4096];
-            loop {
-                let Ok(count) = stderr.read(&mut buffer) else {
-                    break;
-                };
+            while let Ok(count) = stderr.read(&mut buffer) {
                 if count == 0 {
                     break;
                 }
@@ -999,10 +994,7 @@ fn git_stdout_bounded(
         thread::spawn(move || {
             let mut output = Vec::new();
             let mut buffer = [0_u8; 4096];
-            loop {
-                let Ok(count) = stderr.read(&mut buffer) else {
-                    break;
-                };
+            while let Ok(count) = stderr.read(&mut buffer) {
                 if count == 0 {
                     break;
                 }

--- a/tools/performance_self_iteration/src/history.rs
+++ b/tools/performance_self_iteration/src/history.rs
@@ -9,6 +9,7 @@ use std::{
 use serde_json::Value;
 
 use crate::{
+    architecture_notes::AlgorithmArchitectureImprovement,
     git_ops::PatchSnapshot,
     scoring::{EvaluationObservation, ScoreBreakdown},
 };
@@ -21,6 +22,7 @@ pub struct HistoryPaths {
     pub memory: PathBuf,
     pub runs_jsonl: PathBuf,
     pub score_csv: PathBuf,
+    pub algorithm_architecture_markdown: PathBuf,
 }
 
 impl HistoryPaths {
@@ -49,6 +51,7 @@ impl HistoryPaths {
             memory: root.join("memory"),
             runs_jsonl: root.join("runs.jsonl"),
             score_csv: root.join("score.csv"),
+            algorithm_architecture_markdown: root.join("algorithm-architecture-improvements.md"),
             root,
         })
     }
@@ -70,6 +73,7 @@ pub struct RunRecordInput<'a> {
     pub report_path: &'a Path,
     pub score: &'a ScoreBreakdown,
     pub observation: &'a EvaluationObservation,
+    pub algorithm_architecture_improvements: &'a [AlgorithmArchitectureImprovement],
     pub commit: Option<&'a str>,
 }
 
@@ -125,6 +129,7 @@ pub fn make_run_record(input: RunRecordInput<'_>) -> Value {
         "reject_reasons": input.score.reject_reasons,
         "improvements": input.score.improvements,
         "degradations": input.score.degradations,
+        "algorithm_architecture_improvements": input.algorithm_architecture_improvements,
         "generated_diff": input.observation.generated_diff,
         "patch": input.patch.serializable(),
         "report": input.report_path.display().to_string(),
@@ -186,6 +191,69 @@ pub fn write_memory(paths: &HistoryPaths, record: &Value) -> Result<(), String> 
     .map_err(|error| format!("failed to write memory: {error}"))
 }
 
+pub fn append_algorithm_architecture_markdown(
+    paths: &HistoryPaths,
+    record: &Value,
+) -> Result<(), String> {
+    let Some(improvements) = record
+        .get("algorithm_architecture_improvements")
+        .and_then(Value::as_array)
+    else {
+        return Ok(());
+    };
+    if improvements.is_empty() {
+        return Ok(());
+    }
+    paths.ensure()?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&paths.algorithm_architecture_markdown)
+        .map_err(|error| {
+            format!(
+                "failed to open {}: {error}",
+                paths.algorithm_architecture_markdown.display()
+            )
+        })?;
+    writeln!(
+        file,
+        "\n## {}\n\n- profile: {}\n- accepted: {}\n- score: {}\n- patch: `{}`\n",
+        text(record, "run_id"),
+        text(record, "profile"),
+        record
+            .get("accepted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        record
+            .get("score")
+            .map(Value::to_string)
+            .unwrap_or_default(),
+        record
+            .get("patch")
+            .and_then(|patch| patch.get("path"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+    )
+    .map_err(|error| format!("failed to append architecture markdown: {error}"))?;
+    for improvement in improvements {
+        let area = improvement
+            .get("area")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let summary = improvement
+            .get("improvement")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let evidence = improvement
+            .get("evidence")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        writeln!(file, "- `{area}`: {summary} Evidence: {evidence}")
+            .map_err(|error| format!("failed to append architecture markdown: {error}"))?;
+    }
+    Ok(())
+}
+
 pub fn recent_memory(paths: &HistoryPaths, limit: usize) -> String {
     let Ok(runs) = load_runs(paths) else {
         return "No prior performance self-iteration memory.".to_owned();
@@ -193,7 +261,7 @@ pub fn recent_memory(paths: &HistoryPaths, limit: usize) -> String {
     let mut lines = Vec::new();
     for run in runs.into_iter().rev().take(limit) {
         lines.push(format!(
-            "- run_id={} accepted={} score={} reasons={} findings={}",
+            "- run_id={} accepted={} score={} reasons={} architecture={} findings={}",
             text(&run, "run_id"),
             run.get("accepted")
                 .and_then(Value::as_bool)
@@ -202,6 +270,7 @@ pub fn recent_memory(paths: &HistoryPaths, limit: usize) -> String {
             run.get("reject_reasons")
                 .map(Value::to_string)
                 .unwrap_or_default(),
+            architecture_improvement_summary(&run),
             log_finding_summary(&run)
         ));
     }
@@ -210,6 +279,34 @@ pub fn recent_memory(paths: &HistoryPaths, limit: usize) -> String {
     } else {
         lines.join("\n")
     }
+}
+
+fn architecture_improvement_summary(run: &Value) -> String {
+    let Some(items) = run
+        .get("algorithm_architecture_improvements")
+        .and_then(Value::as_array)
+    else {
+        return "[]".to_owned();
+    };
+    let entries = items
+        .iter()
+        .take(4)
+        .map(|item| {
+            let area = item
+                .get("area")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let improvement = item
+                .get("improvement")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .chars()
+                .take(180)
+                .collect::<String>();
+            format!("{area}:{improvement}")
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_owned())
 }
 
 pub fn export_score_csv(paths: &HistoryPaths) -> Result<PathBuf, String> {
@@ -325,6 +422,7 @@ mod tests {
             memory: root.join("memory"),
             runs_jsonl: root.join("runs.jsonl"),
             score_csv: root.join("score.csv"),
+            algorithm_architecture_markdown: root.join("algorithm-architecture-improvements.md"),
             root,
         };
         paths.ensure().unwrap();
@@ -355,6 +453,52 @@ mod tests {
     }
 
     #[test]
+    fn algorithm_architecture_improvements_are_logged_and_recalled() {
+        let root = std::env::temp_dir().join(format!(
+            "relay-teams-history-architecture-{}",
+            std::process::id()
+        ));
+        let paths = HistoryPaths {
+            patches: root.join("patches"),
+            reports: root.join("reports"),
+            memory: root.join("memory"),
+            runs_jsonl: root.join("runs.jsonl"),
+            score_csv: root.join("score.csv"),
+            algorithm_architecture_markdown: root.join("algorithm-architecture-improvements.md"),
+            root,
+        };
+        paths.ensure().unwrap();
+        let record = serde_json::json!({
+            "run_id": "run-architecture",
+            "timestamp": 1,
+            "profile": "pressure-fast",
+            "accepted": false,
+            "score": 0.42,
+            "reject_reasons": ["latency_p95_ms above budget"],
+            "patch": {"path": "/tmp/candidate.patch"},
+            "algorithm_architecture_improvements": [{
+                "area": "src",
+                "improvement": "Separated queue admission from SSE stream draining.",
+                "evidence": "codex final notes"
+            }],
+            "log_findings": []
+        });
+
+        append_run(&paths, &record).unwrap();
+        write_memory(&paths, &record).unwrap();
+        append_algorithm_architecture_markdown(&paths, &record).unwrap();
+        let memory = recent_memory(&paths, 1);
+        let markdown = fs::read_to_string(&paths.algorithm_architecture_markdown).unwrap();
+        let memory_json = fs::read_to_string(paths.memory.join("run-architecture.json")).unwrap();
+        let _ = fs::remove_dir_all(&paths.root);
+
+        assert!(memory.contains("Separated queue admission"));
+        assert!(markdown.contains("run-architecture"));
+        assert!(markdown.contains("Separated queue admission"));
+        assert!(memory_json.contains("algorithm_architecture_improvements"));
+    }
+
+    #[test]
     fn previous_scored_run_uses_latest_accepted_run() {
         let root = std::env::temp_dir().join(format!(
             "relay-teams-history-baseline-{}",
@@ -366,6 +510,7 @@ mod tests {
             memory: root.join("memory"),
             runs_jsonl: root.join("runs.jsonl"),
             score_csv: root.join("score.csv"),
+            algorithm_architecture_markdown: root.join("algorithm-architecture-improvements.md"),
             root,
         };
         paths.ensure().unwrap();
@@ -411,6 +556,7 @@ mod tests {
             memory: root.join("memory"),
             runs_jsonl: root.join("runs.jsonl"),
             score_csv: root.join("score.csv"),
+            algorithm_architecture_markdown: root.join("algorithm-architecture-improvements.md"),
             root,
         };
         paths.ensure().unwrap();

--- a/tools/performance_self_iteration/src/log_scan.rs
+++ b/tools/performance_self_iteration/src/log_scan.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     fs::{self, File},
     io::{Read, Seek, SeekFrom},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use serde::{Deserialize, Serialize};
@@ -119,10 +119,7 @@ fn scan_one(
     Ok(())
 }
 
-fn record_log_scan_truncated(
-    path: &PathBuf,
-    findings: &mut BTreeMap<(String, String), LogFinding>,
-) {
+fn record_log_scan_truncated(path: &Path, findings: &mut BTreeMap<(String, String), LogFinding>) {
     let severity = "ERROR".to_owned();
     let signature = format!("log scan exceeded {} byte cap", MAX_LOG_SCAN_BYTES);
     findings

--- a/tools/performance_self_iteration/src/main.rs
+++ b/tools/performance_self_iteration/src/main.rs
@@ -1,3 +1,4 @@
+mod architecture_notes;
 mod codex;
 mod command;
 mod config;
@@ -107,7 +108,18 @@ async fn evaluate_current(cli: &Cli, paths: &history::HistoryPaths) -> Result<i3
     let previous = history::previous_scored_run(paths, &cli.profile)?;
     let evaluation = evaluate_candidate(cli, paths, &run_id, &patch).await?;
     let score = scoring::score_evaluation(&evaluation.observation, previous.as_ref());
-    let report_path = history::write_report(paths, &run_id, &evaluation.report)?;
+    let algorithm_architecture_improvements =
+        architecture_notes::candidate_algorithm_architecture_improvements(
+            &patch,
+            None,
+            &score,
+            &evaluation.observation,
+        );
+    let report = architecture_notes::report_with_algorithm_architecture_improvements(
+        &evaluation.report,
+        &algorithm_architecture_improvements,
+    )?;
+    let report_path = history::write_report(paths, &run_id, &report)?;
     let record = history::make_run_record(history::RunRecordInput {
         run_id: &run_id,
         profile: &cli.profile,
@@ -116,10 +128,12 @@ async fn evaluate_current(cli: &Cli, paths: &history::HistoryPaths) -> Result<i3
         report_path: &report_path,
         score: &score,
         observation: &evaluation.observation,
+        algorithm_architecture_improvements: &algorithm_architecture_improvements,
         commit: None,
     });
     history::append_run(paths, &record)?;
     history::write_memory(paths, &record)?;
+    history::append_algorithm_architecture_markdown(paths, &record)?;
     println!(
         "[perf-iterate] score={:.6} accepted={} reasons={}",
         score.score,
@@ -214,9 +228,12 @@ async fn run_generation_iteration(cli: &Cli, paths: &history::HistoryPaths) -> R
             &run_id,
             &patch,
             &evaluation,
-            &base_state,
-            ignored_snapshot.as_ref(),
-            previous.as_ref(),
+            RejectionContext {
+                base_state: &base_state,
+                ignored_snapshot: ignored_snapshot.as_ref(),
+                previous: previous.as_ref(),
+                codex_result: codex_result.as_ref(),
+            },
         )
         .await?;
         return Ok(1);
@@ -265,9 +282,12 @@ async fn run_generation_iteration(cli: &Cli, paths: &history::HistoryPaths) -> R
             &run_id,
             &patch,
             &evaluation,
-            &base_state,
-            ignored_snapshot.as_ref(),
-            previous.as_ref(),
+            RejectionContext {
+                base_state: &base_state,
+                ignored_snapshot: ignored_snapshot.as_ref(),
+                previous: previous.as_ref(),
+                codex_result: codex_result.as_ref(),
+            },
         )
         .await?;
         return Ok(1);
@@ -280,9 +300,12 @@ async fn run_generation_iteration(cli: &Cli, paths: &history::HistoryPaths) -> R
             &run_id,
             &patch,
             &evaluation,
-            &base_state,
-            ignored_snapshot.as_ref(),
-            previous.as_ref(),
+            RejectionContext {
+                base_state: &base_state,
+                ignored_snapshot: ignored_snapshot.as_ref(),
+                previous: previous.as_ref(),
+                codex_result: codex_result.as_ref(),
+            },
         )
         .await?;
         return Ok(1);
@@ -303,9 +326,12 @@ async fn run_generation_iteration(cli: &Cli, paths: &history::HistoryPaths) -> R
                 &run_id,
                 &patch,
                 &evaluation,
-                &base_state,
-                ignored_snapshot.as_ref(),
-                previous.as_ref(),
+                RejectionContext {
+                    base_state: &base_state,
+                    ignored_snapshot: ignored_snapshot.as_ref(),
+                    previous: previous.as_ref(),
+                    codex_result: codex_result.as_ref(),
+                },
             )
             .await?;
             return Ok(1);
@@ -351,7 +377,18 @@ async fn run_generation_iteration(cli: &Cli, paths: &history::HistoryPaths) -> R
         (&evaluation, &score)
     };
     let persist_result = (|| -> Result<(), String> {
-        let report_path = history::write_report(paths, &run_id, &evaluation.report)?;
+        let algorithm_architecture_improvements =
+            architecture_notes::candidate_algorithm_architecture_improvements(
+                &patch,
+                codex_result.as_ref(),
+                score,
+                &evaluation.observation,
+            );
+        let report = architecture_notes::report_with_algorithm_architecture_improvements(
+            &evaluation.report,
+            &algorithm_architecture_improvements,
+        )?;
+        let report_path = history::write_report(paths, &run_id, &report)?;
         let record = history::make_run_record(history::RunRecordInput {
             run_id: &run_id,
             profile: &cli.profile,
@@ -360,10 +397,12 @@ async fn run_generation_iteration(cli: &Cli, paths: &history::HistoryPaths) -> R
             report_path: &report_path,
             score,
             observation: &evaluation.observation,
+            algorithm_architecture_improvements: &algorithm_architecture_improvements,
             commit: commit.as_deref(),
         });
         history::append_run(paths, &record)?;
         history::write_memory(paths, &record)?;
+        history::append_algorithm_architecture_markdown(paths, &record)?;
         Ok(())
     })();
     println!(
@@ -420,19 +459,35 @@ async fn run_generation_iteration(cli: &Cli, paths: &history::HistoryPaths) -> R
     }
 }
 
+struct RejectionContext<'a> {
+    base_state: &'a git_ops::HeadState,
+    ignored_snapshot: Option<&'a git_ops::IgnoredOutputSnapshot>,
+    previous: Option<&'a serde_json::Value>,
+    codex_result: Option<&'a command::CommandResult>,
+}
+
 async fn persist_and_reject(
     cli: &Cli,
     paths: &history::HistoryPaths,
     run_id: &str,
     patch: &git_ops::PatchSnapshot,
     evaluation: &scoring::EvaluationRun,
-    base_state: &git_ops::HeadState,
-    ignored_snapshot: Option<&git_ops::IgnoredOutputSnapshot>,
-    previous: Option<&serde_json::Value>,
+    context: RejectionContext<'_>,
 ) -> Result<(), String> {
     let persist_result = (|| -> Result<(), String> {
-        let score = scoring::score_evaluation(&evaluation.observation, previous);
-        let report_path = history::write_report(paths, run_id, &evaluation.report)?;
+        let score = scoring::score_evaluation(&evaluation.observation, context.previous);
+        let algorithm_architecture_improvements =
+            architecture_notes::candidate_algorithm_architecture_improvements(
+                patch,
+                context.codex_result,
+                &score,
+                &evaluation.observation,
+            );
+        let report = architecture_notes::report_with_algorithm_architecture_improvements(
+            &evaluation.report,
+            &algorithm_architecture_improvements,
+        )?;
+        let report_path = history::write_report(paths, run_id, &report)?;
         let record = history::make_run_record(history::RunRecordInput {
             run_id,
             profile: &cli.profile,
@@ -441,14 +496,16 @@ async fn persist_and_reject(
             report_path: &report_path,
             score: &score,
             observation: &evaluation.observation,
+            algorithm_architecture_improvements: &algorithm_architecture_improvements,
             commit: None,
         });
         history::append_run(paths, &record)?;
         history::write_memory(paths, &record)?;
+        history::append_algorithm_architecture_markdown(paths, &record)?;
         Ok(())
     })();
     let restore_result = if should_restore_rejected_candidate(cli.use_current_candidate) {
-        restore_candidate_worktree(&cli.workspace, base_state, ignored_snapshot)
+        restore_candidate_worktree(&cli.workspace, context.base_state, context.ignored_snapshot)
     } else {
         Ok(())
     };
@@ -484,9 +541,12 @@ async fn reject_patch_capture_failure(
         run_id,
         &patch,
         &evaluation,
-        base_state,
-        ignored_snapshot,
-        previous,
+        RejectionContext {
+            base_state,
+            ignored_snapshot,
+            previous,
+            codex_result: None,
+        },
     )
     .await
 }
@@ -992,6 +1052,7 @@ mod tests {
             memory: root.join("memory"),
             runs_jsonl: root.join("runs.jsonl"),
             score_csv: root.join("score.csv"),
+            algorithm_architecture_markdown: root.join("algorithm-architecture-improvements.md"),
             root,
         }
     }
@@ -1037,9 +1098,12 @@ mod tests {
             "current-preserve",
             &patch,
             &evaluation,
-            &base_state,
-            Some(&ignored_snapshot),
-            None,
+            RejectionContext {
+                base_state: &base_state,
+                ignored_snapshot: Some(&ignored_snapshot),
+                previous: None,
+                codex_result: None,
+            },
         )
         .await
         .unwrap();
@@ -1211,9 +1275,12 @@ mod tests {
             "preloaded-baseline",
             &patch,
             &evaluation,
-            &base_state,
-            Some(&ignored_snapshot),
-            Some(&previous),
+            RejectionContext {
+                base_state: &base_state,
+                ignored_snapshot: Some(&ignored_snapshot),
+                previous: Some(&previous),
+                codex_result: None,
+            },
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- record candidate algorithm architecture improvements in performance self-iteration run records, reports, memory, and markdown history
- prompt generated candidates to provide explicit algorithm architecture improvement notes
- document the new self-iteration state artifact

Fixes #948

## Validation
- cargo fmt --manifest-path tools/performance_self_iteration/Cargo.toml
- cargo clippy --locked --manifest-path tools/performance_self_iteration/Cargo.toml -- -D warnings
- cargo test --locked --manifest-path tools/performance_self_iteration/Cargo.toml
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests
- cargo run --locked --manifest-path tools/performance_self_iteration/Cargo.toml -- evaluate --workspace . --use-current-candidate --profile smoke (expected exit 1 from smoke acceptance gate; verified records were written)