### PR TITLE
Guard semantic consolidation without backend

### DIFF
--- a/src/relay_teams/memory/event_handler.py
+++ b/src/relay_teams/memory/event_handler.py
@@ -258,6 +258,13 @@ class MemoryEventHandler:
                 ),
             )
             try:
+                if not self._memory_bank.semantic_consolidation_available():
+                    LOGGER.debug(
+                        "semantic consolidation skipped for run=%s because no "
+                        "semantic backend is configured",
+                        run_id,
+                    )
+                    return
                 semantic_result = await self._memory_bank.consolidate_async(
                     semantic_request
                 )

--- a/src/relay_teams/memory/service.py
+++ b/src/relay_teams/memory/service.py
@@ -290,6 +290,11 @@ class MemoryBankService:
         self._message_repo = message_repo
         self._event_log = event_log
 
+    def semantic_consolidation_available(self) -> bool:
+        return (
+            self._message_repo is not None and self._llm_provider_resolver() is not None
+        )
+
     # ------------------------------------------------------------------
     # 1. Create
     # ------------------------------------------------------------------

--- a/tests/unit_tests/memory/test_event_handler_async.py
+++ b/tests/unit_tests/memory/test_event_handler_async.py
@@ -29,6 +29,7 @@ def mock_memory_bank() -> MagicMock:
     empty_query_result.total_count = 0
     svc.list_entries_async = AsyncMock(return_value=empty_query_result)
     svc.infer_single_run_role_id_async = AsyncMock(return_value=None)
+    svc.semantic_consolidation_available = MagicMock(return_value=True)
     svc.consolidate_async = AsyncMock(
         return_value=MemoryConsolidationResult(
             source_entry_count=2,
@@ -144,6 +145,22 @@ class TestOnRunCompletedAsync:
             run_id=None,
         )
         assert mock_memory_bank.consolidate_async.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_semantic_not_triggered_without_backend(
+        self, handler: MemoryEventHandler, mock_memory_bank: MagicMock
+    ) -> None:
+        mock_memory_bank.semantic_consolidation_available.return_value = False
+
+        await handler.on_run_completed_async(
+            workspace_id="ws-1",
+            session_id="sess-1",
+            run_id="run-1",
+        )
+
+        assert mock_memory_bank.consolidate_async.call_count == 1
+        request = mock_memory_bank.consolidate_async.call_args.args[0]
+        assert request.consolidation_mode == ConsolidationMode.STRUCTURAL
 
     @pytest.mark.asyncio
     async def test_semantic_failure_non_fatal(

--- a/tests/unit_tests/memory/test_semantic_consolidation.py
+++ b/tests/unit_tests/memory/test_semantic_consolidation.py
@@ -62,6 +62,46 @@ def service_with_llm(tmp_path: Path) -> MemoryBankService:
     return MemoryBankService(repository=repo, llm_provider=provider)
 
 
+class _SemanticMessageRepo:
+    async def get_messages_by_session_run_ids_async(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        _ = (
+            session_id,
+            run_ids,
+            include_cleared,
+            include_hidden_from_context,
+        )
+        return []
+
+
+async def test_semantic_consolidation_available_requires_provider_and_message_repo(
+    tmp_path: Path,
+) -> None:
+    missing_provider = MemoryBankService(
+        repository=MemoryBankRepository(tmp_path / "missing_provider.db"),
+        message_repo=_SemanticMessageRepo(),
+    )
+    missing_message_repo = MemoryBankService(
+        repository=MemoryBankRepository(tmp_path / "missing_message_repo.db"),
+        llm_provider=EchoProvider(),
+    )
+    configured = MemoryBankService(
+        repository=MemoryBankRepository(tmp_path / "configured.db"),
+        llm_provider=EchoProvider(),
+        message_repo=_SemanticMessageRepo(),
+    )
+
+    assert missing_provider.semantic_consolidation_available() is False
+    assert missing_message_repo.semantic_consolidation_available() is False
+    assert configured.semantic_consolidation_available() is True
+
+
 def _create_entry_request(**overrides: object) -> CreateMemoryEntryRequest:
     base: dict[str, object] = {
         "tier": MemoryTier.WORKING,


### PR DESCRIPTION
## Summary
- Skip semantic consolidation when no semantic backend is configured
- Add MemoryBankService availability check for provider and message repository
- Add unit coverage for handler skip behavior and service availability

Fixes #958

## Validation
- uv run --extra dev pytest -q tests/unit_tests/memory/test_event_handler_async.py tests/unit_tests/memory/test_semantic_consolidation.py
- uv run --extra dev ruff check src/relay_teams/memory/event_handler.py src/relay_teams/memory/service.py tests/unit_tests/memory/test_event_handler_async.py tests/unit_tests/memory/test_semantic_consolidation.py