### PR TITLE
Improve high-concurrency performance

### DIFF
--- a/src/relay_teams/gateway/xiaoluban/im_listener.py
+++ b/src/relay_teams/gateway/xiaoluban/im_listener.py
@@ -49,12 +49,16 @@ class XiaolubanImListenerService:
         public_host: str | None = None,
     ) -> None:
         self._service = service
+        raw_env_port = os.environ.get(XIAOLUBAN_IM_LISTENER_PORT_ENV)
         self._host = _normalize_host(
             host
             or os.environ.get(XIAOLUBAN_IM_LISTENER_HOST_ENV)
             or DEFAULT_XIAOLUBAN_IM_LISTENER_HOST
         )
         self._port = port or _listener_port_from_env()
+        self._port_explicitly_configured = (
+            port is not None or raw_env_port is not None and bool(raw_env_port.strip())
+        )
         self._public_host = _normalize_optional_host(
             public_host or os.environ.get(XIAOLUBAN_IM_PUBLIC_HOST_ENV)
         )
@@ -80,12 +84,21 @@ class XiaolubanImListenerService:
             if self.is_running():
                 return
             if not _can_bind(self._host, self._port):
+                level = (
+                    logging.WARNING
+                    if self._port_explicitly_configured
+                    else logging.INFO
+                )
                 log_event(
                     LOGGER,
-                    logging.WARNING,
+                    level,
                     event="gateway.xiaoluban.im_listener.port_unavailable",
                     message="Xiaoluban IM listener port is unavailable",
-                    payload={"host": self._host, "port": self._port},
+                    payload={
+                        "host": self._host,
+                        "port": self._port,
+                        "explicit_port": self._port_explicitly_configured,
+                    },
                 )
                 return
             config = uvicorn.Config(

--- a/src/relay_teams/interfaces/server/app.py
+++ b/src/relay_teams/interfaces/server/app.py
@@ -1150,7 +1150,7 @@ def _register_signal_handlers() -> None:
         signame = signal.Signals(sig).name
         log_event(
             logger,
-            logging.WARNING,
+            logging.INFO,
             event="process.signal.received",
             message="Shutdown signal received",
             payload={"signal": signame},

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -109,6 +109,7 @@ from relay_teams.hooks import HookService
 logger = get_logger(__name__)
 _T = TypeVar("_T")
 SLOW_RUN_WORKER_STAGE_SECONDS = 1.0
+SLOW_COMPLETED_RUNNER_STAGE_WARNING_SECONDS = 15.0
 RUN_START_SCHEDULER_CONCURRENCY = 2
 
 
@@ -132,10 +133,15 @@ def _log_slow_run_worker_stage(
     elapsed_seconds = time.perf_counter() - started
     if elapsed_seconds < SLOW_RUN_WORKER_STAGE_SECONDS:
         return
+    log_level = _slow_run_worker_stage_log_level(
+        stage=stage,
+        elapsed_seconds=elapsed_seconds,
+        payload=payload,
+    )
     with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
         log_event(
             logger,
-            logging.WARNING,
+            log_level,
             event="run.worker.stage_slow",
             message="Run worker stage was slow",
             duration_ms=int(elapsed_seconds * 1000),
@@ -144,6 +150,21 @@ def _log_slow_run_worker_stage(
                 **(payload or {}),
             },
         )
+
+
+def _slow_run_worker_stage_log_level(
+    *,
+    stage: str,
+    elapsed_seconds: float,
+    payload: dict[str, JsonValue] | None,
+) -> int:
+    if stage != "runner":
+        return logging.WARNING
+    if payload is None or payload.get("status") != "completed":
+        return logging.WARNING
+    if elapsed_seconds >= SLOW_COMPLETED_RUNNER_STAGE_WARNING_SECONDS:
+        return logging.WARNING
+    return logging.DEBUG
 
 
 def _clear_current_task_cancellation_requests() -> None:

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -1497,6 +1497,10 @@ def test_browser_workspace_and_automation_project_views(
     page.locator("#project-view-close").click()
     expect(page.locator("#project-view")).to_be_hidden(timeout=_WAIT_TIMEOUT_MS)
 
+    workspace_card.hover()
+    expect(workspace_card.locator(".project-options-btn")).to_be_visible(
+        timeout=_WAIT_TIMEOUT_MS
+    )
     with page.expect_request(
         lambda request: (
             request.method == "DELETE"

--- a/tests/unit_tests/gateway/test_xiaoluban_im_listener.py
+++ b/tests/unit_tests/gateway/test_xiaoluban_im_listener.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi.testclient import TestClient
 import pytest
 
+import relay_teams.gateway.xiaoluban.im_listener as im_listener_module
 from relay_teams.gateway.xiaoluban.im_listener import (
     _format_host_for_url,
     _is_local_or_unspecified_hostname,
@@ -221,6 +224,74 @@ def test_is_running_returns_false_when_not_started() -> None:
     listener = XiaolubanImListenerService(service=_FakeInboundHandler())
 
     assert listener.is_running() is False
+
+
+def test_default_listener_port_unavailable_logs_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RELAY_TEAMS_XIAOLUBAN_IM_LISTENER_PORT", raising=False)
+    monkeypatch.setattr(im_listener_module, "_can_bind", lambda _host, _port: False)
+    logged_levels: list[int] = []
+    logged_payloads: list[dict[str, object]] = []
+
+    def fake_log_event(
+        _logger: logging.Logger,
+        level: int,
+        *,
+        event: str,
+        message: str,
+        payload: dict[str, object] | None = None,
+        duration_ms: int | None = None,
+        exc_info: BaseException | None = None,
+    ) -> None:
+        _ = event, message, duration_ms, exc_info
+        logged_levels.append(level)
+        if payload is not None:
+            logged_payloads.append(payload)
+
+    monkeypatch.setattr(im_listener_module, "log_event", fake_log_event)
+
+    listener = XiaolubanImListenerService(service=_FakeInboundHandler())
+    listener.start()
+
+    assert logged_levels == [logging.INFO]
+    assert logged_payloads == [
+        {"host": "0.0.0.0", "port": 9009, "explicit_port": False}
+    ]
+
+
+def test_explicit_listener_port_unavailable_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(im_listener_module, "_can_bind", lambda _host, _port: False)
+    logged_levels: list[int] = []
+    logged_payloads: list[dict[str, object]] = []
+
+    def fake_log_event(
+        _logger: logging.Logger,
+        level: int,
+        *,
+        event: str,
+        message: str,
+        payload: dict[str, object] | None = None,
+        duration_ms: int | None = None,
+        exc_info: BaseException | None = None,
+    ) -> None:
+        _ = event, message, duration_ms, exc_info
+        logged_levels.append(level)
+        if payload is not None:
+            logged_payloads.append(payload)
+
+    monkeypatch.setattr(im_listener_module, "log_event", fake_log_event)
+
+    listener = XiaolubanImListenerService(
+        service=_FakeInboundHandler(),
+        port=9010,
+    )
+    listener.start()
+
+    assert logged_levels == [logging.WARNING]
+    assert logged_payloads == [{"host": "0.0.0.0", "port": 9010, "explicit_port": True}]
 
 
 def test_format_host_for_url_ipv6() -> None:

--- a/tests/unit_tests/gateway/test_xiaoluban_im_listener.py
+++ b/tests/unit_tests/gateway/test_xiaoluban_im_listener.py
@@ -5,7 +5,6 @@ import logging
 from fastapi.testclient import TestClient
 import pytest
 
-import relay_teams.gateway.xiaoluban.im_listener as im_listener_module
 from relay_teams.gateway.xiaoluban.im_listener import (
     _format_host_for_url,
     _is_local_or_unspecified_hostname,
@@ -230,7 +229,10 @@ def test_default_listener_port_unavailable_logs_info(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("RELAY_TEAMS_XIAOLUBAN_IM_LISTENER_PORT", raising=False)
-    monkeypatch.setattr(im_listener_module, "_can_bind", lambda _host, _port: False)
+    monkeypatch.setattr(
+        "relay_teams.gateway.xiaoluban.im_listener._can_bind",
+        lambda _host, _port: False,
+    )
     logged_levels: list[int] = []
     logged_payloads: list[dict[str, object]] = []
 
@@ -249,7 +251,10 @@ def test_default_listener_port_unavailable_logs_info(
         if payload is not None:
             logged_payloads.append(payload)
 
-    monkeypatch.setattr(im_listener_module, "log_event", fake_log_event)
+    monkeypatch.setattr(
+        "relay_teams.gateway.xiaoluban.im_listener.log_event",
+        fake_log_event,
+    )
 
     listener = XiaolubanImListenerService(service=_FakeInboundHandler())
     listener.start()
@@ -263,7 +268,10 @@ def test_default_listener_port_unavailable_logs_info(
 def test_explicit_listener_port_unavailable_logs_warning(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(im_listener_module, "_can_bind", lambda _host, _port: False)
+    monkeypatch.setattr(
+        "relay_teams.gateway.xiaoluban.im_listener._can_bind",
+        lambda _host, _port: False,
+    )
     logged_levels: list[int] = []
     logged_payloads: list[dict[str, object]] = []
 
@@ -282,7 +290,10 @@ def test_explicit_listener_port_unavailable_logs_warning(
         if payload is not None:
             logged_payloads.append(payload)
 
-    monkeypatch.setattr(im_listener_module, "log_event", fake_log_event)
+    monkeypatch.setattr(
+        "relay_teams.gateway.xiaoluban.im_listener.log_event",
+        fake_log_event,
+    )
 
     listener = XiaolubanImListenerService(
         service=_FakeInboundHandler(),

--- a/tests/unit_tests/interfaces/server/test_app.py
+++ b/tests/unit_tests/interfaces/server/test_app.py
@@ -53,6 +53,7 @@ def test_register_signal_handlers_logs_and_chains_previous_handler(
 ) -> None:
     assigned_handlers: dict[int, server_app.SignalHandler] = {}
     previous_called_with: list[int] = []
+    logged_levels: list[int] = []
     logged_signals: list[str] = []
 
     def previous_handler(sig: int, _frame: FrameType | None) -> None:
@@ -67,8 +68,18 @@ def test_register_signal_handlers_logs_and_chains_previous_handler(
         assigned_handlers[sig] = handler
         return previous_handler
 
-    def fake_log_event(*_args: object, **kwargs: object) -> None:
-        payload = kwargs.get("payload")
+    def fake_log_event(
+        _logger: logging.Logger,
+        level: int,
+        *,
+        event: str,
+        message: str,
+        payload: dict[str, object] | None = None,
+        duration_ms: int | None = None,
+        exc_info: BaseException | None = None,
+    ) -> None:
+        _ = event, message, duration_ms, exc_info
+        logged_levels.append(level)
         if isinstance(payload, dict):
             signal_name = payload.get("signal")
             if isinstance(signal_name, str):
@@ -83,6 +94,7 @@ def test_register_signal_handlers_logs_and_chains_previous_handler(
     assigned_handlers[signal.SIGINT](signal.SIGINT, None)
 
     assert previous_called_with == [signal.SIGINT]
+    assert logged_levels == [logging.INFO]
     assert logged_signals == ["SIGINT"]
 
 

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -4958,13 +4958,14 @@ async def test_ensure_run_started_local_async_validates_recoverable_state(
 def test_log_slow_run_worker_stage_emits_warning(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    events: list[tuple[str, int]] = []
+    events: list[tuple[str, int, int]] = []
 
     def capture_log_event(*args: object, **kwargs: object) -> None:
-        _ = args
+        level = args[1]
+        assert isinstance(level, int)
         duration_ms = kwargs["duration_ms"]
         assert isinstance(duration_ms, int)
-        events.append((str(kwargs["event"]), duration_ms))
+        events.append((str(kwargs["event"]), duration_ms, level))
 
     monkeypatch.setattr(run_service_module.time, "perf_counter", lambda: 12.5)
     monkeypatch.setattr(run_service_module, "log_event", capture_log_event)
@@ -4977,7 +4978,74 @@ def test_log_slow_run_worker_stage_emits_warning(
         payload={"queued": True},
     )
 
-    assert events == [("run.worker.stage_slow", 2500)]
+    assert events == [
+        ("run.worker.stage_slow", 2500, run_service_module.logging.WARNING)
+    ]
+
+
+def test_completed_runner_stage_below_runner_warning_threshold_logs_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, int, int]] = []
+
+    def capture_log_event(*args: object, **kwargs: object) -> None:
+        level = args[1]
+        assert isinstance(level, int)
+        duration_ms = kwargs["duration_ms"]
+        assert isinstance(duration_ms, int)
+        events.append((str(kwargs["event"]), duration_ms, level))
+
+    monkeypatch.setattr(run_service_module.time, "perf_counter", lambda: 12.5)
+    monkeypatch.setattr(run_service_module, "log_event", capture_log_event)
+
+    run_service_module._log_slow_run_worker_stage(
+        run_id="run-1",
+        session_id="session-1",
+        stage="runner",
+        started=10.0,
+        payload={
+            "status": "completed",
+            "completion_reason": "assistant_response",
+        },
+    )
+
+    assert events == [("run.worker.stage_slow", 2500, run_service_module.logging.DEBUG)]
+
+
+def test_completed_runner_stage_above_runner_warning_threshold_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, int, int]] = []
+
+    def capture_log_event(*args: object, **kwargs: object) -> None:
+        level = args[1]
+        assert isinstance(level, int)
+        duration_ms = kwargs["duration_ms"]
+        assert isinstance(duration_ms, int)
+        events.append((str(kwargs["event"]), duration_ms, level))
+
+    monkeypatch.setattr(
+        run_service_module,
+        "SLOW_COMPLETED_RUNNER_STAGE_WARNING_SECONDS",
+        3.0,
+    )
+    monkeypatch.setattr(run_service_module.time, "perf_counter", lambda: 13.25)
+    monkeypatch.setattr(run_service_module, "log_event", capture_log_event)
+
+    run_service_module._log_slow_run_worker_stage(
+        run_id="run-1",
+        session_id="session-1",
+        stage="runner",
+        started=10.0,
+        payload={
+            "status": "completed",
+            "completion_reason": "assistant_response",
+        },
+    )
+
+    assert events == [
+        ("run.worker.stage_slow", 3250, run_service_module.logging.WARNING)
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- improve high-concurrency runtime behavior
- add regression coverage for app, listener, browser smoke, and run service recovery paths

Fixes #960

## Tests
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev ruff check --no-cache --force-exclude .
- uv run --extra dev ruff format --check --no-cache --force-exclude .
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests (running)
