### PR TITLE
feat: inherit model profile for subagents

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -1613,7 +1613,7 @@ Request:
 Rules:
 - Sending `null` clears the override and returns to the selected role's default model.
 - A non-empty value must name an existing model profile or the endpoint returns `422`.
-- The value is only applied to normal-mode root runs and `@Role` targets. Orchestration mode and normal-mode subagents continue to use their configured role models.
+- The value is applied to normal-mode root runs, `@Role` targets, and normal-mode child subagents spawned within that run. Orchestration-mode runs clear the normal-mode override.
 - Existing persisted values that later point at a missing profile do not block run creation; provider construction logs a warning and falls back through the existing provider defaults.
 
 ### `DELETE /sessions/{session_id}`
@@ -1836,6 +1836,7 @@ Response fields include:
 - `updated_at`
 - `runtime_system_prompt`
 - `runtime_tools_json`
+- `model_profile`
 
 ### `GET /sessions/{session_id}/subagents`
 
@@ -1873,6 +1874,7 @@ Response fields include:
 - `deletable`
 - `runtime_system_prompt`
 - `runtime_tools_json`
+- `model_profile`
 
 ### `GET /sessions/{session_id}/subagents:snapshot`
 
@@ -2057,7 +2059,7 @@ Notes:
 - `target_role_id` is optional. When set, that run starts from the specified role instead of the session-default root role, without mutating the saved session topology.
 - `target_role_id` may point to `Coordinator`, `MainAgent`, or any normal role known to the role registry.
 - `normal_model_profile` is optional. When set, it must name an existing model profile and overrides the session normal-mode model profile for this run only.
-- `normal_model_profile` is only applied to normal-mode root runs and `target_role_id` runs. Orchestration-mode runs clear the normal-mode override.
+- `normal_model_profile` is applied to normal-mode root runs, `target_role_id` runs, and normal-mode child subagents spawned within that run. Orchestration-mode runs clear the normal-mode override.
 - `orchestration_policy` is optional. When provided, it overrides the selected orchestration preset policy for that run only and is stored in the run topology snapshot.
 - The backend resolves the session mode at run creation time and snapshots the chosen root topology into the run intent for queued and recoverable resume flows.
 - `session_id`, `target_role_id`, `run_id`, and other identifier-style request fields follow the common identifier validation rules above.

--- a/docs/core/database-schema.md
+++ b/docs/core/database-schema.md
@@ -59,7 +59,7 @@ Notes:
 - `project_kind` and `project_id` identify the logical project owner; workspace sessions default `project_id` to `workspace_id`.
 - `session_mode` is `normal` or `orchestration`.
 - `normal_root_role_id` stores the session-selected root role for normal mode. When `NULL`, runtime falls back to the current `MainAgent`.
-- `normal_model_profile` stores the session-selected normal-mode model override. When `NULL`, the selected root role or `@Role` target uses its role default.
+- `normal_model_profile` stores the session-selected normal-mode model override. When `NULL`, the selected root role, `@Role` target, or normal-mode child subagent uses its role default.
 - `orchestration_preset_id` stores the session-selected preset for orchestration mode.
 - `started_at` is written when the first run is created and locks further mode switching for that session.
 - `last_viewed_terminal_run_id` stores the latest terminal top-level run the user has opened, so the sidebar can distinguish newly finished runs from already-viewed sessions.
@@ -171,6 +171,7 @@ CREATE TABLE IF NOT EXISTS agent_instances (
     parent_instance_id    TEXT,
     runtime_system_prompt TEXT NOT NULL DEFAULT '',
     runtime_tools_json    TEXT NOT NULL DEFAULT '',
+    model_profile         TEXT NOT NULL DEFAULT '',
     created_at            TEXT NOT NULL,
     updated_at            TEXT NOT NULL
 );
