### PR TITLE
Default self-iteration Codex runs to yolo

### DIFF
--- a/tools/performance_self_iteration/src/codex.rs
+++ b/tools/performance_self_iteration/src/codex.rs
@@ -29,7 +29,7 @@ pub fn run_codex(cli: &Cli, prompt: &str) -> Result<CommandResult, String> {
 
 pub fn build_codex_command(cli: &Cli) -> Vec<String> {
     let mut command = vec![cli.codex_path.clone()];
-    if cli.yolo {
+    if cli.effective_yolo() {
         command.extend(["-a".to_owned(), "never".to_owned()]);
     }
     command.extend([
@@ -37,7 +37,7 @@ pub fn build_codex_command(cli: &Cli) -> Vec<String> {
         "-C".to_owned(),
         cli.workspace.display().to_string(),
     ]);
-    if cli.yolo {
+    if cli.effective_yolo() {
         command.extend([
             "--dangerously-bypass-approvals-and-sandbox".to_owned(),
             "-s".to_owned(),
@@ -120,6 +120,7 @@ mod tests {
             stop_after_accepted: None,
             sleep_seconds: 1,
             yolo: true,
+            no_yolo: false,
             dry_run_codex: false,
             use_current_candidate: false,
             fail_fast: false,
@@ -136,6 +137,44 @@ mod tests {
         assert!(command.iter().any(|item| item == "-a"));
         assert!(
             command
+                .iter()
+                .any(|item| item == "--dangerously-bypass-approvals-and-sandbox")
+        );
+    }
+
+    #[test]
+    fn no_yolo_omits_noninteractive_flags() {
+        let cli = Cli {
+            mode: Mode::Once,
+            workspace: PathBuf::from("."),
+            profile: "smoke".to_owned(),
+            base_url: "http://127.0.0.1:8000".to_owned(),
+            concurrency: 1,
+            duration_seconds: 1,
+            sessions: 1,
+            request_timeout_seconds: 1,
+            log_files: Vec::new(),
+            max_iterations: None,
+            stop_after_accepted: None,
+            sleep_seconds: 1,
+            yolo: true,
+            no_yolo: true,
+            dry_run_codex: false,
+            use_current_candidate: false,
+            fail_fast: false,
+            commit_accepted: false,
+            commit_message: None,
+            codex_path: "codex".to_owned(),
+            model: "gpt-5.5".to_owned(),
+            codex_reasoning_effort: "xhigh".to_owned(),
+            codex_profile: None,
+            codex_timeout_seconds: 1,
+            command_timeout_seconds: 1,
+        };
+        let command = build_codex_command(&cli);
+        assert!(!command.iter().any(|item| item == "-a"));
+        assert!(
+            !command
                 .iter()
                 .any(|item| item == "--dangerously-bypass-approvals-and-sandbox")
         );
@@ -168,6 +207,7 @@ mod tests {
             stop_after_accepted: None,
             sleep_seconds: 1,
             yolo: false,
+            no_yolo: false,
             dry_run_codex: false,
             use_current_candidate: false,
             fail_fast: false,

--- a/tools/performance_self_iteration/src/config.rs
+++ b/tools/performance_self_iteration/src/config.rs
@@ -39,8 +39,10 @@ pub struct Cli {
     pub stop_after_accepted: Option<usize>,
     #[arg(long, default_value_t = 5)]
     pub sleep_seconds: u64,
-    #[arg(long)]
+    #[arg(long, default_value_t = true)]
     pub yolo: bool,
+    #[arg(long)]
+    pub no_yolo: bool,
     #[arg(long)]
     pub dry_run_codex: bool,
     #[arg(long)]
@@ -68,6 +70,10 @@ pub struct Cli {
 impl Cli {
     pub fn parse_args() -> Self {
         Self::parse()
+    }
+
+    pub fn effective_yolo(&self) -> bool {
+        self.yolo && !self.no_yolo
     }
 
     pub fn validate_profile(&self) -> Result<(), String> {
@@ -215,6 +221,7 @@ mod tests {
             stop_after_accepted: None,
             sleep_seconds: 5,
             yolo: false,
+            no_yolo: false,
             dry_run_codex: false,
             use_current_candidate: false,
             fail_fast: false,
@@ -250,6 +257,7 @@ mod tests {
             stop_after_accepted: None,
             sleep_seconds: 1,
             yolo: false,
+            no_yolo: false,
             dry_run_codex: false,
             use_current_candidate: false,
             fail_fast: false,
@@ -286,6 +294,7 @@ mod tests {
             stop_after_accepted: None,
             sleep_seconds: 1,
             yolo: false,
+            no_yolo: false,
             dry_run_codex: false,
             use_current_candidate: false,
             fail_fast: false,
@@ -318,5 +327,19 @@ mod tests {
         assert!(gates.iter().any(|gate| gate.name == "basedpyright"));
         assert!(gates.iter().any(|gate| gate.name == "pytest_unit"));
         assert!(gates.iter().any(|gate| gate.name == "pytest_integration"));
+    }
+
+    #[test]
+    fn yolo_is_effective_by_default() {
+        let cli = Cli::try_parse_from(["relay-teams-performance-iterate"]).unwrap();
+
+        assert!(cli.effective_yolo());
+    }
+
+    #[test]
+    fn no_yolo_disables_effective_yolo() {
+        let cli = Cli::try_parse_from(["relay-teams-performance-iterate", "--no-yolo"]).unwrap();
+
+        assert!(!cli.effective_yolo());
     }
 }

--- a/tools/performance_self_iteration/src/main.rs
+++ b/tools/performance_self_iteration/src/main.rs
@@ -996,6 +996,7 @@ mod tests {
             stop_after_accepted: None,
             sleep_seconds: 1,
             yolo: false,
+            no_yolo: false,
             dry_run_codex: false,
             use_current_candidate: false,
             fail_fast: false,


### PR DESCRIPTION
## Summary
- enable yolo behavior by default for performance self-iteration Codex generation
- add an explicit --no-yolo opt-out
- route Codex command construction through the effective yolo setting and cover both modes with tests

Fixes #950

## Validation
- cargo fmt --manifest-path tools/performance_self_iteration/Cargo.toml -- --check
- cargo test --locked --manifest-path tools/performance_self_iteration/Cargo.toml
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests