### PR TITLE
Prevent background task waits from blocking tool execution

### DIFF
--- a/src/relay_teams/interfaces/cli/app.py
+++ b/src/relay_teams/interfaces/cli/app.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import http.client
 import ipaddress
 import json
+import logging
+import math
 import os
 from pathlib import Path
 import re
@@ -30,6 +32,7 @@ from relay_teams.interfaces.cli.manifest import (
     CLI_ROOT_HELP,
     CliCommandSpec,
 )
+from relay_teams.logger import get_logger, log_event
 
 try:
     import keyring
@@ -37,6 +40,11 @@ except ImportError:  # pragma: no cover - import availability depends on environ
     keyring = None
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+DEFAULT_FAST_PROMPT_STREAM_TIMEOUT_SECONDS = 600.0
+FAST_PROMPT_STREAM_TIMEOUT_SECONDS_ENV = (
+    "RELAY_TEAMS_FAST_PROMPT_STREAM_TIMEOUT_SECONDS"
+)
+LOGGER = get_logger(__name__)
 _APP_ENV_SECRET_NAMESPACE = "app_env"
 _KEYRING_SERVICE_NAME = "agent-teams"
 _SECRETS_FILE_NAME = "secrets.json"
@@ -1547,7 +1555,11 @@ def _stream_fast_prompt_events(*, base_url: str, run_id: str) -> None:
         if parsed.scheme == "https"
         else http.client.HTTPConnection
     )
-    connection = connection_class(address, port, timeout=600.0)
+    connection = connection_class(
+        address,
+        port,
+        timeout=_resolve_fast_prompt_stream_timeout_seconds(),
+    )
     try:
         connection.request(
             "GET",
@@ -1572,6 +1584,32 @@ def _stream_fast_prompt_events(*, base_url: str, run_id: str) -> None:
                 return
     finally:
         connection.close()
+
+
+def _resolve_fast_prompt_stream_timeout_seconds() -> float:
+    raw_value = os.environ.get(FAST_PROMPT_STREAM_TIMEOUT_SECONDS_ENV)
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_FAST_PROMPT_STREAM_TIMEOUT_SECONDS
+    normalized = raw_value.strip()
+    try:
+        timeout_seconds = float(normalized)
+    except ValueError:
+        _log_invalid_fast_prompt_stream_timeout(raw_value)
+        return DEFAULT_FAST_PROMPT_STREAM_TIMEOUT_SECONDS
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        _log_invalid_fast_prompt_stream_timeout(raw_value)
+        return DEFAULT_FAST_PROMPT_STREAM_TIMEOUT_SECONDS
+    return timeout_seconds
+
+
+def _log_invalid_fast_prompt_stream_timeout(raw_value: str) -> None:
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="cli.fast_prompt.stream_timeout.invalid_env",
+        message="Ignoring invalid fast prompt stream timeout",
+        payload={FAST_PROMPT_STREAM_TIMEOUT_SECONDS_ENV: raw_value},
+    )
 
 
 def _handle_fast_prompt_stream_line(line: str) -> bool:

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -9,6 +9,7 @@ import contextvars
 import inspect
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
@@ -118,11 +119,72 @@ from relay_teams.hooks import (
 LOGGER = get_logger(__name__)
 ParamT = ParamSpec("ParamT")
 ResultT = TypeVar("ResultT")
-TOOL_ACTION_WORKER_COUNT = 16
 TOOL_STATE_WORKER_COUNT = 4
 TOOL_APPROVAL_WORKER_COUNT = 4
-PER_RUN_TOOL_ACTION_CONCURRENCY = 8
-GLOBAL_TOOL_ACTION_CONCURRENCY = 16
+DEFAULT_TOOL_ACTION_WORKER_COUNT = 16
+DEFAULT_PER_RUN_TOOL_ACTION_CONCURRENCY = 8
+DEFAULT_GLOBAL_TOOL_ACTION_CONCURRENCY = 16
+DEFAULT_WAIT_TOOL_ACTION_CONCURRENCY = 64
+TOOL_ACTION_WORKER_COUNT_ENV = "RELAY_TEAMS_TOOL_ACTION_WORKER_COUNT"
+PER_RUN_TOOL_ACTION_CONCURRENCY_ENV = "RELAY_TEAMS_PER_RUN_TOOL_ACTION_CONCURRENCY"
+GLOBAL_TOOL_ACTION_CONCURRENCY_ENV = "RELAY_TEAMS_GLOBAL_TOOL_ACTION_CONCURRENCY"
+WAIT_TOOL_ACTION_CONCURRENCY_ENV = "RELAY_TEAMS_WAIT_TOOL_ACTION_CONCURRENCY"
+
+
+def _resolve_positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tools.runtime.invalid_env",
+            message="Ignoring invalid tool runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tools.runtime.invalid_env",
+            message="Ignoring non-positive tool runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+def _resolve_tool_runtime_limits() -> tuple[int, int, int, int]:
+    return (
+        _resolve_positive_int_env(
+            TOOL_ACTION_WORKER_COUNT_ENV,
+            DEFAULT_TOOL_ACTION_WORKER_COUNT,
+        ),
+        _resolve_positive_int_env(
+            PER_RUN_TOOL_ACTION_CONCURRENCY_ENV,
+            DEFAULT_PER_RUN_TOOL_ACTION_CONCURRENCY,
+        ),
+        _resolve_positive_int_env(
+            GLOBAL_TOOL_ACTION_CONCURRENCY_ENV,
+            DEFAULT_GLOBAL_TOOL_ACTION_CONCURRENCY,
+        ),
+        _resolve_positive_int_env(
+            WAIT_TOOL_ACTION_CONCURRENCY_ENV,
+            DEFAULT_WAIT_TOOL_ACTION_CONCURRENCY,
+        ),
+    )
+
+
+(
+    TOOL_ACTION_WORKER_COUNT,
+    PER_RUN_TOOL_ACTION_CONCURRENCY,
+    GLOBAL_TOOL_ACTION_CONCURRENCY,
+    WAIT_TOOL_ACTION_CONCURRENCY,
+) = _resolve_tool_runtime_limits()
 _TOOL_ACTION_EXECUTOR = ThreadPoolExecutor(
     max_workers=TOOL_ACTION_WORKER_COUNT,
     thread_name_prefix="tool-action",
@@ -136,6 +198,7 @@ _TOOL_APPROVAL_EXECUTOR = ThreadPoolExecutor(
     thread_name_prefix="tool-approval",
 )
 _GLOBAL_TOOL_ACTION_SEMAPHORE = asyncio.Semaphore(GLOBAL_TOOL_ACTION_CONCURRENCY)
+_WAIT_TOOL_ACTION_SEMAPHORE = asyncio.Semaphore(WAIT_TOOL_ACTION_CONCURRENCY)
 _RUN_TOOL_ACTION_GATES_LOCK = threading.Lock()
 _RUN_TOOL_ACTION_GATES: dict[str, _RunToolActionGate] = {}
 _AUDITED_FILE_WRITE_TOOLS = frozenset({"write", "write_tmp", "edit", "notebook_edit"})
@@ -143,6 +206,11 @@ _AUDITED_TOOL_NAMES = _AUDITED_FILE_WRITE_TOOLS | frozenset(
     {"shell", "orch_dispatch_task"}
 )
 _AUDIT_REASON_LIMIT = 4_000
+
+
+class ToolActionCapacity(str, Enum):
+    STANDARD = "standard"
+    WAIT = "wait"
 
 
 class _RunToolActionGate:
@@ -233,6 +301,7 @@ async def execute_tool(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    action_capacity: ToolActionCapacity = ToolActionCapacity.STANDARD,
     allow_tool_return: Literal[False] = False,
 ) -> dict[str, JsonValue]: ...
 
@@ -260,6 +329,7 @@ async def execute_tool(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    action_capacity: ToolActionCapacity = ToolActionCapacity.STANDARD,
     allow_tool_return: Literal[True] = True,
 ) -> ToolReturn | dict[str, JsonValue]: ...
 
@@ -286,6 +356,7 @@ async def execute_tool(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    action_capacity: ToolActionCapacity = ToolActionCapacity.STANDARD,
     allow_tool_return: bool = False,
 ) -> ToolReturn | dict[str, JsonValue]:
     """Run a tool action with approval, logging, and normalized envelopes."""
@@ -515,6 +586,7 @@ async def execute_tool(
                     ctx=ctx,
                     action=action,
                     tool_input=effective_tool_input,
+                    action_capacity=action_capacity,
                 )
             finally:
                 reset_tool_hook_runtime_env(hook_env_token)
@@ -1646,32 +1718,75 @@ async def _invoke_tool_action_with_limits(
     ctx: ToolContext,
     action: Callable[..., object | Awaitable[object]] | object,
     tool_input: dict[str, JsonValue],
+    action_capacity: ToolActionCapacity = ToolActionCapacity.STANDARD,
 ) -> object:
+    if action_capacity is ToolActionCapacity.WAIT:
+        return await _invoke_wait_tool_action_with_limits(
+            ctx=ctx,
+            action=action,
+            tool_input=tool_input,
+        )
+
     run_gate = _retain_run_tool_action_gate(ctx.deps.run_id)
     queued_at = time.perf_counter()
     try:
         async with run_gate.semaphore:
             async with _GLOBAL_TOOL_ACTION_SEMAPHORE:
                 wait_ms = int((time.perf_counter() - queued_at) * 1000)
-                if wait_ms >= 250:
-                    log_event(
-                        LOGGER,
-                        logging.DEBUG,
-                        event="tool.action.queue_wait",
-                        message="Tool action waited for execution capacity",
-                        duration_ms=wait_ms,
-                        payload={
-                            "run_id": ctx.deps.run_id,
-                            "session_id": ctx.deps.session_id,
-                            "tool_call_id": ctx.tool_call_id,
-                        },
-                    )
+                _log_tool_action_queue_wait(
+                    ctx=ctx,
+                    action_capacity=ToolActionCapacity.STANDARD,
+                    wait_ms=wait_ms,
+                )
                 return await _invoke_tool_action_async(
                     action=action,
                     tool_input=tool_input,
                 )
     finally:
         _release_run_tool_action_gate(ctx.deps.run_id, run_gate)
+
+
+async def _invoke_wait_tool_action_with_limits(
+    *,
+    ctx: ToolContext,
+    action: Callable[..., object | Awaitable[object]] | object,
+    tool_input: dict[str, JsonValue],
+) -> object:
+    queued_at = time.perf_counter()
+    async with _WAIT_TOOL_ACTION_SEMAPHORE:
+        wait_ms = int((time.perf_counter() - queued_at) * 1000)
+        _log_tool_action_queue_wait(
+            ctx=ctx,
+            action_capacity=ToolActionCapacity.WAIT,
+            wait_ms=wait_ms,
+        )
+        return await _invoke_tool_action_async(
+            action=action,
+            tool_input=tool_input,
+        )
+
+
+def _log_tool_action_queue_wait(
+    *,
+    ctx: ToolContext,
+    action_capacity: ToolActionCapacity,
+    wait_ms: int,
+) -> None:
+    if wait_ms < 250:
+        return
+    log_event(
+        LOGGER,
+        logging.DEBUG,
+        event="tool.action.queue_wait",
+        message="Tool action waited for execution capacity",
+        duration_ms=wait_ms,
+        payload={
+            "run_id": ctx.deps.run_id,
+            "session_id": ctx.deps.session_id,
+            "tool_call_id": ctx.tool_call_id,
+            "capacity": action_capacity.value,
+        },
+    )
 
 
 def _retain_run_tool_action_gate(run_id: str) -> _RunToolActionGate:

--- a/src/relay_teams/tools/workspace_tools/wait_background_task.py
+++ b/src/relay_teams/tools/workspace_tools/wait_background_task.py
@@ -9,7 +9,7 @@ from relay_teams.tools.runtime.context import (
     ToolContext,
     ToolDeps,
 )
-from relay_teams.tools.runtime.execution import execute_tool
+from relay_teams.tools.runtime.execution import ToolActionCapacity, execute_tool
 from relay_teams.tools.workspace_tools.background_task_tool_support import (
     project_background_task_tool_result,
     require_background_task_service,
@@ -43,4 +43,5 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 "background_task_id": background_task_id,
             },
             action=_action,
+            action_capacity=ToolActionCapacity.WAIT,
         )

--- a/tests/unit_tests/interfaces/cli/test_fast_dispatcher.py
+++ b/tests/unit_tests/interfaces/cli/test_fast_dispatcher.py
@@ -3777,6 +3777,7 @@ def test_fast_prompt_stream_events_reads_sse_until_completion(
             self.closed = True
 
     monkeypatch.setattr(http.client, "HTTPConnection", FakeConnection)
+    monkeypatch.delenv(cli_app.FAST_PROMPT_STREAM_TIMEOUT_SECONDS_ENV, raising=False)
 
     _STREAM_FAST_PROMPT_EVENTS(base_url="http://0.0.0.0:8000/root", run_id="run 1")
 
@@ -3798,6 +3799,67 @@ def test_fast_prompt_stream_events_reads_sse_until_completion(
     ]
     assert connection.closed is True
     assert capsys.readouterr().out == "hi"
+
+
+def test_fast_prompt_stream_events_uses_configured_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeSseResponse:
+        status = 200
+
+        def readline(self) -> bytes:
+            return b'data: {"event_type":"run_completed","payload_json":"{}"}\n'
+
+        def read(self) -> bytes:
+            return b""
+
+    class FakeConnection:
+        instances: list[FakeConnection] = []
+
+        def __init__(self, address: str, port: int, timeout: float) -> None:
+            self.address = address
+            self.port = port
+            self.timeout = timeout
+            self.requests: list[tuple[str, str, dict[str, str]]] = []
+            FakeConnection.instances.append(self)
+
+        def request(
+            self,
+            method: str,
+            path: str,
+            *,
+            headers: dict[str, str],
+        ) -> None:
+            self.requests.append((method, path, headers))
+
+        def getresponse(self) -> FakeSseResponse:
+            return FakeSseResponse()
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(http.client, "HTTPConnection", FakeConnection)
+    monkeypatch.setenv(cli_app.FAST_PROMPT_STREAM_TIMEOUT_SECONDS_ENV, "1800")
+
+    _STREAM_FAST_PROMPT_EVENTS(base_url="http://127.0.0.1:8000", run_id="run-1")
+
+    assert FakeConnection.instances[0].timeout == 1800.0
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    [" ", "not-a-number", "0", "-1", "nan", "inf"],
+)
+def test_fast_prompt_stream_timeout_defaults_when_invalid(
+    raw_value: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(cli_app.FAST_PROMPT_STREAM_TIMEOUT_SECONDS_ENV, raw_value)
+
+    assert (
+        cli_app._resolve_fast_prompt_stream_timeout_seconds()
+        == cli_app.DEFAULT_FAST_PROMPT_STREAM_TIMEOUT_SECONDS
+    )
 
 
 def test_fast_prompt_stream_events_delegates_when_proxy_required(

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -8,7 +8,6 @@ import asyncio
 import sqlite3
 import threading
 import time
-from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
 from types import SimpleNamespace
@@ -173,10 +172,15 @@ class _FakeApprovalManager:
         _ = kwargs
 
 
-@dataclass(frozen=True)
 class _FakePolicy:
-    needs_approval: bool
-    timeout_seconds: float = 0.01
+    def __init__(
+        self,
+        *,
+        needs_approval: bool,
+        timeout_seconds: float = 0.01,
+    ) -> None:
+        self.needs_approval = needs_approval
+        self.timeout_seconds = timeout_seconds
 
     def requires_approval(self, tool_name: str) -> bool:
         _ = tool_name
@@ -510,6 +514,54 @@ def test_execute_tool_marks_reported_failed_result_event_as_error() -> None:
     assert tool_result_payloads[0]["result"] == result
 
 
+@pytest.mark.timeout(10)
+def test_tool_runtime_limits_can_be_configured_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(execution_module.TOOL_ACTION_WORKER_COUNT_ENV, "23")
+    monkeypatch.setenv(execution_module.PER_RUN_TOOL_ACTION_CONCURRENCY_ENV, "11")
+    monkeypatch.setenv(execution_module.GLOBAL_TOOL_ACTION_CONCURRENCY_ENV, "29")
+    monkeypatch.setenv(execution_module.WAIT_TOOL_ACTION_CONCURRENCY_ENV, "97")
+
+    assert execution_module._resolve_tool_runtime_limits() == (
+        23,
+        11,
+        29,
+        97,
+    )
+
+
+def test_tool_runtime_env_resolver_ignores_invalid_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RELAY_TEAMS_TEST_TOOL_LIMIT", "many")
+    assert (
+        execution_module._resolve_positive_int_env(
+            "RELAY_TEAMS_TEST_TOOL_LIMIT",
+            8,
+        )
+        == 8
+    )
+
+    monkeypatch.setenv("RELAY_TEAMS_TEST_TOOL_LIMIT", "0")
+    assert (
+        execution_module._resolve_positive_int_env(
+            "RELAY_TEAMS_TEST_TOOL_LIMIT",
+            8,
+        )
+        == 8
+    )
+
+    monkeypatch.setenv("RELAY_TEAMS_TEST_TOOL_LIMIT", "12")
+    assert (
+        execution_module._resolve_positive_int_env(
+            "RELAY_TEAMS_TEST_TOOL_LIMIT",
+            8,
+        )
+        == 12
+    )
+
+
 def test_tool_action_limits_live_unpersisted_batch_per_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -631,6 +683,137 @@ def test_tool_action_run_gate_waiters_do_not_hold_global_capacity(
 
         assert run_b_started_before_first_a_released is True
         assert results == ["a1", "a2", "b1"]
+        assert execution_module._RUN_TOOL_ACTION_GATES == {}
+
+    asyncio.run(_run())
+
+
+def test_wait_tool_action_capacity_does_not_hold_standard_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        monkeypatch.setattr(execution_module, "PER_RUN_TOOL_ACTION_CONCURRENCY", 1)
+        monkeypatch.setattr(
+            execution_module,
+            "_GLOBAL_TOOL_ACTION_SEMAPHORE",
+            asyncio.Semaphore(1),
+        )
+        monkeypatch.setattr(
+            execution_module,
+            "_WAIT_TOOL_ACTION_SEMAPHORE",
+            asyncio.Semaphore(1),
+        )
+        execution_module._RUN_TOOL_ACTION_GATES.clear()
+
+        ctx = SimpleNamespace(
+            deps=SimpleNamespace(run_id="run-wait", session_id="session-wait"),
+            tool_call_id="tool-wait",
+        )
+        wait_started = asyncio.Event()
+        release_wait = asyncio.Event()
+        standard_started = asyncio.Event()
+
+        async def wait_action() -> str:
+            wait_started.set()
+            await release_wait.wait()
+            return "wait"
+
+        async def standard_action() -> str:
+            standard_started.set()
+            return "standard"
+
+        wait_task = asyncio.create_task(
+            execution_module._invoke_tool_action_with_limits(
+                ctx=cast(ToolContext, cast(object, ctx)),
+                action=wait_action,
+                tool_input={},
+                action_capacity=execution_module.ToolActionCapacity.WAIT,
+            )
+        )
+        await wait_started.wait()
+        standard_task = asyncio.create_task(
+            execution_module._invoke_tool_action_with_limits(
+                ctx=cast(ToolContext, cast(object, ctx)),
+                action=standard_action,
+                tool_input={},
+            )
+        )
+
+        try:
+            await asyncio.wait_for(standard_started.wait(), timeout=0.1)
+            standard_started_before_wait_released = True
+        except TimeoutError:
+            standard_started_before_wait_released = False
+        finally:
+            release_wait.set()
+
+        results = await asyncio.gather(wait_task, standard_task)
+
+        assert standard_started_before_wait_released is True
+        assert results == ["wait", "standard"]
+        assert execution_module._RUN_TOOL_ACTION_GATES == {}
+
+    asyncio.run(_run())
+
+
+def test_wait_tool_action_capacity_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        monkeypatch.setattr(
+            execution_module,
+            "_WAIT_TOOL_ACTION_SEMAPHORE",
+            asyncio.Semaphore(1),
+        )
+        execution_module._RUN_TOOL_ACTION_GATES.clear()
+
+        ctx = SimpleNamespace(
+            deps=SimpleNamespace(run_id="run-wait-limit", session_id="session-wait"),
+            tool_call_id="tool-wait-limit",
+        )
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        second_started = asyncio.Event()
+
+        async def first_wait_action() -> str:
+            first_started.set()
+            await release_first.wait()
+            return "first"
+
+        async def second_wait_action() -> str:
+            second_started.set()
+            return "second"
+
+        first_task = asyncio.create_task(
+            execution_module._invoke_tool_action_with_limits(
+                ctx=cast(ToolContext, cast(object, ctx)),
+                action=first_wait_action,
+                tool_input={},
+                action_capacity=execution_module.ToolActionCapacity.WAIT,
+            )
+        )
+        await first_started.wait()
+        second_task = asyncio.create_task(
+            execution_module._invoke_tool_action_with_limits(
+                ctx=cast(ToolContext, cast(object, ctx)),
+                action=second_wait_action,
+                tool_input={},
+                action_capacity=execution_module.ToolActionCapacity.WAIT,
+            )
+        )
+
+        try:
+            await asyncio.wait_for(second_started.wait(), timeout=0.05)
+            second_started_before_first_released = True
+        except TimeoutError:
+            second_started_before_first_released = False
+        finally:
+            release_first.set()
+
+        results = await asyncio.gather(first_task, second_task)
+
+        assert second_started_before_first_released is False
+        assert results == ["first", "second"]
         assert execution_module._RUN_TOOL_ACTION_GATES == {}
 
     asyncio.run(_run())

--- a/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
+++ b/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
@@ -20,6 +20,7 @@ from relay_teams.sessions.runs.background_tasks.models import (
     BackgroundTaskStatus,
 )
 from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.execution import ToolActionCapacity
 from relay_teams.tools.runtime.models import (
     ToolExecutionError,
     ToolResultProjection,
@@ -648,6 +649,7 @@ async def test_wait_background_task_waits_without_optional_timeout_argument(
         ),
     )
     captured_args: dict[str, object] = {}
+    captured_action_capacity: list[ToolActionCapacity] = []
 
     async def _fake_execute_tool(
         ctx,
@@ -655,10 +657,12 @@ async def test_wait_background_task_waits_without_optional_timeout_argument(
         tool_name: str,
         args_summary: dict[str, object],
         action: Callable[[], Awaitable[ToolResultProjection]],
+        action_capacity: ToolActionCapacity = ToolActionCapacity.STANDARD,
         approval_request=None,
     ) -> dict[str, object]:
         del ctx, tool_name, approval_request
         captured_args.update(args_summary)
+        captured_action_capacity.append(action_capacity)
         return cast(dict[str, object], (await action()).visible_data)
 
     from relay_teams.tools.workspace_tools import (
@@ -674,6 +678,7 @@ async def test_wait_background_task_waits_without_optional_timeout_argument(
         "background_task_id": "subagent_123",
     }
     assert captured_args == {"background_task_id": "subagent_123"}
+    assert captured_action_capacity == [ToolActionCapacity.WAIT]
     assert result["background_task_id"] == "subagent_123"
     assert result["completed"] is True
 


### PR DESCRIPTION
## Summary
- prevent background task waits from consuming tool execution capacity
- add capacity-aware background task wait scheduling
- add CLI/runtime/workspace tool regression tests

Fixes #969

## Tests
- uv run pytest tests/unit_tests/interfaces/cli/test_fast_dispatcher.py tests/unit_tests/tools/runtime/test_execution.py tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
- uv run pytest tests/unit_tests/tools/runtime/test_execution.py -q
- RELAY_TEAMS_UNIT_TEST_TIMEOUT_SECONDS=5 uv run pytest tests/unit_tests/tools/runtime/test_execution.py::test_tool_runtime_limits_can_be_configured_from_environment -q
- uv run ruff check tests/unit_tests/tools/runtime/test_execution.py src/relay_teams/tools/runtime/execution.py
- uv run ruff format --check tests/unit_tests/tools/runtime/test_execution.py src/relay_teams/tools/runtime/execution.py
- uv run basedpyright tests/unit_tests/tools/runtime/test_execution.py src/relay_teams/tools/runtime/execution.py
- changed-file spec gate via .venv Python: PASS