@@ -179,7 +180,7 @@ CREATE INDEX IF NOT EXISTS idx_agent_instances_run_status
     ON agent_instances(run_id, status);
 ```
 
-Purpose: runtime snapshot of agent instances. Besides lifecycle state, each row now stores the latest runtime system prompt and runtime tools JSON shown in the subagent panel.
+Purpose: runtime snapshot of agent instances. Besides lifecycle state, each row now stores the latest runtime system prompt, runtime tools JSON, and effective model profile shown in subagent session details.
 
 Notes:
 - Runtime semantics distinguish reusable session role instances from ephemeral clones.
@@ -188,6 +189,7 @@ Notes:
 - Same-role concurrent dispatches may create `ephemeral` clone rows whose `parent_instance_id` points at the reusable instance.
 - `workspace_id` is the execution workspace bound from the owning session.
 - `conversation_id` is the conversation continuity key for the role instance.
+- `model_profile` stores the effective model profile used by the latest execution snapshot. Empty string means legacy, unknown, or role default.
 
 `status` values:
 - `idle`
@@ -1070,7 +1072,7 @@ Notes:
 - `intent` remains a text summary used for previews and logs.
 - `input_json` stores the canonical typed run input array, including text and media references.
 - `run_kind` distinguishes `conversation`, `generate_image`, `generate_audio`, and `generate_video`.
-- `normal_model_profile` snapshots the nullable session-level normal-mode model override for the root role or `@Role` target. Orchestration-mode intents store `NULL`.
+- `normal_model_profile` snapshots the nullable session-level normal-mode model override for the root role, `@Role` target, or normal-mode child subagent tasks spawned within that run. Orchestration-mode intents store `NULL`.
 - `generation_config_json` stores the typed native media-generation config for provider-native image/audio/video runs.
 - `yolo` controls whether tool approvals are skipped entirely for that run.
 - `shell_safety_policy_enabled` controls whether shell execution keeps the local shell safety deny layer enabled for that run.

--- a/frontend/dist/css/components/subagent.css
+++ b/frontend/dist/css/components/subagent.css
@@ -437,8 +437,34 @@
 }
 
 .subagent-session-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 0;
     color: var(--text-secondary);
     font-size: 0.78rem;
+}
+
+.subagent-session-meta-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.subagent-session-model-profile {
+    flex: 0 1 auto;
+    max-width: min(24rem, 48vw);
+    padding: 0.08rem 0.36rem;
+    border: 1px solid color-mix(in srgb, var(--border-color) 84%, transparent);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--bg-hover) 58%, transparent);
+    color: color-mix(in srgb, var(--text-secondary) 80%, var(--text-primary));
+    font-size: 0.72rem;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .subagent-session-badge {

--- a/frontend/dist/js/components/subagentRail.js
+++ b/frontend/dist/js/components/subagentRail.js
@@ -125,6 +125,9 @@ export function rememberLiveSubagent(instanceId, roleId) {
         updated_at: nowIso,
         runtime_system_prompt: existingIndex >= 0 ? existingRecord.runtime_system_prompt : '',
         runtime_tools_json: existingIndex >= 0 ? existingRecord.runtime_tools_json : '',
+        model_profile: existingIndex >= 0
+            ? String(existingRecord.model_profile || existingRecord.modelProfile || '')
+            : '',
         reflection_summary_preview: existingIndex >= 0 ? existingRecord.reflection_summary_preview : '',
         reflection_updated_at: existingIndex >= 0 ? existingRecord.reflection_updated_at : '',
     };
@@ -175,6 +178,7 @@ function normalizeSessionAgents(payload) {
             updated_at: String(item.updated_at || item.created_at || ''),
             runtime_system_prompt: String(item.runtime_system_prompt || ''),
             runtime_tools_json: String(item.runtime_tools_json || ''),
+            model_profile: String(item.model_profile || item.modelProfile || ''),
             reflection_summary_preview: String(item.reflection_summary_preview || ''),
             reflection_updated_at: String(item.reflection_updated_at || ''),
         };
@@ -250,6 +254,7 @@ function reconcileSessionAgentsWithTasks(agentsPayload, tasksPayload) {
             updated_at: latestTimestamp(existing?.updated_at || '', task.updated_at || ''),
             runtime_system_prompt: existing?.runtime_system_prompt || '',
             runtime_tools_json: existing?.runtime_tools_json || '',
+            model_profile: existing?.model_profile || existing?.modelProfile || '',
             reflection_summary_preview: existing?.reflection_summary_preview || '',
             reflection_updated_at: existing?.reflection_updated_at || '',
         });

--- a/frontend/dist/js/components/subagentSessions.js
+++ b/frontend/dist/js/components/subagentSessions.js
@@ -1090,6 +1090,7 @@ function normalizeSubagentSession(record, sessionId) {
         createdAt: String(record.created_at || record.createdAt || '').trim(),
         updatedAt: String(record.updated_at || record.updatedAt || record.created_at || '').trim(),
         conversationId: String(record.conversation_id || record.conversationId || '').trim(),
+        modelProfile: String(record.model_profile || record.modelProfile || '').trim(),
     };
   }
 
@@ -1395,8 +1396,27 @@ function syncSubagentSessionViewChrome(active, wrapper = null) {
         badgeEl.textContent = status;
     }
     if (metaEl) {
-        metaEl.textContent = buildSubagentSessionLabel(active);
+        metaEl.innerHTML = renderSubagentSessionMeta(active);
     }
+}
+
+function renderSubagentSessionMeta(active) {
+    const label = buildSubagentSessionLabel(active);
+    const modelProfile = String(
+        active?.modelProfile || active?.model_profile || '',
+    ).trim();
+    if (!modelProfile) {
+        return `<span class="subagent-session-meta-label">${escapeHtml(label)}</span>`;
+    }
+    const title = t('subagent_session.model_profile_title').replace(
+        '{model}',
+        modelProfile,
+    );
+    const text = t('subagent_session.model_profile').replace('{model}', modelProfile);
+    return [
+        `<span class="subagent-session-meta-label">${escapeHtml(label)}</span>`,
+        `<span class="subagent-session-model-profile" title="${escapeAttribute(title)}">${escapeHtml(text)}</span>`,
+    ].join('');
 }
 
 function emitSubagentSessionsChanged(detail = {}) {
@@ -1491,6 +1511,7 @@ function areSubagentSessionStructureRecordsEqual(left, right) {
           && left.title === right.title
           && left.subagentKind === right.subagentKind
           && left.conversationId === right.conversationId
+          && left.modelProfile === right.modelProfile
     );
 }
 
@@ -1514,6 +1535,7 @@ function areSubagentSessionListRecordsEqual(left, right) {
         && left.createdAt === right.createdAt
         && left.updatedAt === right.updatedAt
         && left.conversationId === right.conversationId
+        && left.modelProfile === right.modelProfile
     );
 }
 
@@ -1537,5 +1559,6 @@ function areSubagentSessionRecordsEqual(left, right) {
         && left.createdAt === right.createdAt
         && left.updatedAt === right.updatedAt
         && left.conversationId === right.conversationId
+        && left.modelProfile === right.modelProfile
     );
 }

--- a/frontend/dist/js/core/stream.js
+++ b/frontend/dist/js/core/stream.js
@@ -1254,6 +1254,10 @@ function isTerminalRunEvent(evType) {
     );
 }
 
+function shouldRefreshNormalModeSubagentSnapshot(evType) {
+    return evType === 'llm_fallback_activated';
+}
+
 function isSidebarTerminalRunEvent(evType) {
     return (
         evType === 'run_completed'
@@ -1807,7 +1811,10 @@ function openNormalModeSubagentSessionStreamConnection(connection, { afterEventI
             const evType = data.event_type;
             const payload = JSON.parse(data.payload_json || '{}');
             routeEvent(evType, payload, data);
-            if (isTerminalRunEvent(evType)) {
+            if (
+                shouldRefreshNormalModeSubagentSnapshot(evType)
+                || isTerminalRunEvent(evType)
+            ) {
                 scheduleCurrentSessionSubagentDiscovery({ delayMs: 250 });
             }
         } catch (e) {
@@ -1935,6 +1942,9 @@ function openNormalModeSubagentRunStreamConnection(connection, { afterEventId = 
             const evType = data.event_type;
             const payload = JSON.parse(data.payload_json || '{}');
             routeEvent(evType, payload, data);
+            if (shouldRefreshNormalModeSubagentSnapshot(evType)) {
+                scheduleCurrentSessionSubagentDiscovery({ delayMs: 250 });
+            }
             if (isTerminalRunEvent(evType)) {
                 connection.terminal = true;
                 finishNormalModeSubagentConnection(connection);

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -6115,11 +6115,15 @@ Object.assign(TRANSLATIONS['zh-CN'], {
 Object.assign(TRANSLATIONS['en-US'], {
     'rounds.model_profile': '{model}',
     'rounds.model_profile_title': 'Model profile used for this run: {model}',
+    'subagent_session.model_profile': '{model}',
+    'subagent_session.model_profile_title': 'Model profile used for this subagent: {model}',
 });
 
 Object.assign(TRANSLATIONS['zh-CN'], {
     'rounds.model_profile': '{model}',
     'rounds.model_profile_title': '\u672c\u6b21\u8fd0\u884c\u4f7f\u7528\u7684\u6a21\u578b profile\uff1a{model}',
+    'subagent_session.model_profile': '{model}',
+    'subagent_session.model_profile_title': '\u5b50\u4ee3\u7406\u4f7f\u7528\u7684\u6a21\u578b profile\uff1a{model}',
 });
 
 function updateLanguageButton() {

--- a/src/relay_teams/agent_runtimes/instances/instance_repository.py
+++ b/src/relay_teams/agent_runtimes/instances/instance_repository.py
@@ -40,6 +40,7 @@ class AgentInstanceRepository(SharedSqliteRepository):
                     parent_instance_id TEXT,
                     runtime_system_prompt TEXT NOT NULL DEFAULT '',
                     runtime_tools_json TEXT NOT NULL DEFAULT '',
+                    model_profile TEXT NOT NULL DEFAULT '',
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 )
@@ -66,6 +67,10 @@ class AgentInstanceRepository(SharedSqliteRepository):
             if "runtime_tools_json" not in columns:
                 self._conn.execute(
                     "ALTER TABLE agent_instances ADD COLUMN runtime_tools_json TEXT NOT NULL DEFAULT ''"
+                )
+            if "model_profile" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE agent_instances ADD COLUMN model_profile TEXT NOT NULL DEFAULT ''"
                 )
             if "lifecycle" not in columns:
                 self._conn.execute(
@@ -104,6 +109,7 @@ class AgentInstanceRepository(SharedSqliteRepository):
         status: InstanceStatus,
         lifecycle: InstanceLifecycle | None = None,
         parent_instance_id: str | None = None,
+        model_profile: str | None = None,
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
         resolved_conversation_id = conversation_id or build_conversation_id(
@@ -111,13 +117,16 @@ class AgentInstanceRepository(SharedSqliteRepository):
             role_id,
         )
         lifecycle_value = lifecycle.value if lifecycle is not None else None
+        model_profile_value = (
+            model_profile.strip() if model_profile is not None else None
+        )
         run_sqlite_write_with_retry(
             conn=self._conn,
             db_path=self._db_path,
             operation=lambda: self._conn.execute(
                 """
-                INSERT INTO agent_instances(run_id, trace_id, session_id, instance_id, role_id, workspace_id, conversation_id, status, lifecycle, parent_instance_id, runtime_system_prompt, runtime_tools_json, created_at, updated_at)
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, 'reusable'), ?, '', '', ?, ?)
+                INSERT INTO agent_instances(run_id, trace_id, session_id, instance_id, role_id, workspace_id, conversation_id, status, lifecycle, parent_instance_id, runtime_system_prompt, runtime_tools_json, model_profile, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, 'reusable'), ?, '', '', COALESCE(?, ''), ?, ?)
                 ON CONFLICT(instance_id)
                 DO UPDATE SET
                     run_id=excluded.run_id,
@@ -135,6 +144,10 @@ class AgentInstanceRepository(SharedSqliteRepository):
                         WHEN ? IS NULL THEN agent_instances.parent_instance_id
                         ELSE excluded.parent_instance_id
                     END,
+                    model_profile=CASE
+                        WHEN ? IS NULL THEN agent_instances.model_profile
+                        ELSE excluded.model_profile
+                    END,
                     updated_at=excluded.updated_at
                 """,
                 (
@@ -148,10 +161,12 @@ class AgentInstanceRepository(SharedSqliteRepository):
                     status.value,
                     lifecycle_value,
                     parent_instance_id,
+                    model_profile_value,
                     now,
                     now,
                     lifecycle_value,
                     parent_instance_id,
+                    model_profile_value,
                 ),
             ),
             lock=self._lock,
@@ -172,6 +187,7 @@ class AgentInstanceRepository(SharedSqliteRepository):
         status: InstanceStatus,
         lifecycle: InstanceLifecycle | None = None,
         parent_instance_id: str | None = None,
+        model_profile: str | None = None,
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
         resolved_conversation_id = conversation_id or build_conversation_id(
@@ -179,13 +195,16 @@ class AgentInstanceRepository(SharedSqliteRepository):
             role_id,
         )
         lifecycle_value = lifecycle.value if lifecycle is not None else None
+        model_profile_value = (
+            model_profile.strip() if model_profile is not None else None
+        )
 
         async def operation() -> None:
             conn = await self._get_async_conn()
             cursor = await conn.execute(
                 """
-                INSERT INTO agent_instances(run_id, trace_id, session_id, instance_id, role_id, workspace_id, conversation_id, status, lifecycle, parent_instance_id, runtime_system_prompt, runtime_tools_json, created_at, updated_at)
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, 'reusable'), ?, '', '', ?, ?)
+                INSERT INTO agent_instances(run_id, trace_id, session_id, instance_id, role_id, workspace_id, conversation_id, status, lifecycle, parent_instance_id, runtime_system_prompt, runtime_tools_json, model_profile, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, 'reusable'), ?, '', '', COALESCE(?, ''), ?, ?)
                 ON CONFLICT(instance_id)
                 DO UPDATE SET
                     run_id=excluded.run_id,
@@ -203,6 +222,10 @@ class AgentInstanceRepository(SharedSqliteRepository):
                         WHEN ? IS NULL THEN agent_instances.parent_instance_id
                         ELSE excluded.parent_instance_id
                     END,
+                    model_profile=CASE
+                        WHEN ? IS NULL THEN agent_instances.model_profile
+                        ELSE excluded.model_profile
+                    END,
                     updated_at=excluded.updated_at
                 """,
                 (
@@ -216,10 +239,12 @@ class AgentInstanceRepository(SharedSqliteRepository):
                     status.value,
                     lifecycle_value,
                     parent_instance_id,
+                    model_profile_value,
                     now,
                     now,
                     lifecycle_value,
                     parent_instance_id,
+                    model_profile_value,
                 ),
             )
             await cursor.close()
@@ -235,18 +260,35 @@ class AgentInstanceRepository(SharedSqliteRepository):
         *,
         runtime_system_prompt: str,
         runtime_tools_json: str,
+        model_profile: str | None = None,
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
+        model_profile_value = (
+            model_profile.strip() if model_profile is not None else None
+        )
         run_sqlite_write_with_retry(
             conn=self._conn,
             db_path=self._db_path,
             operation=lambda: self._conn.execute(
                 """
                 UPDATE agent_instances
-                SET runtime_system_prompt=?, runtime_tools_json=?, updated_at=?
+                SET runtime_system_prompt=?,
+                    runtime_tools_json=?,
+                    model_profile=CASE
+                        WHEN ? IS NULL THEN model_profile
+                        ELSE ?
+                    END,
+                    updated_at=?
                 WHERE instance_id=?
                 """,
-                (runtime_system_prompt, runtime_tools_json, now, instance_id),
+                (
+                    runtime_system_prompt,
+                    runtime_tools_json,
+                    model_profile_value,
+                    model_profile_value,
+                    now,
+                    instance_id,
+                ),
             ),
             lock=self._lock,
             repository_name="AgentInstanceRepository",
@@ -254,24 +296,76 @@ class AgentInstanceRepository(SharedSqliteRepository):
         )
 
     async def update_runtime_snapshot_async(
-        self, instance_id: str, *, runtime_system_prompt: str, runtime_tools_json: str
+        self,
+        instance_id: str,
+        *,
+        runtime_system_prompt: str,
+        runtime_tools_json: str,
+        model_profile: str | None = None,
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
+        model_profile_value = (
+            model_profile.strip() if model_profile is not None else None
+        )
 
         async def operation() -> None:
             conn = await self._get_async_conn()
             cursor = await conn.execute(
                 """
                 UPDATE agent_instances
-                SET runtime_system_prompt=?, runtime_tools_json=?, updated_at=?
+                SET runtime_system_prompt=?,
+                    runtime_tools_json=?,
+                    model_profile=CASE
+                        WHEN ? IS NULL THEN model_profile
+                        ELSE ?
+                    END,
+                    updated_at=?
                 WHERE instance_id=?
                 """,
-                (runtime_system_prompt, runtime_tools_json, now, instance_id),
+                (
+                    runtime_system_prompt,
+                    runtime_tools_json,
+                    model_profile_value,
+                    model_profile_value,
+                    now,
+                    instance_id,
+                ),
             )
             await cursor.close()
 
         await self._run_async_write(
             operation_name="update_runtime_snapshot_async",
+            operation=lambda _conn: operation(),
+        )
+
+    async def update_model_profile_async(
+        self,
+        instance_id: str,
+        *,
+        model_profile: str,
+    ) -> None:
+        now = datetime.now(tz=timezone.utc).isoformat()
+        model_profile_value = model_profile.strip()
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                UPDATE agent_instances
+                SET model_profile=?,
+                    updated_at=?
+                WHERE instance_id=?
+                """,
+                (
+                    model_profile_value,
+                    now,
+                    instance_id,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="update_model_profile_async",
             operation=lambda _conn: operation(),
         )
 
@@ -774,6 +868,7 @@ class AgentInstanceRepository(SharedSqliteRepository):
             else None,
             runtime_system_prompt=str(row["runtime_system_prompt"] or ""),
             runtime_tools_json=str(row["runtime_tools_json"] or ""),
+            model_profile=str(row["model_profile"] or ""),
             created_at=datetime.fromisoformat(str(row["created_at"])),
             updated_at=datetime.fromisoformat(str(row["updated_at"])),
         )

--- a/src/relay_teams/agent_runtimes/instances/models.py
+++ b/src/relay_teams/agent_runtimes/instances/models.py
@@ -74,6 +74,7 @@ class AgentRuntimeRecord(BaseModel):
     parent_instance_id: str | None = None
     runtime_system_prompt: str = ""
     runtime_tools_json: str = ""
+    model_profile: str = ""
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
 

--- a/src/relay_teams/agents/execution/session_recovery.py
+++ b/src/relay_teams/agents/execution/session_recovery.py
@@ -621,6 +621,10 @@ class SessionRecoveryMixin(AgentLlmSessionMixinBase):
         total_attempts: int,
         decision: LlmFallbackDecision,
     ) -> None:
+        await self._agent_repo.update_model_profile_async(
+            request.instance_id,
+            model_profile=decision.to_profile_name,
+        )
         await self._failure_handling_service().handle_fallback_activated_async(
             request=request,
             retry_number=retry_number,

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -47,7 +47,10 @@ from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.media import MediaAssetService
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.providers.model_profile_names import explicit_model_profile_reference
+from relay_teams.providers.model_profile_names import (
+    explicit_model_profile_reference,
+    resolve_model_profile_reference,
+)
 from relay_teams.reminders import ReminderDecision
 from relay_teams.reminders.service import SystemReminderService
 from relay_teams.memory.event_handler import MemoryEventHandler
@@ -75,6 +78,7 @@ from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketReposit
 from relay_teams.workspace import WorkspaceHandle, WorkspaceManager
 
 LOGGER = get_logger(__name__)
+ModelProfileNameResolver = Callable[[RoleDefinition, str | None], str | None]
 
 
 class ExecutionConfig(NamedTuple):
@@ -110,6 +114,7 @@ class ExecutionHarness(BaseModel):
     workspace_manager: WorkspaceManager
     prompt_builder: RuntimePromptBuilder
     provider_factory: Callable[..., object]
+    model_profile_name_resolver: ModelProfileNameResolver | None = None
     tool_registry: object
     skill_registry: object
     skill_runtime_service: object | None = None
@@ -233,7 +238,6 @@ class ExecutionHarness(BaseModel):
         if task.parent_task_id is not None:
             session_mode = "normal"
             run_kind = RunKind.CONVERSATION
-            normal_model_profile = ""
         if normal_model_profile:
             role_for_run = role_for_run.model_copy(
                 update={
@@ -288,6 +292,10 @@ class ExecutionHarness(BaseModel):
             instance_id,
             runtime_system_prompt=runtime_system_prompt,
             runtime_tools_json=prepared.runtime_tools_json,
+            model_profile=self._resolve_runtime_model_profile_name(
+                role=role_for_run,
+                session_id=task.session_id,
+            ),
         )
         return ExecutionConfig(
             runner=runner,
@@ -302,6 +310,35 @@ class ExecutionHarness(BaseModel):
             runtime_tools_json=prepared.runtime_tools_json,
             instance_record=instance_record,
         )
+
+    def _resolve_runtime_model_profile_name(
+        self,
+        *,
+        role: RoleDefinition,
+        session_id: str | None,
+    ) -> str:
+        if role.bound_agent_id:
+            return ""
+        resolver = self.model_profile_name_resolver
+        if resolver is None:
+            return resolve_model_profile_reference(role.model_profile)[0]
+        return self._resolve_runtime_model_profile_name_with_resolver(
+            resolver=resolver,
+            role=role,
+            session_id=session_id,
+        )
+
+    @staticmethod
+    def _resolve_runtime_model_profile_name_with_resolver(
+        *,
+        resolver: ModelProfileNameResolver,
+        role: RoleDefinition,
+        session_id: str | None,
+    ) -> str:
+        resolved_name = resolver(role, session_id)
+        if resolved_name is not None and resolved_name.strip():
+            return resolved_name.strip()
+        return resolve_model_profile_reference(role.model_profile)[0]
 
     async def run_llm_execution(
         self,

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -125,6 +125,9 @@ class TaskExecutionService(BaseModel):
     workspace_manager: WorkspaceManager
     prompt_builder: RuntimePromptBuilder
     provider_factory: Callable[[RoleDefinition, str | None], object]
+    model_profile_name_resolver: (
+        Callable[[RoleDefinition, str | None], str | None] | None
+    ) = None
     tool_registry: object
     skill_registry: object
     skill_runtime_service: object | None = None
@@ -159,6 +162,7 @@ class TaskExecutionService(BaseModel):
             workspace_manager=getattr(self, "workspace_manager", None),
             prompt_builder=getattr(self, "prompt_builder", None),
             provider_factory=getattr(self, "provider_factory", None),
+            model_profile_name_resolver=self.model_profile_name_resolver,
             tool_registry=getattr(self, "tool_registry", None),
             skill_registry=getattr(self, "skill_registry", None),
             skill_runtime_service=getattr(self, "skill_runtime_service", None),

--- a/src/relay_teams/agents/orchestration/task_execution_service_factory.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service_factory.py
@@ -57,6 +57,9 @@ def create_task_execution_service(
     app_config_dir: Path | None,
     prompt_instructions: tuple[str, ...] = (),
     provider_factory: Callable[[RoleDefinition, str | None], LLMProvider],
+    model_profile_name_resolver: (
+        Callable[[RoleDefinition, str | None], str | None] | None
+    ) = None,
     tool_registry: ToolRegistry,
     skill_registry: SkillRegistry,
     skill_runtime_service: SkillRuntimeService | None,
@@ -98,6 +101,7 @@ def create_task_execution_service(
             runtime_mcp_schema_loader=runtime_mcp_schema_loader,
         ),
         provider_factory=provider_factory,
+        model_profile_name_resolver=model_profile_name_resolver,
         tool_registry=tool_registry,
         skill_registry=skill_registry,
         skill_runtime_service=skill_runtime_service,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -1402,6 +1402,12 @@ class ServerContainer:
             app_config_dir=self.runtime.paths.config_dir,
             prompt_instructions=self.runtime.prompt_instructions.instructions,
             provider_factory=self._provider_factory,
+            model_profile_name_resolver=lambda role, session_id: (
+                self._resolve_autoharness_model_config(
+                    role,
+                    session_id,
+                )[1]
+            ),
             tool_registry=self.tool_registry,
             skill_registry=self.skill_registry,
             skill_runtime_service=self.skill_runtime_service,

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -306,6 +306,7 @@ class _BackgroundTaskAgentRepository(Protocol):
         status: InstanceStatus,
         lifecycle: InstanceLifecycle | None = None,
         parent_instance_id: str | None = None,
+        model_profile: str | None = None,
     ) -> None:
         pass
 
@@ -1791,6 +1792,7 @@ class BackgroundTaskService:
         parent_yolo = False
         parent_shell_safety_policy_enabled = True
         parent_conversation_context = None
+        parent_normal_model_profile = ""
         try:
             parent_intent = self._run_intent_repo.get(parent_run_id)
         except KeyError:
@@ -1802,6 +1804,10 @@ class BackgroundTaskService:
                 parent_intent.shell_safety_policy_enabled
             )
             parent_conversation_context = parent_intent.conversation_context
+            if parent_intent.session_mode == SessionMode.NORMAL:
+                parent_normal_model_profile = str(
+                    parent_intent.normal_model_profile or ""
+                ).strip()
         self._run_intent_repo.upsert(
             run_id=subagent_run_id,
             session_id=session_id,
@@ -1815,9 +1821,31 @@ class BackgroundTaskService:
                 thinking=parent_thinking,
                 target_role_id=subagent_role_id,
                 session_mode=SessionMode.NORMAL,
+                normal_model_profile=parent_normal_model_profile or None,
                 conversation_context=parent_conversation_context,
             ),
         )
+
+    def _parent_normal_model_profile(self, parent_run_id: str) -> str:
+        if self._run_intent_repo is None:
+            return ""
+        try:
+            parent_intent = self._run_intent_repo.get(parent_run_id)
+        except KeyError:
+            return ""
+        if parent_intent.session_mode != SessionMode.NORMAL:
+            return ""
+        return str(parent_intent.normal_model_profile or "").strip()
+
+    def _initial_subagent_model_profile(
+        self,
+        *,
+        parent_run_id: str,
+        subagent_role: RoleDefinition | None,
+    ) -> str:
+        if subagent_role is not None and subagent_role.bound_agent_id:
+            return ""
+        return self._parent_normal_model_profile(parent_run_id)
 
     def _prepare_subagent_launch(
         self,
@@ -1918,6 +1946,10 @@ class BackgroundTaskService:
         task_repo = self._require_task_repo()
         subagent_instance = prepared.subagent_instance
         subagent_task = prepared.subagent_task
+        model_profile = self._initial_subagent_model_profile(
+            parent_run_id=parent_run_id,
+            subagent_role=subagent_role,
+        )
         agent_repo.upsert_instance(
             run_id=prepared.subagent_run_id,
             trace_id=prepared.subagent_run_id,
@@ -1928,6 +1960,7 @@ class BackgroundTaskService:
             conversation_id=subagent_instance.conversation_id,
             status=InstanceStatus.IDLE,
             lifecycle=InstanceLifecycle.EPHEMERAL,
+            model_profile=model_profile or None,
         )
         if not self._subagent_task_exists(task_repo, subagent_task.task_id):
             task_repo.create(subagent_task)

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -182,6 +182,7 @@ _SNAPSHOT_DIRTY_EVENT_TYPES = frozenset(
         RunEventType.TODO_UPDATED,
         RunEventType.USER_QUESTION_REQUESTED,
         RunEventType.USER_QUESTION_ANSWERED,
+        RunEventType.LLM_FALLBACK_ACTIVATED,
         RunEventType.SUBAGENT_SESSION_STATUS_CHANGED,
         RunEventType.SUBAGENT_STOPPED,
         RunEventType.SUBAGENT_RESUMED,

--- a/tests/integration_tests/frontend/test_subagent_rail_ui.py
+++ b/tests/integration_tests/frontend/test_subagent_rail_ui.py
@@ -58,6 +58,7 @@ console.log(JSON.stringify({
             "updated_at": "2026-03-13T00:02:00.000Z",
             "runtime_system_prompt": "You are the runtime writer.",
             "runtime_tools_json": '{"local_tools":[],"skill_tools":[],"mcp_tools":[]}',
+            "model_profile": "fast",
             "reflection_summary_preview": "",
             "reflection_updated_at": "",
         }
@@ -92,12 +93,14 @@ console.log(JSON.stringify({
             "instanceId": "writer-1",
             "roleId": "writer",
             "runId": "run-1",
+            "modelProfile": "fast",
         },
         {
             "sessionId": "session-1",
             "instanceId": "writer-2",
             "roleId": "writer",
             "runId": "run-1",
+            "modelProfile": "fast",
         },
     ]
 
@@ -125,6 +128,7 @@ console.log(JSON.stringify({
             "instanceId": "writer-live",
             "roleId": "writer",
             "runId": "run-live",
+            "modelProfile": "",
         }
     ]
 
@@ -264,6 +268,7 @@ console.log(JSON.stringify({
             "updated_at": "2026-03-13T00:04:00Z",
             "runtime_system_prompt": "",
             "runtime_tools_json": "",
+            "model_profile": "",
             "reflection_summary_preview": "",
             "reflection_updated_at": "",
         }
@@ -329,6 +334,7 @@ console.log(JSON.stringify({
             "updated_at": "2026-03-13T00:02:00.000Z",
             "runtime_system_prompt": "",
             "runtime_tools_json": "",
+            "model_profile": "",
             "reflection_summary_preview": "",
             "reflection_updated_at": "",
         }
@@ -411,6 +417,7 @@ console.log(JSON.stringify({
             "updated_at": "2026-03-13T00:02:00Z",
             "runtime_system_prompt": "",
             "runtime_tools_json": "",
+            "model_profile": "",
             "reflection_summary_preview": "",
             "reflection_updated_at": "",
         }
@@ -467,6 +474,7 @@ console.log(JSON.stringify({
             "updated_at": "2026-03-13T00:04:00Z",
             "runtime_system_prompt": "",
             "runtime_tools_json": "",
+            "model_profile": "",
             "reflection_summary_preview": "",
             "reflection_updated_at": "",
         }
@@ -573,6 +581,7 @@ export async function fetchSessionAgents(sessionId = "", options = {}) {
             updated_at: "2026-03-13T00:01:00Z",
             runtime_system_prompt: "You are the runtime writer.",
             runtime_tools_json: '{"local_tools":[],"skill_tools":[],"mcp_tools":[]}',
+            model_profile: "fast",
         },
     ];
 }
@@ -661,6 +670,7 @@ export function rememberOrchestrationSubagentSession(sessionId, record = {}) {
         instanceId: record.instance_id || "",
         roleId: record.role_id || "",
         runId: record.run_id || "",
+        modelProfile: record.model_profile || "",
     });
     return record;
 }

--- a/tests/integration_tests/frontend/test_subagent_sessions_ui.py
+++ b/tests/integration_tests/frontend/test_subagent_sessions_ui.py
@@ -151,6 +151,19 @@ export function getRoleDisplayName(roleId, { fallback } = {}) {
     )
     (tmp_path / "mockDom.mjs").write_text(
         """
+function createNode() {
+    return {
+        innerHTML: "",
+        textContent: "",
+        className: "",
+        hidden: false,
+        dataset: {},
+        addEventListener() {
+            return undefined;
+        },
+    };
+}
+
 function createBodyElement() {
     return {
         innerHTML: "",
@@ -160,6 +173,10 @@ function createBodyElement() {
 
 function createSectionElement() {
     const body = createBodyElement();
+    const title = createNode();
+    const badge = createNode();
+    const meta = createNode();
+    const back = createNode();
     return {
         className: "",
         dataset: {},
@@ -171,6 +188,18 @@ function createSectionElement() {
             return this._innerHTML;
         },
         querySelector(selector) {
+            if (selector === ".subagent-session-title") {
+                return title;
+            }
+            if (selector === ".subagent-session-badge") {
+                return badge;
+            }
+            if (selector === ".subagent-session-meta") {
+                return meta;
+            }
+            if (selector === ".subagent-session-back-btn") {
+                return back;
+            }
             if (selector === ".subagent-session-body") {
                 return body;
             }
@@ -248,6 +277,8 @@ const translations = {
     "subagent.task_prompt": "Task prompt",
     "subagent_session.empty": "No messages",
     "subagent_session.load_failed": "Load failed",
+    "subagent_session.model_profile": "{model}",
+    "subagent_session.model_profile_title": "Model profile used for this subagent: {model}",
 };
 
 export function t(key) {
@@ -287,6 +318,7 @@ await openSubagentSession("session-1", {
     runId: "subagent_run_1",
     title: "Explore history",
     status: "running",
+    modelProfile: "fast",
 });
 
 const hiddenWhileOpen = els.inputContainer.style.display || "";
@@ -294,6 +326,10 @@ const hintWhileOpen = els.promptInputHint.textContent;
 const sendDisabledWhileOpen = els.sendBtn.disabled;
 const activeViewWhileOpen = state.activeView;
 const chatContainerClassWhileOpen = els.chatContainer.className;
+const modelMetaWhileOpen = els.chatMessages.children[0]
+    ?.querySelector?.(".subagent-session-meta")
+    ?.innerHTML || "";
+const activeModelProfileWhileOpen = state.activeSubagentSession?.modelProfile || "";
 
 clearActiveSubagentSession();
 
@@ -303,6 +339,8 @@ console.log(JSON.stringify({
     sendDisabledWhileOpen,
     activeViewWhileOpen,
     chatContainerClassWhileOpen,
+    modelMetaWhileOpen,
+    activeModelProfileWhileOpen,
     hiddenAfterClear: els.inputContainer.style.display || "",
     hintAfterClear: els.promptInputHint.textContent,
     sendDisabledAfterClear: els.sendBtn.disabled,
@@ -340,6 +378,9 @@ console.log(JSON.stringify({
     assert payload["sendDisabledWhileOpen"] is True
     assert payload["activeViewWhileOpen"] == "subagent-session"
     assert payload["chatContainerClassWhileOpen"] == "is-subagent-session-active"
+    assert payload["activeModelProfileWhileOpen"] == "fast"
+    assert "subagent-session-model-profile" in payload["modelMetaWhileOpen"]
+    assert "fast" in payload["modelMetaWhileOpen"]
     assert payload["hiddenAfterClear"] == ""
     assert payload["hintAfterClear"] == ""
     assert payload["sendDisabledAfterClear"] is False
@@ -2408,6 +2449,7 @@ console.log(JSON.stringify({
             "createdAt": "",
             "updatedAt": "2026-04-28T11:01:00Z",
             "conversationId": "",
+            "modelProfile": "",
         }
     ]
     assert payload["events"]

--- a/tests/integration_tests/frontend/test_subagent_streams_ui.py
+++ b/tests/integration_tests/frontend/test_subagent_streams_ui.py
@@ -88,6 +88,38 @@ def test_normal_mode_subagent_discovery_polls_while_parent_run_active() -> None:
     assert "normalModeSubagentStreams.size > 0" in block
 
 
+def test_normal_mode_subagent_fallback_event_refreshes_snapshot() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "core" / "stream.js").read_text(
+        encoding="utf-8"
+    )
+    session_stream_block = source.split(
+        "function openNormalModeSubagentSessionStreamConnection",
+        1,
+    )[1].split(
+        "\nfunction scheduleSubagentSessionReconnect",
+        1,
+    )[0]
+    run_stream_block = source.split(
+        "function openNormalModeSubagentRunStreamConnection",
+        1,
+    )[1].split(
+        "\nfunction scheduleSubagentReconnect",
+        1,
+    )[0]
+
+    assert "function shouldRefreshNormalModeSubagentSnapshot(evType)" in source
+    assert "evType === 'llm_fallback_activated'" in source
+    assert "shouldRefreshNormalModeSubagentSnapshot(evType)" in session_stream_block
+    assert "scheduleCurrentSessionSubagentDiscovery({ delayMs: 250 });" in (
+        session_stream_block
+    )
+    assert "shouldRefreshNormalModeSubagentSnapshot(evType)" in run_stream_block
+    assert "scheduleCurrentSessionSubagentDiscovery({ delayMs: 250 });" in (
+        run_stream_block
+    )
+
+
 def _write_stream_runtime_inject_mocks(tmp_path: Path) -> None:
     (tmp_path / "mockRuntimeInjectQueue.mjs").write_text(
         """

--- a/tests/unit_tests/agent_runtimes/instances/test_instance_repository.py
+++ b/tests/unit_tests/agent_runtimes/instances/test_instance_repository.py
@@ -66,12 +66,14 @@ def test_repository_migrates_lifecycle_columns_for_existing_tables(
     record = repository.get_instance("inst-1")
     assert record.lifecycle == InstanceLifecycle.REUSABLE
     assert record.parent_instance_id is None
+    assert record.model_profile == ""
     with sqlite3.connect(db_path) as conn:
         columns = {
             str(row[1]) for row in conn.execute("PRAGMA table_info(agent_instances)")
         }
     assert "lifecycle" in columns
     assert "parent_instance_id" in columns
+    assert "model_profile" in columns
 
 
 def test_upsert_preserves_existing_lifecycle_when_not_explicit(
@@ -138,6 +140,51 @@ def test_upsert_preserves_existing_lifecycle_when_not_explicit(
     refreshed = repository.get_instance("inst-1")
     assert refreshed.lifecycle == InstanceLifecycle.REUSABLE
     assert refreshed.parent_instance_id == "inst-new-parent"
+
+
+def test_upsert_preserves_existing_model_profile_when_not_explicit(
+    tmp_path: Path,
+) -> None:
+    repository = AgentInstanceRepository(tmp_path / "agent_instances_profile.db")
+    repository.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="writer",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        status=InstanceStatus.IDLE,
+        model_profile="fast",
+    )
+
+    repository.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="writer",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        status=InstanceStatus.RUNNING,
+    )
+
+    assert repository.get_instance("inst-1").model_profile == "fast"
+
+    repository.update_runtime_snapshot(
+        "inst-1",
+        runtime_system_prompt="system",
+        runtime_tools_json='{"local_tools":[]}',
+        model_profile="precise",
+    )
+    assert repository.get_instance("inst-1").model_profile == "precise"
+
+    repository.update_runtime_snapshot(
+        "inst-1",
+        runtime_system_prompt="system",
+        runtime_tools_json='{"local_tools":[]}',
+    )
+    assert repository.get_instance("inst-1").model_profile == "precise"
 
 
 def test_repository_lists_instances_by_session_ids(tmp_path: Path) -> None:
@@ -340,7 +387,16 @@ async def test_async_methods_preserve_existing_instance_fields(
             "inst-1",
             runtime_system_prompt="system",
             runtime_tools_json='{"tools":[]}',
+            model_profile="fast",
         )
+        assert (await repository.get_instance_async("inst-1")).model_profile == "fast"
+        await repository.update_model_profile_async(
+            "inst-1",
+            model_profile="precise",
+        )
+        assert (
+            await repository.get_instance_async("inst-1")
+        ).model_profile == "precise"
         await repository.upsert_instance_async(
             run_id="run-2",
             trace_id="run-2",

--- a/tests/unit_tests/agents/execution/session_recovery_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_recovery_test_cases.py
@@ -669,6 +669,7 @@ async def test_async_fallback_wrappers_delegate_to_failure_handling_service() ->
         rate_limited=True,
     )
     calls: list[str] = []
+    profile_updates: list[tuple[str, str]] = []
 
     class _FailureHandlingService:
         async def handle_fallback_activated_async(self, **kwargs: object) -> None:
@@ -679,7 +680,17 @@ async def test_async_fallback_wrappers_delegate_to_failure_handling_service() ->
             assert kwargs["error"] == retry_error
             calls.append("exhausted")
 
+    class _AgentRepo:
+        async def update_model_profile_async(
+            self,
+            instance_id: str,
+            *,
+            model_profile: str,
+        ) -> None:
+            profile_updates.append((instance_id, model_profile))
+
     session.__dict__["_failure_handling_service"] = lambda: _FailureHandlingService()
+    session.__dict__["_agent_repo"] = _AgentRepo()
 
     await AgentLlmSession._handle_fallback_activated_async(
         session,
@@ -698,6 +709,7 @@ async def test_async_fallback_wrappers_delegate_to_failure_handling_service() ->
     )
 
     assert calls == ["activated", "exhausted"]
+    assert profile_updates == [("inst-1", "secondary")]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -305,13 +305,17 @@ def _build_service(
     artifact_repo: TaskArtifactRepository | None = None,
     memory_bank_service: MemoryBankService | None = None,
     provider_factory: Callable[[RoleDefinition, str | None], object] | None = None,
+    model_profile_name_resolver: (
+        Callable[[RoleDefinition, str | None], str | None] | None
+    ) = None,
+    role: RoleDefinition | None = None,
 ) -> tuple[
     TaskExecutionService,
     TaskRepository,
     AgentInstanceRepository,
     MessageRepository,
 ]:
-    role = RoleDefinition(
+    role_definition = role or RoleDefinition(
         role_id="time",
         name="time",
         description="Reports the current time.",
@@ -320,7 +324,7 @@ def _build_service(
         system_prompt="You are the time role.",
     )
     role_registry = RoleRegistry()
-    role_registry.register(role)
+    role_registry.register(role_definition)
 
     task_repo = TaskRepository(db_path)
     agent_repo = AgentInstanceRepository(db_path)
@@ -344,6 +348,7 @@ def _build_service(
             mcp_registry=McpRegistry(),
         ),
         provider_factory=provider_factory or (lambda _, __=None: provider),
+        model_profile_name_resolver=model_profile_name_resolver,
         tool_registry=build_default_registry(),
         skill_registry=_StaticSkillRegistry(),
         mcp_registry=McpRegistry(),
@@ -1176,7 +1181,7 @@ async def test_execute_applies_normal_model_profile_to_root_task(
 
 
 @pytest.mark.asyncio
-async def test_execute_does_not_apply_normal_model_profile_to_child_task(
+async def test_execute_applies_normal_model_profile_to_child_task(
     tmp_path: Path,
 ) -> None:
     provider = _CapturingProvider()
@@ -1214,7 +1219,148 @@ async def test_execute_does_not_apply_normal_model_profile_to_child_task(
         task=task,
     )
 
+    assert captured_roles[0].model_profile == "fast"
+    assert agent_repo.get_instance(instance_id).model_profile == "fast"
+
+
+@pytest.mark.asyncio
+async def test_execute_persists_resolved_runtime_model_profile_name(
+    tmp_path: Path,
+) -> None:
+    provider = _CapturingProvider()
+    captured_roles: list[RoleDefinition] = []
+    resolver_calls: list[tuple[str, str | None]] = []
+
+    def provider_factory(role: RoleDefinition, session_id: str | None) -> object:
+        captured_roles.append(role)
+        return provider
+
+    def model_profile_name_resolver(
+        role: RoleDefinition,
+        session_id: str | None,
+    ) -> str | None:
+        resolver_calls.append((role.model_profile, session_id))
+        return "runtime-default"
+
+    service, task_repo, agent_repo, message_repo = _build_service(
+        tmp_path / "task_execution_service_resolved_model_profile.db",
+        provider,
+        provider_factory=provider_factory,
+        model_profile_name_resolver=model_profile_name_resolver,
+    )
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+    )
+
+    _ = await service.execute(
+        instance_id=instance_id,
+        role_id="time",
+        task=task,
+    )
+
     assert captured_roles[0].model_profile == "default"
+    assert resolver_calls == [("default", task.session_id)]
+    assert agent_repo.get_instance(instance_id).model_profile == "runtime-default"
+
+
+@pytest.mark.asyncio
+async def test_execute_omits_local_model_profile_snapshot_for_bound_agent(
+    tmp_path: Path,
+) -> None:
+    provider = _CapturingProvider()
+    captured_roles: list[RoleDefinition] = []
+    resolver_calls: list[tuple[str, str | None]] = []
+    role = RoleDefinition(
+        role_id="time",
+        name="time",
+        description="Reports the current time.",
+        version="1",
+        tools=(),
+        system_prompt="You are the time role.",
+        bound_agent_id="external-agent-1",
+    )
+
+    def provider_factory(role: RoleDefinition, session_id: str | None) -> object:
+        _ = session_id
+        captured_roles.append(role)
+        return provider
+
+    def model_profile_name_resolver(
+        role: RoleDefinition,
+        session_id: str | None,
+    ) -> str | None:
+        resolver_calls.append((role.model_profile, session_id))
+        return "runtime-default"
+
+    service, task_repo, agent_repo, message_repo = _build_service(
+        tmp_path / "task_execution_service_bound_agent_model_profile.db",
+        provider,
+        provider_factory=provider_factory,
+        model_profile_name_resolver=model_profile_name_resolver,
+        role=role,
+    )
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+    )
+
+    _ = await service.execute(
+        instance_id=instance_id,
+        role_id="time",
+        task=task,
+    )
+
+    assert captured_roles[0].bound_agent_id == "external-agent-1"
+    assert resolver_calls == []
+    assert agent_repo.get_instance(instance_id).model_profile == ""
+
+
+@pytest.mark.asyncio
+async def test_execute_persists_resolved_normal_model_profile_fallback(
+    tmp_path: Path,
+) -> None:
+    provider = _CapturingProvider()
+    captured_roles: list[RoleDefinition] = []
+
+    def provider_factory(role: RoleDefinition, session_id: str | None) -> object:
+        _ = session_id
+        captured_roles.append(role)
+        return provider
+
+    service, task_repo, agent_repo, message_repo = _build_service(
+        tmp_path / "task_execution_service_missing_model_profile.db",
+        provider,
+        provider_factory=provider_factory,
+        model_profile_name_resolver=lambda _, __: "runtime-default",
+    )
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+        parent_task_id=None,
+    )
+    assert service.run_intent_repo is not None
+    service.run_intent_repo.upsert(
+        run_id=task.trace_id,
+        session_id=task.session_id,
+        intent=IntentInput(
+            session_id=task.session_id,
+            input=content_parts_from_text("query time"),
+            normal_model_profile="missing",
+        ),
+    )
+
+    _ = await service.execute(
+        instance_id=instance_id,
+        role_id="time",
+        task=task,
+    )
+
+    assert captured_roles[0].model_profile == "missing"
+    assert agent_repo.get_instance(instance_id).model_profile == "runtime-default"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/env/test_w3_auth_token_env.py
+++ b/tests/unit_tests/env/test_w3_auth_token_env.py
@@ -58,6 +58,7 @@ class _TokenService:
         return MaaSAuthContext(token=self._token)
 
 
+@pytest.mark.timeout(30)
 def test_package_env_import_does_not_load_maas_provider_runtime_boundary() -> None:
     command = [
         sys.executable,

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -525,18 +525,44 @@ def _build_record(
     )
 
 
-def _parent_intent() -> IntentInput:
+def _parent_intent(*, normal_model_profile: str | None = None) -> IntentInput:
     return IntentInput(
         session_id="session-1",
         execution_mode=ExecutionMode.AI,
         shell_safety_policy_enabled=False,
         thinking=RunThinkingConfig(enabled=True, effort="medium"),
         session_mode=SessionMode.NORMAL,
+        normal_model_profile=normal_model_profile,
     )
 
 
+def test_background_task_service_parent_model_profile_missing_fallbacks() -> None:
+    service_without_repo = BackgroundTaskService(
+        background_task_manager=None,
+        repository=cast(BackgroundTaskRepository, object()),
+    )
+    assert service_without_repo._parent_normal_model_profile("run-1") == ""
+
+    missing_intent_service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=cast(BackgroundTaskRepository, object()),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent(normal_model_profile="fast")),
+    )
+    assert missing_intent_service._parent_normal_model_profile("missing-run") == ""
+
+    orchestration_intent = _parent_intent(
+        normal_model_profile="fast",
+    ).model_copy(update={"session_mode": SessionMode.ORCHESTRATION})
+    orchestration_intent_service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=cast(BackgroundTaskRepository, object()),
+        run_intent_repo=_FakeRunIntentRepo(orchestration_intent),
+    )
+    assert orchestration_intent_service._parent_normal_model_profile("run-1") == ""
+
+
 def test_background_task_service_subagent_intent_inherits_shell_policy() -> None:
-    intent_repo = _FakeRunIntentRepo(_parent_intent())
+    intent_repo = _FakeRunIntentRepo(_parent_intent(normal_model_profile="fast"))
     service = BackgroundTaskService(
         background_task_manager=None,
         repository=cast(BackgroundTaskRepository, object()),
@@ -553,6 +579,7 @@ def test_background_task_service_subagent_intent_inherits_shell_policy() -> None
 
     subagent_intent = intent_repo.get("run-subagent-1")
     assert subagent_intent.shell_safety_policy_enabled is False
+    assert subagent_intent.normal_model_profile == "fast"
 
 
 @pytest.mark.asyncio
@@ -934,7 +961,7 @@ async def test_background_task_service_start_subagent_completes_and_persists_res
     )
     agent_repo = _FakeAgentRepo()
     task_repo = _FakeTaskRepo()
-    intent_repo = _FakeRunIntentRepo(_parent_intent())
+    intent_repo = _FakeRunIntentRepo(_parent_intent(normal_model_profile="fast"))
     run_control_manager = _FakeRunControlManager()
     service = BackgroundTaskService(
         background_task_manager=None,
@@ -976,8 +1003,10 @@ async def test_background_task_service_start_subagent_completes_and_persists_res
     assert persisted.status == BackgroundTaskStatus.COMPLETED
     assert persisted.output_excerpt == "analysis complete"
     assert agent_repo.calls[0]["run_id"] == updated.subagent_run_id
+    assert agent_repo.calls[0]["model_profile"] == "fast"
     assert executor.calls[0]["role_id"] == "Crafter"
     assert updated.subagent_run_id in intent_repo._records
+    assert intent_repo.get(updated.subagent_run_id or "").normal_model_profile == "fast"
     assert run_control_manager.unregistered_run_ids == [updated.subagent_run_id]
     runtime = runtime_repo.get(updated.subagent_run_id or "")
     assert runtime is not None
@@ -994,6 +1023,61 @@ async def test_background_task_service_start_subagent_completes_and_persists_res
         "instance_id": updated.subagent_instance_id,
         "status": InstanceStatus.COMPLETED,
     }
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_start_bound_subagent_leaves_model_profile_empty(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-bound-subagent.db"
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    agent_repo = _FakeAgentRepo()
+    role = RoleDefinition(
+        role_id="ExternalCrafter",
+        name="External Crafter",
+        description="Delegates work to an external agent.",
+        version="1",
+        mode=RoleMode.SUBAGENT,
+        bound_agent_id="external-agent-1",
+        system_prompt="Delegate externally.",
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=agent_repo,
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent(normal_model_profile="fast")),
+        run_control_manager=_FakeRunControlManager(),
+    )
+
+    started = await service.start_subagent(
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="MainAgent",
+        tool_call_id="call-1",
+        workspace_id="workspace-1",
+        cwd=Path("C:/workspace"),
+        subagent_role_id=role.role_id,
+        subagent_role=role,
+        title="Investigate failures",
+        prompt="Inspect the failing tests and summarize the cause.",
+    )
+    _, completed = await service.wait_for_run(
+        run_id="run-1",
+        background_task_id=started.background_task_id,
+    )
+
+    assert completed is True
+    assert agent_repo.calls[0]["model_profile"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/test_session_snapshot_cache.py
+++ b/tests/unit_tests/sessions/test_session_snapshot_cache.py
@@ -1274,6 +1274,62 @@ async def test_session_service_subagent_status_event_marks_session_snapshot_dirt
 
 
 @pytest.mark.asyncio
+async def test_session_service_fallback_event_marks_subagent_snapshot_dirty(
+    tmp_path: Path,
+) -> None:
+    runner = _CountingRunner()
+    db_path = tmp_path / "session-subagent-fallback-cache.db"
+    service = _build_service(db_path, runner=runner)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    _seed_root_task(
+        db_path,
+        run_id="subagent_run_1",
+        session_id="session-1",
+        task_id="task-subagent-1",
+    )
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="subagent_run_1",
+        trace_id="subagent_run_1",
+        session_id="session-1",
+        instance_id="inst-subagent",
+        role_id="Explorer",
+        workspace_id="default",
+        conversation_id="conv-session-1-explorer",
+        status=InstanceStatus.RUNNING,
+        model_profile="fast",
+    )
+    first = await service.list_session_subagents_async("session-1")
+    assert first[0]["model_profile"] == "fast"
+
+    await agent_repo.update_model_profile_async(
+        "inst-subagent",
+        model_profile="precise",
+    )
+    runner.block_next = True
+    service.mark_run_event_dirty(
+        RunEvent(
+            session_id="session-1",
+            run_id="subagent_run_1",
+            trace_id="subagent_run_1",
+            instance_id="inst-subagent",
+            event_type=RunEventType.LLM_FALLBACK_ACTIVATED,
+        )
+    )
+
+    stale = await service.list_session_subagents_async("session-1")
+
+    assert stale[0]["model_profile"] == "fast"
+    assert await _wait_for_event(runner.started)
+    runner.release.set()
+    fresh = await service.list_session_subagents_async(
+        "session-1",
+        force_refresh=True,
+    )
+    assert fresh[0]["model_profile"] == "precise"
+
+
+@pytest.mark.asyncio
 async def test_session_service_pending_action_event_requires_fresh_session_list(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Inherit model profile behavior for subagent execution paths.
- Update related API/database docs, frontend subagent UI, CLI path, and focused tests.
- Keep the W3 auth import-boundary unit test stable on slower Windows subprocess startup by giving it an explicit timeout budget.

Fixes #979

## Notes
- Source branch was fetched from `liyanqi01/feat/subagent-model-profile` and pushed to `origin/feat/subagent-model-profile` because GitHub could not create a readable cross-repository PR head from `liyanqi01/agent-teams`.
- Branch has been rebased onto `origin/main` at `87b2be71` and reduced to one commit.

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/agent_runtimes/instances/test_instance_repository.py tests/unit_tests/agents/orchestration/test_task_execution_service.py tests/unit_tests/sessions/runs/background_tasks/test_service.py tests/integration_tests/frontend/test_subagent_rail_ui.py tests/integration_tests/frontend/test_subagent_sessions_ui.py` (106 passed)
- `uv run --extra dev pytest -q tests/unit_tests` (8002 passed, 8 skipped)
- `uv run --extra dev pytest -q tests/integration_tests` attempted locally; blocked by missing Playwright Chromium cache after `playwright install chromium` returned proxy 407, and by existing fast CLI cold-start timing assertions on this Windows host.